### PR TITLE
feat(test) Add gomock-generated mock for counter.Counter, replacing hand-written test mocks

### DIFF
--- a/extension/counter/BUILD.bazel
+++ b/extension/counter/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@rules_go//go:def.bzl", "go_library")
 
+exports_files(
+    ["counter.go"],
+    visibility = ["//extension/counter/mock:__pkg__"],
+)
+
 go_library(
     name = "counter",
     srcs = ["counter.go"],

--- a/extension/counter/counter.go
+++ b/extension/counter/counter.go
@@ -1,5 +1,7 @@
 package counter
 
+//go:generate mockgen -source=counter.go -destination=mock/counter.go -package=mock
+
 import "context"
 
 // Counter provides atomic sequential number generation for a given domain.

--- a/extension/counter/mock/BUILD.bazel
+++ b/extension/counter/mock/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_go//extras:gomock.bzl", "gomock")
+load("@rules_go//go:def.bzl", "go_library")
+
+_MOCKGEN = "@org_uber_go_mock//mockgen"
+
+gomock(
+    name = "mock_counter_src",
+    out = "counter_mock.go",
+    mockgen_tool = _MOCKGEN,
+    package = "mock",
+    source = "//extension/counter:counter.go",
+    source_importpath = "github.com/uber/submitqueue/extension/counter",
+)
+
+# gazelle:ignore
+go_library(
+    name = "mock",
+    srcs = [
+        ":mock_counter_src",
+    ],
+    importpath = "github.com/uber/submitqueue/extension/counter/mock",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//extension/counter",
+        "@org_uber_go_mock//gomock",
+    ],
+)

--- a/gateway/controller/BUILD.bazel
+++ b/gateway/controller/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     deps = [
         "//entity",
         "//entity/queue",
+        "//extension/counter/mock",
         "//extension/storage/mock",
         "//gateway/protopb",
         "@com_github_stretchr_testify//assert",

--- a/gateway/controller/land_test.go
+++ b/gateway/controller/land_test.go
@@ -10,19 +10,12 @@ import (
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/entity"
 	"github.com/uber/submitqueue/entity/queue"
+	countermock "github.com/uber/submitqueue/extension/counter/mock"
 	storagemock "github.com/uber/submitqueue/extension/storage/mock"
 	pb "github.com/uber/submitqueue/gateway/protopb"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 )
-
-type mockCounter struct {
-	nextFunc func(ctx context.Context, domain string) (int64, error)
-}
-
-func (m *mockCounter) Next(ctx context.Context, domain string) (int64, error) {
-	return m.nextFunc(ctx, domain)
-}
 
 type mockPublisher struct {
 	publishFunc func(ctx context.Context, topic string, msg queue.Message) error
@@ -47,9 +40,7 @@ func TestNewLandController(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := storagemock.NewMockStorage(ctrl)
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 1, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
 	controller := NewLandController(zap.NewNop().Sugar(), tally.NoopScope, store, cnt, noopPublisher(), "request")
 	require.NotNil(t, controller)
 }
@@ -61,9 +52,8 @@ func TestLand_ReturnsSqid(t *testing.T) {
 	store := storagemock.NewMockStorage(ctrl)
 	store.EXPECT().GetRequestStore().Return(mockReqStore).AnyTimes()
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 1, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
+	cnt.EXPECT().Next(gomock.Any(), gomock.Any()).Return(int64(1), nil)
 	controller := NewLandController(zap.NewNop().Sugar(), tally.NoopScope, store, cnt, noopPublisher(), "request")
 	ctx := context.Background()
 
@@ -91,9 +81,8 @@ func TestLand_PassesCorrectParametersToStore(t *testing.T) {
 	store := storagemock.NewMockStorage(ctrl)
 	store.EXPECT().GetRequestStore().Return(mockReqStore).AnyTimes()
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 42, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
+	cnt.EXPECT().Next(gomock.Any(), gomock.Any()).Return(int64(42), nil)
 	controller := NewLandController(zap.NewNop().Sugar(), tally.NoopScope, store, cnt, noopPublisher(), "request")
 	ctx := context.Background()
 
@@ -121,9 +110,8 @@ func TestLand_ReturnsErrorOnStorageFailure(t *testing.T) {
 	store := storagemock.NewMockStorage(ctrl)
 	store.EXPECT().GetRequestStore().Return(mockReqStore).AnyTimes()
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 1, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
+	cnt.EXPECT().Next(gomock.Any(), gomock.Any()).Return(int64(1), nil)
 	controller := NewLandController(zap.NewNop().Sugar(), tally.NoopScope, store, cnt, noopPublisher(), "request")
 	ctx := context.Background()
 
@@ -140,9 +128,8 @@ func TestLand_ReturnsErrorOnCounterFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := storagemock.NewMockStorage(ctrl)
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 0, fmt.Errorf("counter unavailable")
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
+	cnt.EXPECT().Next(gomock.Any(), gomock.Any()).Return(int64(0), fmt.Errorf("counter unavailable"))
 	controller := NewLandController(zap.NewNop().Sugar(), tally.NoopScope, store, cnt, noopPublisher(), "request")
 	ctx := context.Background()
 
@@ -164,10 +151,13 @@ func TestLand_CounterDomainIncludesQueue(t *testing.T) {
 	store := storagemock.NewMockStorage(ctrl)
 	store.EXPECT().GetRequestStore().Return(mockReqStore).AnyTimes()
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		capturedDomain = domain
-		return 1, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
+	cnt.EXPECT().Next(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, domain string) (int64, error) {
+			capturedDomain = domain
+			return 1, nil
+		},
+	)
 	controller := NewLandController(zap.NewNop().Sugar(), tally.NoopScope, store, cnt, noopPublisher(), "request")
 	ctx := context.Background()
 
@@ -185,9 +175,7 @@ func TestLand_ReturnsErrorOnEmptyQueue(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := storagemock.NewMockStorage(ctrl)
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 1, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
 	controller := NewLandController(zap.NewNop().Sugar(), tally.NoopScope, store, cnt, noopPublisher(), "request")
 	ctx := context.Background()
 
@@ -205,9 +193,7 @@ func TestLand_ReturnsErrorOnEmptyChangeUri(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := storagemock.NewMockStorage(ctrl)
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 1, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
 	controller := NewLandController(zap.NewNop().Sugar(), tally.NoopScope, store, cnt, noopPublisher(), "request")
 	ctx := context.Background()
 
@@ -225,9 +211,7 @@ func TestLand_ReturnsErrorOnNilChange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := storagemock.NewMockStorage(ctrl)
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 1, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
 	controller := NewLandController(zap.NewNop().Sugar(), tally.NoopScope, store, cnt, noopPublisher(), "request")
 	ctx := context.Background()
 
@@ -251,9 +235,8 @@ func TestLand_PublishesToQueue(t *testing.T) {
 	store := storagemock.NewMockStorage(ctrl)
 	store.EXPECT().GetRequestStore().Return(mockReqStore).AnyTimes()
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 123, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
+	cnt.EXPECT().Next(gomock.Any(), gomock.Any()).Return(int64(123), nil)
 	publisher := &mockPublisher{publishFunc: func(ctx context.Context, topic string, msg queue.Message) error {
 		publishedTopic = topic
 		publishedMessage = msg
@@ -296,9 +279,8 @@ func TestLand_ContinuesWhenPublishFails(t *testing.T) {
 	store := storagemock.NewMockStorage(ctrl)
 	store.EXPECT().GetRequestStore().Return(mockReqStore).AnyTimes()
 
-	cnt := &mockCounter{nextFunc: func(ctx context.Context, domain string) (int64, error) {
-		return 999, nil
-	}}
+	cnt := countermock.NewMockCounter(ctrl)
+	cnt.EXPECT().Next(gomock.Any(), gomock.Any()).Return(int64(999), nil)
 	publisher := &mockPublisher{publishFunc: func(ctx context.Context, topic string, msg queue.Message) error {
 		return fmt.Errorf("queue unavailable")
 	}}

--- a/orchestrator/controller/batch/BUILD.bazel
+++ b/orchestrator/controller/batch/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "//core/consumer",
         "//entity",
         "//entity/queue",
+        "//extension/counter/mock",
         "//extension/queue/mock",
         "//extension/storage",
         "//extension/storage/mock",

--- a/orchestrator/controller/batch/batch_test.go
+++ b/orchestrator/controller/batch/batch_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/uber/submitqueue/core/consumer"
 	"github.com/uber/submitqueue/entity"
 	"github.com/uber/submitqueue/entity/queue"
+	countermock "github.com/uber/submitqueue/extension/counter/mock"
 	queuemock "github.com/uber/submitqueue/extension/queue/mock"
 	"github.com/uber/submitqueue/extension/storage"
 	storagemock "github.com/uber/submitqueue/extension/storage/mock"
@@ -19,28 +20,21 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-// mockCounter implements counter.Counter for testing.
-type mockCounter struct {
-	nextFunc func(ctx context.Context, domain string) (int64, error)
-}
-
-func (m *mockCounter) Next(ctx context.Context, domain string) (int64, error) {
-	return m.nextFunc(ctx, domain)
-}
-
 // newSequentialCounter returns a mock counter that returns incrementing values starting at 1.
-func newSequentialCounter() *mockCounter {
+func newSequentialCounter(ctrl *gomock.Controller) *countermock.MockCounter {
 	var seq int64
-	return &mockCounter{
-		nextFunc: func(ctx context.Context, domain string) (int64, error) {
+	cnt := countermock.NewMockCounter(ctrl)
+	cnt.EXPECT().Next(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, domain string) (int64, error) {
 			return atomic.AddInt64(&seq, 1), nil
 		},
-	}
+	).AnyTimes()
+	return cnt
 }
 
 // newTestController creates a controller with test dependencies.
 // If mockStorage is nil, a default MockStorage with an empty batch store is created.
-func newTestController(t *testing.T, ctrl *gomock.Controller, cnt *mockCounter, mockStorage *storagemock.MockStorage, publishErr error) *Controller {
+func newTestController(t *testing.T, ctrl *gomock.Controller, cnt *countermock.MockCounter, mockStorage *storagemock.MockStorage, publishErr error) *Controller {
 	logger := zaptest.NewLogger(t).Sugar()
 	scope := tally.NoopScope
 
@@ -72,7 +66,7 @@ func newTestController(t *testing.T, ctrl *gomock.Controller, cnt *mockCounter, 
 
 func TestNewController(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	controller := newTestController(t, ctrl, newSequentialCounter(), nil, nil)
+	controller := newTestController(t, ctrl, newSequentialCounter(ctrl), nil, nil)
 
 	require.NotNil(t, controller)
 	assert.Equal(t, consumer.TopicKeyToBatch, controller.TopicKey())
@@ -83,7 +77,7 @@ func TestNewController(t *testing.T) {
 func TestController_Process_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	controller := newTestController(t, ctrl, newSequentialCounter(), nil, nil)
+	controller := newTestController(t, ctrl, newSequentialCounter(ctrl), nil, nil)
 
 	request := entity.Request{
 		ID:           "test-queue/123",
@@ -109,7 +103,7 @@ func TestController_Process_Success(t *testing.T) {
 func TestController_Process_InvalidJSON(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	controller := newTestController(t, ctrl, newSequentialCounter(), nil, nil)
+	controller := newTestController(t, ctrl, newSequentialCounter(ctrl), nil, nil)
 
 	invalidPayload := []byte(`{"invalid": json"}`)
 	msg := queue.NewMessage("invalid-msg", invalidPayload, "partition1", nil)
@@ -126,7 +120,7 @@ func TestController_Process_InvalidJSON(t *testing.T) {
 func TestController_Process_PublishFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	controller := newTestController(t, ctrl, newSequentialCounter(), nil, fmt.Errorf("publish failed"))
+	controller := newTestController(t, ctrl, newSequentialCounter(ctrl), nil, fmt.Errorf("publish failed"))
 
 	request := entity.Request{
 		ID:           "test-queue/123",
@@ -152,11 +146,8 @@ func TestController_Process_PublishFailure(t *testing.T) {
 func TestController_Process_CounterFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	cnt := &mockCounter{
-		nextFunc: func(ctx context.Context, domain string) (int64, error) {
-			return 0, fmt.Errorf("counter unavailable")
-		},
-	}
+	cnt := countermock.NewMockCounter(ctrl)
+	cnt.EXPECT().Next(gomock.Any(), gomock.Any()).Return(int64(0), fmt.Errorf("counter unavailable"))
 	controller := newTestController(t, ctrl, cnt, nil, nil)
 
 	request := entity.Request{
@@ -205,7 +196,7 @@ func TestController_Process_WithDependencies(t *testing.T) {
 	mockStorage.EXPECT().GetBatchStore().Return(mockBatchStore).AnyTimes()
 	mockStorage.EXPECT().GetBatchDependentStore().Return(mockBatchDependentStore).AnyTimes()
 
-	controller := newTestController(t, ctrl, newSequentialCounter(), mockStorage, nil)
+	controller := newTestController(t, ctrl, newSequentialCounter(ctrl), mockStorage, nil)
 
 	request := entity.Request{
 		ID:           "test-queue/456",
@@ -230,7 +221,7 @@ func TestController_Process_WithDependencies(t *testing.T) {
 
 func TestController_InterfaceImplementation(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	controller := newTestController(t, ctrl, newSequentialCounter(), nil, nil)
+	controller := newTestController(t, ctrl, newSequentialCounter(ctrl), nil, nil)
 
 	var _ consumer.Controller = controller
 }


### PR DESCRIPTION
## Summary
feat(test) Add gomock-generated mock for counter.Counter, replacing hand-written test mocks

## What? 
Replace hand-written mockCounter structs in land_test.go and batch_test.go with a gomock-generated mock. The mocks are generated at build time — no generated .go files are checked in.

## Why? 
This eliminates hand wriiten mocks which helps keeps mocks in sync due to any changes in the interface.

## Test Plan


## Issues
https://github.com/uber/submitqueue/issues/93
