### PR TITLE
feat(entities) Update build status enum with more states

### DIFF
--- a/entity/BUILD.bazel
+++ b/entity/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 go_test(
     name = "entity_test",
     srcs = [
+        "build_test.go",
         "queue_config_test.go",
         "request_test.go",
     ],

--- a/entity/build.go
+++ b/entity/build.go
@@ -4,10 +4,39 @@ package entity
 type BuildStatus string
 
 const (
-	// BuildStateUnknown is the unreachable state. It is set by default when the structure is initialized. It should never be seen in the system.
-	BuildStateUnknown BuildStatus = ""
-	// TODO: Add comprehensive list of known build states.
+	// BuildStatusUnknown is the unreachable state. It is set by default when the structure is initialized. It should never be seen in the system.
+	BuildStatusUnknown BuildStatus = ""
+
+	// BuildStatusQueued indicates the build has been scheduled but not yet started.
+	BuildStatusQueued BuildStatus = "queued"
+
+	// BuildStatusRunning indicates the build is currently executing.
+	BuildStatusRunning BuildStatus = "running"
+
+	// BuildStatusPassed indicates the build completed successfully.
+	// This is a terminal state.
+	BuildStatusPassed BuildStatus = "passed"
+
+	// BuildStatusFailed indicates the build completed with failures.
+	// This is a terminal state.
+	BuildStatusFailed BuildStatus = "failed"
+
+	// BuildStatusCancelled indicates the build was cancelled before completion.
+	// This is a terminal state.
+	BuildStatusCancelled BuildStatus = "cancelled"
+
+	// BuildStatusBlocked indicates the build is waiting for manual approval or unblocking.
+	// Some CI systems (like BuildKite) support manual approval steps.
+	BuildStatusBlocked BuildStatus = "blocked"
 )
+
+// IsTerminal returns true if the build state represents a final state (passed, failed, or cancelled).
+// Terminal states indicate the build has finished and will not change state again.
+// Note: BuildStatusBlocked is NOT terminal as blocked builds can be unblocked and continue execution.
+func (s BuildStatus) IsTerminal() bool {
+	return s == BuildStatusPassed || s == BuildStatusFailed || s == BuildStatusCancelled
+}
+
 
 // SpeculationPathInfo represents the base and head commits of a speculation path used in a build.
 type SpeculationPathInfo struct {

--- a/entity/build_test.go
+++ b/entity/build_test.go
@@ -1,0 +1,57 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildStatus_IsTerminal(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   BuildStatus
+		expected bool
+	}{
+		{
+			name:     "passed is terminal",
+			status:   BuildStatusPassed,
+			expected: true,
+		},
+		{
+			name:     "failed is terminal",
+			status:   BuildStatusFailed,
+			expected: true,
+		},
+		{
+			name:     "cancelled is terminal",
+			status:   BuildStatusCancelled,
+			expected: true,
+		},
+		{
+			name:     "queued is not terminal",
+			status:   BuildStatusQueued,
+			expected: false,
+		},
+		{
+			name:     "running is not terminal",
+			status:   BuildStatusRunning,
+			expected: false,
+		},
+		{
+			name:     "blocked is not terminal",
+			status:   BuildStatusBlocked,
+			expected: false,
+		},
+		{
+			name:     "unknown is not terminal",
+			status:   BuildStatusUnknown,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.status.IsTerminal())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
feat(entities) Update build status enum with more states.

We also add an `IsTerminal` method to check whether a build status is terminal. Tests for this function have also been added.

## Test Plan
Unit tests added


## Issues

