### PR TITLE
feat(entities) Update batch state enum with more states

### DIFF
--- a/entity/BUILD.bazel
+++ b/entity/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 go_test(
     name = "entity_test",
     srcs = [
+        "batch_test.go",
         "build_test.go",
         "queue_config_test.go",
         "request_test.go",

--- a/entity/batch.go
+++ b/entity/batch.go
@@ -6,15 +6,15 @@ type BatchState string
 const (
 	// BatchStateUnknown is the unreachable state. It is set by default when the structure is initialized. It should never be seen in the system.
 	BatchStateUnknown BatchState = ""
-	// BatchStateScheduled is the state of a batch that has been scheduled for processing.
-	BatchStateScheduled BatchState = "scheduled"
+	// BatchStateCreated is the state of a batch that has been created for processing.
+	BatchStateCreated BatchState = "created"
 	// BatchStateSpeculating is the state of a batch that is undergoing speculative execution.
 	BatchStateSpeculating BatchState = "speculating"
 	// BatchStateFinalizing is the state of a batch that is being finalized after speculative execution.
 	BatchStateFinalizing BatchState = "finalizing"
 	// BatchStateSucceeded is the terminal state of a batch that has been successfully landed.
 	BatchStateSucceeded BatchState = "succeeded"
-	// BatchStateFailed is the terminal state of a batch that has failed to land.
+	// BatchStateFailed is the terminal state of a batch that has failed.
 	BatchStateFailed BatchState = "failed"
 	// BatchStateCancelled is the terminal state of a batch that was cancelled before completion.
 	BatchStateCancelled BatchState = "cancelled"

--- a/entity/batch.go
+++ b/entity/batch.go
@@ -6,8 +6,32 @@ type BatchState string
 const (
 	// BatchStateUnknown is the unreachable state. It is set by default when the structure is initialized. It should never be seen in the system.
 	BatchStateUnknown BatchState = ""
-	// TODO: Add comprehensive list of known batch states.
+	// BatchStateScheduled is the state of a batch that has been scheduled for processing.
+	BatchStateScheduled BatchState = "scheduled"
+	// BatchStateSpeculating is the state of a batch that is undergoing speculative execution.
+	BatchStateSpeculating BatchState = "speculating"
+	// BatchStateFinalizing is the state of a batch that is being finalized after speculative execution.
+	BatchStateFinalizing BatchState = "finalizing"
+	// BatchStateSucceeded is the terminal state of a batch that has been successfully landed.
+	BatchStateSucceeded BatchState = "succeeded"
+	// BatchStateFailed is the terminal state of a batch that has failed to land.
+	BatchStateFailed BatchState = "failed"
+	// BatchStateCancelled is the terminal state of a batch that was cancelled before completion.
+	BatchStateCancelled BatchState = "cancelled"
+	// BatchStateCancellationFailed is the terminal state of a batch whose cancellation process itself failed.
+	BatchStateCancellationFailed BatchState = "cancellationfailed"
 )
+
+// IsTerminal returns true if the batch state is a terminal state.
+// Terminal states are states from which no further transitions are possible.
+func (s BatchState) IsTerminal() bool {
+	switch s {
+	case BatchStateSucceeded, BatchStateFailed, BatchStateCancelled, BatchStateCancellationFailed:
+		return true
+	default:
+		return false
+	}
+}
 
 // Batch represents a group of requests to land (merge into target branch of the source control repository).
 type Batch struct {

--- a/entity/batch.go
+++ b/entity/batch.go
@@ -18,15 +18,13 @@ const (
 	BatchStateFailed BatchState = "failed"
 	// BatchStateCancelled is the terminal state of a batch that was cancelled before completion.
 	BatchStateCancelled BatchState = "cancelled"
-	// BatchStateCancellationFailed is the terminal state of a batch whose cancellation process itself failed.
-	BatchStateCancellationFailed BatchState = "cancellationfailed"
 )
 
 // IsTerminal returns true if the batch state is a terminal state.
 // Terminal states are states from which no further transitions are possible.
 func (s BatchState) IsTerminal() bool {
 	switch s {
-	case BatchStateSucceeded, BatchStateFailed, BatchStateCancelled, BatchStateCancellationFailed:
+	case BatchStateSucceeded, BatchStateFailed, BatchStateCancelled:
 		return true
 	default:
 		return false

--- a/entity/batch_test.go
+++ b/entity/batch_test.go
@@ -1,0 +1,31 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchState_IsTerminal(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    BatchState
+		terminal bool
+	}{
+		{name: "unknown", state: BatchStateUnknown, terminal: false},
+		{name: "scheduled", state: BatchStateScheduled, terminal: false},
+		{name: "speculating", state: BatchStateSpeculating, terminal: false},
+		{name: "finalizing", state: BatchStateFinalizing, terminal: false},
+		{name: "succeeded", state: BatchStateSucceeded, terminal: true},
+		{name: "failed", state: BatchStateFailed, terminal: true},
+		{name: "cancelled", state: BatchStateCancelled, terminal: true},
+		{name: "cancellationfailed", state: BatchStateCancellationFailed, terminal: true},
+		{name: "arbitrary string", state: BatchState("something_else"), terminal: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.terminal, tt.state.IsTerminal())
+		})
+	}
+}

--- a/entity/batch_test.go
+++ b/entity/batch_test.go
@@ -19,7 +19,6 @@ func TestBatchState_IsTerminal(t *testing.T) {
 		{name: "succeeded", state: BatchStateSucceeded, terminal: true},
 		{name: "failed", state: BatchStateFailed, terminal: true},
 		{name: "cancelled", state: BatchStateCancelled, terminal: true},
-		{name: "cancellationfailed", state: BatchStateCancellationFailed, terminal: true},
 		{name: "arbitrary string", state: BatchState("something_else"), terminal: false},
 	}
 

--- a/entity/batch_test.go
+++ b/entity/batch_test.go
@@ -13,7 +13,7 @@ func TestBatchState_IsTerminal(t *testing.T) {
 		terminal bool
 	}{
 		{name: "unknown", state: BatchStateUnknown, terminal: false},
-		{name: "scheduled", state: BatchStateScheduled, terminal: false},
+		{name: "created", state: BatchStateCreated, terminal: false},
 		{name: "speculating", state: BatchStateSpeculating, terminal: false},
 		{name: "finalizing", state: BatchStateFinalizing, terminal: false},
 		{name: "succeeded", state: BatchStateSucceeded, terminal: true},


### PR DESCRIPTION
## Summary
feat(entities) Update batch state enum with more states

## What?
Added batch state constants (scheduled, speculating, finalizing, succeeded, failed, cancelled,
cancellationfailed) and an IsTerminal() method to BatchState with table-driven tests.

## Why?
This state information is needed to inspect batches that should be under consideration for dependency graph calculation by the batch manager.

## Test Plan
Unit tests added.

## Issues

