### PR TITLE
feat(storage) Add upsert functionality for batch and batch dependent store

### DIFF
--- a/extension/storage/batch_dependent_store.go
+++ b/extension/storage/batch_dependent_store.go
@@ -21,4 +21,10 @@ type BatchDependentStore interface {
 	// UpdateDependents updates the dependents of a batch dependent if the current version matches the expected version.
 	// If versions do not match, returns ErrVersionMismatch.
 	UpdateDependents(ctx context.Context, batchID string, version int32, dependents []string) error
+
+	// Upsert creates or updates a batch dependent. If the batch dependent does not exist, it is inserted
+	// with the provided version. If the batch dependent already exists and the current version matches the
+	// expected version, all fields are overwritten and the version is incremented by 1.
+	// If versions do not match, returns ErrVersionMismatch.
+	Upsert(ctx context.Context, batchDependent entity.BatchDependent) error
 }

--- a/extension/storage/batch_store.go
+++ b/extension/storage/batch_store.go
@@ -23,4 +23,9 @@ type BatchStore interface {
 
 	// GetByQueueAndStates retrieves all batches that belong to the given queue and are in the given states.
 	GetByQueueAndStates(ctx context.Context, queue string, states []entity.BatchState) ([]entity.Batch, error)
+
+	// Upsert creates or updates a batch. If the batch does not exist, it is inserted with the provided version.
+	// If the batch already exists and the current version matches the expected version, all fields are overwritten
+	// and the version is incremented by 1. If versions do not match, returns ErrVersionMismatch.
+	Upsert(ctx context.Context, batch entity.Batch) error
 }

--- a/extension/storage/mysql/batch_dependent_store.go
+++ b/extension/storage/mysql/batch_dependent_store.go
@@ -68,6 +68,57 @@ func (s *batchDependentStore) Create(ctx context.Context, batchDependent entity.
 	return nil
 }
 
+// Upsert creates or updates a batch dependent. If the batch dependent does not exist, it is inserted
+// with the provided version. If the batch dependent already exists and the current version matches the
+// expected version, all fields are overwritten and the version is incremented by 1.
+// If versions do not match, returns ErrVersionMismatch.
+func (s *batchDependentStore) Upsert(ctx context.Context, batchDependent entity.BatchDependent) error {
+	dependentsJSON, err := json.Marshal(batchDependent.Dependents)
+	if err != nil {
+		return fmt.Errorf("failed to marshal dependents batchID=%s for Upsert batch dependent entity: %w", batchDependent.BatchID, err)
+	}
+
+	// Try insert first.
+	_, err = s.db.ExecContext(ctx,
+		"INSERT INTO batch_dependent (batch_id, dependents, version) VALUES (?, ?, ?)",
+		batchDependent.BatchID, dependentsJSON, batchDependent.Version,
+	)
+	if err == nil {
+		return nil
+	}
+
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) || mysqlErr.Number != 1062 {
+		return fmt.Errorf("failed to upsert batch dependent entity batchID=%s: %w", batchDependent.BatchID, err)
+	}
+
+	// Row already exists; update only if the version matches.
+	result, err := s.db.ExecContext(ctx,
+		"UPDATE batch_dependent SET dependents = ?, version = version + 1 WHERE batch_id = ? AND version = ?",
+		dependentsJSON, batchDependent.BatchID, batchDependent.Version,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to upsert batch dependent entity batchID=%s: %w", batchDependent.BatchID, err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf(
+			"failed to get rows affected from upsert for batchID=%q version=%d: %w",
+			batchDependent.BatchID, batchDependent.Version, err,
+		)
+	}
+
+	if rowsAffected != 1 {
+		return fmt.Errorf(
+			"version mismatch for batch dependent upsert: batchID=%q expected_version=%d: %w",
+			batchDependent.BatchID, batchDependent.Version, storage.ErrVersionMismatch,
+		)
+	}
+
+	return nil
+}
+
 // UpdateDependents updates the dependents of a batch dependent if the current version matches the expected version.
 // If versions do not match, returns ErrVersionMismatch.
 // The implementation increments the version by 1 atomically with the dependents update.

--- a/extension/storage/mysql/batch_store.go
+++ b/extension/storage/mysql/batch_store.go
@@ -111,6 +111,61 @@ func (s *batchStore) UpdateState(ctx context.Context, id string, version int32, 
 	return nil
 }
 
+// Upsert creates or updates a batch. If the batch does not exist, it is inserted with the provided version.
+// If the batch already exists and the current version matches the expected version, all fields are overwritten
+// and the version is incremented by 1. If versions do not match, returns ErrVersionMismatch.
+func (s *batchStore) Upsert(ctx context.Context, batch entity.Batch) error {
+	containsJSON, err := json.Marshal(batch.Contains)
+	if err != nil {
+		return fmt.Errorf("failed to marshal contains=%v id=%s for Upsert batch entity: %w", batch.Contains, batch.ID, err)
+	}
+
+	dependenciesJSON, err := json.Marshal(batch.Dependencies)
+	if err != nil {
+		return fmt.Errorf("failed to marshal dependencies=%v id=%s for Upsert batch entity: %w", batch.Dependencies, batch.ID, err)
+	}
+
+	// Try insert first.
+	_, err = s.db.ExecContext(ctx,
+		"INSERT INTO batch (id, queue, contains, dependencies, state, version) VALUES (?, ?, ?, ?, ?, ?)",
+		batch.ID, batch.Queue, containsJSON, dependenciesJSON, batch.State, batch.Version,
+	)
+	if err == nil {
+		return nil
+	}
+
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) || mysqlErr.Number != 1062 {
+		return fmt.Errorf("failed to upsert batch entity id=%s: %w", batch.ID, err)
+	}
+
+	// Row already exists; update only if the version matches.
+	result, err := s.db.ExecContext(ctx,
+		"UPDATE batch SET queue = ?, contains = ?, dependencies = ?, state = ?, version = version + 1 WHERE id = ? AND version = ?",
+		batch.Queue, containsJSON, dependenciesJSON, batch.State, batch.ID, batch.Version,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to upsert batch entity id=%s: %w", batch.ID, err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf(
+			"failed to get rows affected from upsert for id=%q version=%d: %w",
+			batch.ID, batch.Version, err,
+		)
+	}
+
+	if rowsAffected != 1 {
+		return fmt.Errorf(
+			"version mismatch for batch upsert: id=%q expected_version=%d: %w",
+			batch.ID, batch.Version, storage.ErrVersionMismatch,
+		)
+	}
+
+	return nil
+}
+
 // GetByQueueAndStates retrieves all batches that belong to the given queue and are in the given states.
 func (s *batchStore) GetByQueueAndStates(ctx context.Context, queue string, states []entity.BatchState) ([]entity.Batch, error) {
 	if len(states) == 0 {


### PR DESCRIPTION
## Summary
feat(storage) Add upsert functionality for batch and batch dependent store

## What?
New method to the batch store and batch dependent store interfaces for encapsulating Upsert functionality.

## Why?
Batch manager will require to upsert the state of a batch and batch dependent.
* For batch - In the event of a failure in batch manager after an insert into the batch store; reprocessing of the request should trigger an overwrite.
* For batch dependent - Any new incoming requests can alter the dependents for existing batches.

## Test Plan


## Issues

