### PR TITLE
feat(entities) Adds batch entity and batch sql schema

### DIFF
--- a/entity/batch.go
+++ b/entity/batch.go
@@ -1,5 +1,14 @@
 package entity
 
+// BatchState defines the possible states of a batch.
+type BatchState string
+
+const (
+	// BatchStateUnknown is the unreachable state. It is set by default when the structure is initialized. It should never be seen in the system.
+	BatchStateUnknown BatchState = ""
+	// TODO: Add comprehensive list of known batch states.
+)
+
 // Batch represents a group of requests to land (merge into target branch of the source control repository).
 type Batch struct {
 	// ID is the globally unique identifier for the batch. Format: "<queue>/batch/<counter_value>".
@@ -8,13 +17,24 @@ type Batch struct {
 	Queue string
 	// Contains is a list of land request IDs that are part of this batch.
 	// Request IDs will always be part of the same queue.
+	//
 	// For e.g. - [queueA/1, queueA/2, queueA/3].
+	//
 	Contains []string
-	// Dependencies is a list of batch IDs (and associated metdata) for this batch.
+	// Dependencies is a list of batch IDs (and associated metadata) for this batch.
 	// Dependencies will always be part of the same queue.
+	//
+	// For e.g - Consider batches - queueA/batch/1, queueA/batch/2, queueA/batch/3
+	// such that - queueA/batch/2 and queueA/batch/3 depend on queueA/batch/1
+	//
+	// In this case, the Dependencies field for -
+	// - queueA/batch/1 will be empty
+	// - queueA/batch/2 will contain queueA/batch/1
+	// - queueA/batch/3 will contain queueA/batch/1
+	//
 	Dependencies []map[string]interface{}
 	// The state of the batch lifecycle this batch is in.
-	State string
+	State BatchState
 	// Version is the version of the object. It is used for optimistic locking.
 	// Versioning starts at 1 and is incremented for each change to the object.
 	Version int32

--- a/entity/batch.go
+++ b/entity/batch.go
@@ -1,0 +1,21 @@
+package entity
+
+// Batch represents a group of requests to land (merge into target branch of the source control repository).
+type Batch struct {
+	// ID is the globally unique identifier for the batch. Format: "<queue>/batch/<counter_value>".
+	ID string
+	// Queue is the name of the queue processing the land request. Queue name is defined in the configuration and should be unique within the system.
+	Queue string
+	// Contains is a list of land request IDs that are part of this batch.
+	// Request IDs will always be part of the same queue.
+	// For e.g. - [queueA/1, queueA/2, queueA/3].
+	Contains []string
+	// Dependencies is a list of batch IDs (and associated metdata) for this batch.
+	// Dependencies will always be part of the same queue.
+	Dependencies []map[string]interface{}
+	// The state of the batch lifecycle this batch is in.
+	State string
+	// Version is the version of the object. It is used for optimistic locking.
+	// Versioning starts at 1 and is incremented for each change to the object.
+	Version int32
+}

--- a/extension/storage/mysql/schema/batch.sql
+++ b/extension/storage/mysql/schema/batch.sql
@@ -5,5 +5,5 @@ CREATE TABLE IF NOT EXISTS batch (
     dependencies JSON NOT NULL,
     state VARCHAR(255) NOT NUll,
     version INT NOT NULL,
-    PRIMARY KEY (id,queue)
+    PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/extension/storage/mysql/schema/batch.sql
+++ b/extension/storage/mysql/schema/batch.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS batch (
+    id VARCHAR(255) NOT NULL,
+    queue VARCHAR(255) NOT NULL,
+    contains JSON NOT NULL,
+    dependencies JSON NOT NULL,
+    state VARCHAR(255) NOT NUll,
+    version INT NOT NULL,
+    PRIMARY KEY (id,queue)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
feat(entities) Adds batch entity and batch sql schema

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
This sets up batch entity and its corresponding sql schema. This establishes the core concept of a batch that will be used through the system.

## What?
* Add a `Batch` entity
* Add `batch` mysql schema
* Note: `BatchStore` in upcoming PR

## Test Plan


## Issues


## Stack
1. #44
1. @ #46
1. #47
1. #48
1. #49
