### PR TITLE
feat(entities) Adds batch dependent entity and sql schema

### DIFF
--- a/entity/BUILD.bazel
+++ b/entity/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "entity",
     srcs = [
         "batch.go",
+        "batch_dependent.go",
         "change_provider.go",
         "request.go",
     ],

--- a/entity/batch_dependent.go
+++ b/entity/batch_dependent.go
@@ -1,0 +1,20 @@
+package entity
+
+// BatchDependent represents the downstream batches that depend on a given batch.
+// The object is immutable after creation.
+type BatchDependent struct {
+	// BatchID is the globally unique identifier representing a batch.
+	BatchID string
+	// Dependents is a list of batch IDs that are dependents for this
+	// batch.
+	//
+	// For e.g - Consider batches - queueA/batch/1, queueA/batch/2, queueA/batch/3
+	// such that - queueA/batch/2 and queueA/batch/3 depend on queueA/batch/1
+	//
+	// In this case, the Dependents field for -
+	// - queueA/batch/1 will be [queueA/batch/2, queueA/batch/3]
+	// - queueA/batch/2 will be empty
+	// - queueA/batch/3 will be empty
+	//
+	Dependents []string
+}

--- a/extension/storage/mysql/schema/batch_dependent.sql
+++ b/extension/storage/mysql/schema/batch_dependent.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS batch_dependent (
+    batch_id VARCHAR(255) NOT NULL,
+    dependents JSON NOT NULL,
+    PRIMARY KEY (batch_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
feat(entities) Adds batch dependent entity and sql schema


## Why?
<!-- Why is this change necessary? What is the motivation or justification? -->
This sets up batch dependent entity and its corresponding sql schema. This helps make reverse look ups for batch dependencies easier throughout the system.

## What?
* Add a `BatchDependent` entity
* Add `batch_dependent` mysql schema
* Note: `BatchDependentStore` in upcoming PR

## Test Plan


## Issues


## Stack
1. @ #54
1. #48
1. #49
1. #56
