### PR TITLE
feat(ping api): adding fun exclamation to the response for empty request message

### DIFF
--- a/gateway/controller/ping.go
+++ b/gateway/controller/ping.go
@@ -33,7 +33,7 @@ func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (*pb.Pin
 
 	c.metricsScope.Counter("ping_requests_total").Inc(1)
 
-	message := "pong"
+	message := "pong!"
 	isEcho := false
 	if req.Message != "" {
 		message = "echo: " + req.Message

--- a/gateway/controller/ping_test.go
+++ b/gateway/controller/ping_test.go
@@ -25,7 +25,7 @@ func TestPing_DefaultMessage(t *testing.T) {
 	resp, err := controller.Ping(ctx, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "pong", resp.Message)
+	assert.Equal(t, "pong!", resp.Message)
 }
 
 func TestPing_CustomMessage(t *testing.T) {

--- a/orchestrator/controller/ping.go
+++ b/orchestrator/controller/ping.go
@@ -33,7 +33,7 @@ func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (*pb.Pin
 
 	c.metricsScope.Counter("ping_requests_total").Inc(1)
 
-	message := "pong"
+	message := "pong!"
 	isEcho := false
 	if req.Message != "" {
 		message = "echo: " + req.Message

--- a/orchestrator/controller/ping_test.go
+++ b/orchestrator/controller/ping_test.go
@@ -25,7 +25,7 @@ func TestPing_DefaultMessage(t *testing.T) {
 	resp, err := controller.Ping(ctx, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "pong", resp.Message)
+	assert.Equal(t, "pong!", resp.Message)
 }
 
 func TestPing_CustomMessage(t *testing.T) {

--- a/speculator/controller/ping.go
+++ b/speculator/controller/ping.go
@@ -33,7 +33,7 @@ func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (*pb.Pin
 
 	c.metricsScope.Counter("ping_requests_total").Inc(1)
 
-	message := "pong"
+	message := "pong!"
 	isEcho := false
 	if req.Message != "" {
 		message = "echo: " + req.Message

--- a/speculator/controller/ping_test.go
+++ b/speculator/controller/ping_test.go
@@ -25,7 +25,7 @@ func TestPing_DefaultMessage(t *testing.T) {
 	resp, err := controller.Ping(ctx, req)
 
 	require.NoError(t, err)
-	assert.Equal(t, "pong", resp.Message)
+	assert.Equal(t, "pong!", resp.Message)
 }
 
 func TestPing_CustomMessage(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->
Making a dummy change to the ping API for all service controllers. 

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
Making a "dummy" commit to practice and test the change workflow

## What?
Adding a `!` to the the ping APIs when message arg is empty.
e.g. `pong` -> `pong!`

## Test Plan
Unit tests.

## Issues

