### PR TITLE
feat(entities) Adds speculation tree entity and sql schema

### DIFF
--- a/entity/BUILD.bazel
+++ b/entity/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "build.go",
         "change_provider.go",
         "request.go",
+        "speculation_tree.go",
     ],
     importpath = "github.com/uber/submitqueue/entity",
     visibility = ["//visibility:public"],

--- a/entity/speculation_tree.go
+++ b/entity/speculation_tree.go
@@ -8,5 +8,15 @@ type SpeculationTree struct {
 	Queue string
 	// Speculations is a list of speculation paths for this batch based on a graph of its
 	// dependents.
+	//
+	// For e.g - Consider batches - queueA/batch/1, queueA/batch/2, queueA/batch/3
+	// such that - queueA/batch/2 and queueA/batch/3 depend on queueA/batch/1
+	//
+	// Speculations for queueA/batch/1 - [{"path": "queueA/batch/1", "state": "scheduled", "score": 0.1}]
+	// Speculations for queueA/batch/2 - [{"path": "queueA/batch/2", "state": "scheduled", "score": 0.9}, {"path": "queueA/batch/1//queueA/batch/2", "state": "scheduled", "score": 0.3}]
+	// Speculations for queueA/batch/3 - [{"path": "queueA/batch/3", "state": "scheduled", "score": 0.9}, {"path": "queueA/batch/1//queueA/batch/3", "state": "scheduled", "score": 0.3}]
+	//
+	// Note that the key value pairs within the map could have additional information about the speculation path if needed.
+	//
 	Speculations []map[string]string
 }

--- a/entity/speculation_tree.go
+++ b/entity/speculation_tree.go
@@ -1,9 +1,21 @@
 package entity
 
+// SpeculationPathAction defines the possible actions for a speculation path.
+type SpeculationPathAction string
+
+const (
+	// SpeculationPathActionUnknown is the default zero value for SpeculationPathAction.
+	SpeculationPathActionUnknown SpeculationPathAction = ""
+	// TODO: Add comprehensive list of actions
+)
+
 // SpeculationInfo represents metadata about a single speculation path, including the path through the dependency graph, its current state, and the predicted build score.
 type SpeculationInfo struct {
+	// Path represents the speculation path.
 	Path string
-	State string
+	// Action is a state that this path is in.
+	Action SpeculationPathAction
+	// Score is score for this speculation path.
 	Score float32
 }
 

--- a/entity/speculation_tree.go
+++ b/entity/speculation_tree.go
@@ -11,8 +11,8 @@ const (
 
 // SpeculationInfo represents metadata about a single speculation path, including the path through the dependency graph, its current state, and the predicted build score.
 type SpeculationInfo struct {
-	// Path represents the speculation path.
-	Path string
+	// Path represents the speculation path; which is an ordered list of batches.
+	Path []string
 	// Action is a state that this path is in.
 	Action SpeculationPathAction
 	// Score is score for this speculation path.
@@ -29,9 +29,9 @@ type SpeculationTree struct {
 	// For e.g - Consider batches - queueA/batch/1, queueA/batch/2, queueA/batch/3
 	// such that - queueA/batch/2 and queueA/batch/3 depend on queueA/batch/1
 	//
-	// Speculations for queueA/batch/1 - [{Path: "queueA/batch/1", State: "scheduled", Score: 0.1}]
-	// Speculations for queueA/batch/2 - [{Path: "queueA/batch/2", State: "scheduled", Score: 0.9}, {Path: "queueA/batch/1//queueA/batch/2", State: "scheduled", Score: 0.3}]
-	// Speculations for queueA/batch/3 - [{Path: "queueA/batch/3", State: "scheduled", Score: 0.9}, {Path: "queueA/batch/1//queueA/batch/3", State: "scheduled", Score: 0.3}]
+	// Speculations for queueA/batch/1 - [{Path: []string{"queueA/batch/1"}, State: "scheduled", Score: 0.1}]
+	// Speculations for queueA/batch/2 - [{Path: []string{"queueA/batch/2"}, State: "scheduled", Score: 0.9}, {Path: []string{"queueA/batch/1", "queueA/batch/2"}, State: "scheduled", Score: 0.3}]
+	// Speculations for queueA/batch/3 - [{Path: []string{"queueA/batch/3"}, State: "scheduled", Score: 0.9}, {Path: []string{"queueA/batch/1", "queueA/batch/3"}, State: "scheduled", Score: 0.3}]
 	//
 	Speculations []SpeculationInfo
 }

--- a/entity/speculation_tree.go
+++ b/entity/speculation_tree.go
@@ -1,0 +1,12 @@
+package entity
+
+// SpeculationTree represents the set of speculation paths constructed for a batch based on its dependency graph.
+type SpeculationTree struct {
+	// BatchID is the batch for which this speculation tree is constructed.
+	BatchID string
+	// Queue is the name of the queue processing the land request. Queue name is defined in the configuration and should be unique within the system.
+	Queue string
+	// Speculations is a list of speculation paths for this batch based on a graph of its
+	// dependents.
+	Speculations []map[string]string
+}

--- a/entity/speculation_tree.go
+++ b/entity/speculation_tree.go
@@ -1,22 +1,25 @@
 package entity
 
+// SpeculationInfo represents metadata about a single speculation path, including the path through the dependency graph, its current state, and the predicted build score.
+type SpeculationInfo struct {
+	Path string
+	State string
+	Score float32
+}
+
 // SpeculationTree represents the set of speculation paths constructed for a batch based on its dependency graph.
 type SpeculationTree struct {
 	// BatchID is the batch for which this speculation tree is constructed.
 	BatchID string
-	// Queue is the name of the queue processing the land request. Queue name is defined in the configuration and should be unique within the system.
-	Queue string
 	// Speculations is a list of speculation paths for this batch based on a graph of its
 	// dependents.
 	//
 	// For e.g - Consider batches - queueA/batch/1, queueA/batch/2, queueA/batch/3
 	// such that - queueA/batch/2 and queueA/batch/3 depend on queueA/batch/1
 	//
-	// Speculations for queueA/batch/1 - [{"path": "queueA/batch/1", "state": "scheduled", "score": 0.1}]
-	// Speculations for queueA/batch/2 - [{"path": "queueA/batch/2", "state": "scheduled", "score": 0.9}, {"path": "queueA/batch/1//queueA/batch/2", "state": "scheduled", "score": 0.3}]
-	// Speculations for queueA/batch/3 - [{"path": "queueA/batch/3", "state": "scheduled", "score": 0.9}, {"path": "queueA/batch/1//queueA/batch/3", "state": "scheduled", "score": 0.3}]
+	// Speculations for queueA/batch/1 - [{Path: "queueA/batch/1", State: "scheduled", Score: 0.1}]
+	// Speculations for queueA/batch/2 - [{Path: "queueA/batch/2", State: "scheduled", Score: 0.9}, {Path: "queueA/batch/1//queueA/batch/2", State: "scheduled", Score: 0.3}]
+	// Speculations for queueA/batch/3 - [{Path: "queueA/batch/3", State: "scheduled", Score: 0.9}, {Path: "queueA/batch/1//queueA/batch/3", State: "scheduled", Score: 0.3}]
 	//
-	// Note that the key value pairs within the map could have additional information about the speculation path if needed.
-	//
-	Speculations []map[string]string
+	Speculations []SpeculationInfo
 }

--- a/extension/storage/mysql/schema/speculation_tree.sql
+++ b/extension/storage/mysql/schema/speculation_tree.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS speculation_tree (
+    batch_id VARCHAR(255) NOT NULL,
+    queue VARCHAR(255) NOT NULL,
+    speculations JSON NOT NULL,
+    PRIMARY KEY (batch_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/extension/storage/mysql/schema/speculation_tree.sql
+++ b/extension/storage/mysql/schema/speculation_tree.sql
@@ -1,6 +1,5 @@
 CREATE TABLE IF NOT EXISTS speculation_tree (
     batch_id VARCHAR(255) NOT NULL,
-    queue VARCHAR(255) NOT NULL,
     speculations JSON NOT NULL,
     PRIMARY KEY (batch_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
feat(entities) Adds speculation tree entity and sql schema

## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
This sets up a speculation tree entity and its corresponding sql schema. This establishes a concrete entity for speculation tree that will be used across the system.

## What?
* Add a `SpeculationTree` entity
* Add `speculation_tree` mysql schema
* Note: `SpeculationTreeStore` in upcoming PR

## Test Plan


## Issues

