### PR TITLE
feat(queueconfig): add ChangeProvider, MergeChecker, LandProvider as string fields for registry/mapping

### DIFF
--- a/entity/queue_config.go
+++ b/entity/queue_config.go
@@ -33,4 +33,19 @@ type QueueConfig struct {
 	//   - Buildkite: "buildkite.com/uber/submitqueue-ci"
 	//   - Jenkins: "jenkins.example.com/job/submitqueue-verify"
 	BuildRunner string `json:"build_runner" yaml:"build_runner"`
+
+	// ChangeProvider identifies the change provider implementation for this queue.
+	// Maps to a registered ChangeProvider in the implementation registry.
+	// Examples: "github", "gitlab", "phabricator"
+	ChangeProvider string `json:"change_provider" yaml:"change_provider"`
+
+	// MergeChecker identifies the merge checker implementation for this queue.
+	// Maps to a registered MergeChecker in the implementation registry.
+	// Examples: "github", "gitlab"
+	MergeChecker string `json:"merge_checker" yaml:"merge_checker"`
+
+	// LandProvider identifies the land provider implementation for this queue.
+	// Maps to a registered LandProvider in the implementation registry.
+	// Examples: "github", "gitlab"
+	LandProvider string `json:"land_provider" yaml:"land_provider"`
 }

--- a/entity/queue_config.go
+++ b/entity/queue_config.go
@@ -35,17 +35,17 @@ type QueueConfig struct {
 	BuildRunner string `json:"build_runner" yaml:"build_runner"`
 
 	// ChangeProvider identifies the change provider implementation for this queue.
-	// Maps to a registered ChangeProvider in the implementation registry.
+	// Opaque to the system; meaningful only to the change provider extension implementation.
 	// Examples: "github", "gitlab", "phabricator"
 	ChangeProvider string `json:"change_provider" yaml:"change_provider"`
 
 	// MergeChecker identifies the merge checker implementation for this queue.
-	// Maps to a registered MergeChecker in the implementation registry.
+	// Opaque to the system; meaningful only to the merge checker extension implementation.
 	// Examples: "github", "gitlab"
 	MergeChecker string `json:"merge_checker" yaml:"merge_checker"`
 
 	// LandProvider identifies the land provider implementation for this queue.
-	// Maps to a registered LandProvider in the implementation registry.
+	// Opaque to the system; meaningful only to the land provider extension implementation.
 	// Examples: "github", "gitlab"
 	LandProvider string `json:"land_provider" yaml:"land_provider"`
 }


### PR DESCRIPTION
## Summary
feat(queueconfig): add ChangeProvider, MergeChecker, LandProvider as string fields for registry/mapping

Adding fields explicitly to queueconfig for per-queue, and the ability to do transparent registry mapping for implementations

## Test Plan


## Issues

