### PR TITLE
fix (test): use TCP healthcheck for MySQL containers to prevent flaky startup

### DIFF
--- a/example/server/docker-compose.yml
+++ b/example/server/docker-compose.yml
@@ -18,7 +18,10 @@ services:
     ports:
       - "3306"  # Random ephemeral port to avoid conflicts
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot"]
+      # Use 127.0.0.1 (TCP) instead of localhost (Unix socket). MySQL treats
+      # "localhost" as a socket connection, which can be ready before the TCP
+      # listener — causing dependent services that connect over TCP to fail.
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -33,7 +36,7 @@ services:
     ports:
       - "3306"  # Random ephemeral port to avoid conflicts
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/example/server/gateway/docker-compose.yml
+++ b/example/server/gateway/docker-compose.yml
@@ -18,7 +18,10 @@ services:
     ports:
       - "3306"  # Random ephemeral port to avoid conflicts
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot"]
+      # Use 127.0.0.1 (TCP) instead of localhost (Unix socket). MySQL treats
+      # "localhost" as a socket connection, which can be ready before the TCP
+      # listener — causing dependent services that connect over TCP to fail.
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -33,7 +36,7 @@ services:
     ports:
       - "3306"  # Random ephemeral port to avoid conflicts
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/example/server/orchestrator/docker-compose.yml
+++ b/example/server/orchestrator/docker-compose.yml
@@ -18,7 +18,10 @@ services:
     ports:
       - "3306"  # Random ephemeral port to avoid conflicts
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot"]
+      # Use 127.0.0.1 (TCP) instead of localhost (Unix socket). MySQL treats
+      # "localhost" as a socket connection, which can be ready before the TCP
+      # listener — causing dependent services that connect over TCP to fail.
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -33,7 +36,7 @@ services:
     ports:
       - "3306"  # Random ephemeral port to avoid conflicts
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/test/integration/extension/counter/mysql/docker-compose.yml
+++ b/test/integration/extension/counter/mysql/docker-compose.yml
@@ -11,7 +11,10 @@ services:
     ports:
       - "3306"  # Random ephemeral port to avoid conflicts
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot"]
+      # Use 127.0.0.1 (TCP) instead of localhost (Unix socket). MySQL treats
+      # "localhost" as a socket connection, which can be ready before the TCP
+      # listener — causing dependent services that connect over TCP to fail.
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/test/integration/extension/queue/mysql/docker-compose.yml
+++ b/test/integration/extension/queue/mysql/docker-compose.yml
@@ -11,7 +11,10 @@ services:
     ports:
       - "3306"  # Random ephemeral port to avoid conflicts
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot"]
+      # Use 127.0.0.1 (TCP) instead of localhost (Unix socket). MySQL treats
+      # "localhost" as a socket connection, which can be ready before the TCP
+      # listener — causing dependent services that connect over TCP to fail.
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/test/integration/extension/storage/mysql/docker-compose.yml
+++ b/test/integration/extension/storage/mysql/docker-compose.yml
@@ -11,7 +11,10 @@ services:
     ports:
       - "3306"  # Random ephemeral port to avoid conflicts
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot"]
+      # Use 127.0.0.1 (TCP) instead of localhost (Unix socket). MySQL treats
+      # "localhost" as a socket connection, which can be ready before the TCP
+      # listener — causing dependent services that connect over TCP to fail.
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/test/testutil/compose.go
+++ b/test/testutil/compose.go
@@ -190,7 +190,8 @@ func (s *ComposeStack) ServiceHost(serviceName string, containerPort int) (strin
 }
 
 // ConnectMySQLService connects to a MySQL service by name in the compose stack.
-// Retries the connection and registers cleanup automatically.
+// Requires that Up() has been called first — the TCP-based healthcheck in
+// docker-compose ensures MySQL is accepting TCP connections before Up() returns.
 func (s *ComposeStack) ConnectMySQLService(serviceName string) (*sql.DB, error) {
 	s.t.Helper()
 
@@ -199,24 +200,14 @@ func (s *ComposeStack) ConnectMySQLService(serviceName string) (*sql.DB, error) 
 		return nil, err
 	}
 
-	// Retry connection a few times as MySQL might still be initializing
-	var db *sql.DB
-	for i := 0; i < 10; i++ {
-		db, err = sql.Open("mysql", dsn)
-		if err != nil {
-			return nil, fmt.Errorf("failed to open mysql connection: %w", err)
-		}
-
-		if err = db.Ping(); err == nil {
-			break
-		}
-
-		db.Close()
-		time.Sleep(1 * time.Second)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open mysql connection: %w", err)
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to %s mysql after retries: %w", serviceName, err)
+	if err = db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to ping %s mysql: %w", serviceName, err)
 	}
 
 	port, _ := s.ServicePort(serviceName, 3306) // We already got the port successfully


### PR DESCRIPTION
## Summary

- Switch MySQL healthchecks from `localhost` (Unix socket) to `127.0.0.1` (TCP) across all 6 docker-compose files
- Remove retry loop from `ConnectMySQLService` since TCP healthcheck guarantees readiness before `Up()` returns

MySQL treats `localhost` as a Unix socket connection, which can be ready before the TCP listener. Dependent services (orchestrator, gateway) connecting over TCP would intermittently get `connection refused` — causing flaky integration tests and CI failures.

## Test plan

- [x] Reproduced flakiness locally (orchestrator failed 2/3 runs, gateway failed 3/3 runs)
- [x] Verified fix: 4 consecutive uncached orchestrator runs pass, 3 consecutive gateway runs pass
- [x] All 5 integration tests pass
- [x] E2E test passes