### PR TITLE
feat(controller) Create batch dependents entity based on the batch created

### DIFF
--- a/orchestrator/controller/batch/BUILD.bazel
+++ b/orchestrator/controller/batch/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "//entity",
         "//entity/queue",
         "//extension/queue/mock",
+        "//extension/storage",
         "//extension/storage/mock",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/orchestrator/controller/batch/batch.go
+++ b/orchestrator/controller/batch/batch.go
@@ -124,15 +124,38 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 		})
 	}
 
+	// Create batch dependent entities (reverse relationship of batch.Dependencies).
+	// For each dependency, record the new batch as a dependent.
+	// If existing dependents are found in the store, append them.
+	for _, dep := range activeBatches {
+		bd := entity.BatchDependent{
+			BatchID:    dep.ID,
+			Dependents: []string{batch.ID},
+		}
+
+		existing, err := c.store.GetBatchDependentStore().Get(ctx, dep.ID)
+		if err != nil && !storage.IsNotFound(err) {
+			c.logger.Errorw("failed to get existing batch dependent",
+				"batch_id", dep.ID,
+				"error", err,
+			)
+			c.metricsScope.Counter("batch_dependent_store_errors").Inc(1)
+			return fmt.Errorf("failed to get batch dependent for batchID=%s: %w", dep.ID, err)
+		}
+		if err == nil {
+			bd.Dependents = append(existing.Dependents, bd.Dependents...)
+		}
+	}
+
 	// TODO:
 	// - Add batch to DB
-	// - Create batch dependent entity
 	// - Add to batch dependent DB
 
 	c.logger.Infow("batch created",
 		"batch_id", batch.ID,
 		"request_id", request.ID,
 		"queue", request.Queue,
+		"dependency_count", len(batch.Dependencies),
 	)
 
 	// Publish to speculate topic

--- a/orchestrator/controller/batch/batch_test.go
+++ b/orchestrator/controller/batch/batch_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/uber/submitqueue/entity"
 	"github.com/uber/submitqueue/entity/queue"
 	queuemock "github.com/uber/submitqueue/extension/queue/mock"
+	"github.com/uber/submitqueue/extension/storage"
 	storagemock "github.com/uber/submitqueue/extension/storage/mock"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
@@ -177,6 +178,54 @@ func TestController_Process_CounterFailure(t *testing.T) {
 
 	err = controller.Process(context.Background(), delivery)
 	assert.Error(t, err)
+}
+
+func TestController_Process_WithDependencies(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	// Set up storage with active batches to become dependencies.
+	activeBatches := []entity.Batch{
+		{ID: "test-queue/batch/1", Queue: "test-queue", State: entity.BatchStateCreated, Version: 1},
+		{ID: "test-queue/batch/2", Queue: "test-queue", State: entity.BatchStateSpeculating, Version: 2},
+	}
+
+	mockBatchStore := storagemock.NewMockBatchStore(ctrl)
+	mockBatchStore.EXPECT().GetByQueueAndStates(gomock.Any(), "test-queue", gomock.Any()).Return(activeBatches, nil)
+
+	mockBatchDependentStore := storagemock.NewMockBatchDependentStore(ctrl)
+	// batch/1 has no existing dependents.
+	mockBatchDependentStore.EXPECT().Get(gomock.Any(), "test-queue/batch/1").Return(entity.BatchDependent{}, storage.ErrNotFound)
+	// batch/2 already has an existing dependent.
+	mockBatchDependentStore.EXPECT().Get(gomock.Any(), "test-queue/batch/2").Return(entity.BatchDependent{
+		BatchID:    "test-queue/batch/2",
+		Dependents: []string{"test-queue/batch/99"},
+	}, nil)
+
+	mockStorage := storagemock.NewMockStorage(ctrl)
+	mockStorage.EXPECT().GetBatchStore().Return(mockBatchStore).AnyTimes()
+	mockStorage.EXPECT().GetBatchDependentStore().Return(mockBatchDependentStore).AnyTimes()
+
+	controller := newTestController(t, ctrl, newSequentialCounter(), mockStorage, nil)
+
+	request := entity.Request{
+		ID:           "test-queue/456",
+		Queue:        "test-queue",
+		Change:       entity.Change{URIs: []string{"github://uber/service/pull/789/abc123def"}},
+		LandStrategy: entity.RequestLandStrategyRebase,
+		State:        entity.RequestStateNew,
+		Version:      1,
+	}
+
+	payload, err := request.ToBytes()
+	require.NoError(t, err)
+
+	msg := queue.NewMessage(request.ID, payload, request.Queue, nil)
+	delivery := queuemock.NewMockDelivery(ctrl)
+	delivery.EXPECT().Message().Return(msg).AnyTimes()
+	delivery.EXPECT().Attempt().Return(1).AnyTimes()
+
+	err = controller.Process(context.Background(), delivery)
+	require.NoError(t, err)
 }
 
 func TestController_InterfaceImplementation(t *testing.T) {


### PR DESCRIPTION
## Summary
feat(controller) Create batch dependents entity based on the batch created

## What?
The batch controller now creates BatchDependent entities (the reverse of Batch.Dependencies) when a new batch is formed. For each active batch the new batch depends on, it looks up existing dependents from the store and merges them with the new batch ID.

## Why? 
Downstream pipeline stages need to know which batches are waiting on a given batch to complete. Batch.Dependencies answers "what do I depend on?" but not "who depends on me?" The BatchDependent reverse index enables efficient lookups for cascading state changes — e.g., when a batch succeeds or fails, the system can quickly find and notify all dependent batches.

## Test Plan


## Issues
#80 
