### PR TITLE
refactor(metrics): route all controllers through core/metrics helpers

### DIFF
--- a/core/consumer/BUILD.bazel
+++ b/core/consumer/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/errs",
+        "//core/metrics",
         "//entity/queue",
         "//extension/queue",
         "@com_github_uber_go_tally_v4//:tally",

--- a/core/consumer/consumer.go
+++ b/core/consumer/consumer.go
@@ -330,8 +330,10 @@ func (m *consumer) processPartition(ctx context.Context, controller Controller, 
 
 // processDelivery calls the controller and performs ack/nack based on the result.
 func (m *consumer) processDelivery(ctx context.Context, controller Controller, delivery queue.Delivery, controllerScope tally.Scope) {
+	const opName = "process"
+
 	start := time.Now()
-	metrics.NamedCounter(controllerScope, "process", "messages_received", 1)
+	metrics.NamedCounter(controllerScope, opName, "messages_received", 1)
 
 	msg := delivery.Message()
 	topicKey := controller.TopicKey()
@@ -365,7 +367,7 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 		}
 	}
 
-	metrics.NamedTimer(controllerScope, "process", "controller_latency", elapsed, metrics.NewTag("success", successTag))
+	metrics.NamedTimer(controllerScope, opName, "controller_latency", elapsed, metrics.NewTag("success", successTag))
 
 	if err != nil {
 		// Check if the error is non-retryable (poison pill message)
@@ -380,7 +382,7 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 				"elapsed_ms", elapsed.Milliseconds(),
 			)
 
-			metrics.NamedCounter(controllerScope, "process", "non_retryable_errors", 1)
+			metrics.NamedCounter(controllerScope, opName, "non_retryable_errors", 1)
 
 			// Reject moves to DLQ (or acks if DLQ disabled)
 			if rejectErr := delivery.Reject(ctx, err.Error()); rejectErr != nil {
@@ -390,7 +392,7 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 					"message_id", msg.ID,
 					"error", rejectErr,
 				)
-				metrics.NamedCounter(controllerScope, "process", "reject_errors", 1)
+				metrics.NamedCounter(controllerScope, opName, "reject_errors", 1)
 			}
 			return
 		}
@@ -412,7 +414,7 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 			"elapsed_ms", elapsed.Milliseconds(),
 		)
 
-		metrics.NamedCounter(controllerScope, "process", "controller_errors", 1)
+		metrics.NamedCounter(controllerScope, opName, "controller_errors", 1)
 
 		// Nack with no delay - let visibility timeout handle retry delay
 		nackStart := time.Now()
@@ -423,10 +425,10 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 				"message_id", msg.ID,
 				"error", nackErr,
 			)
-			metrics.NamedCounter(controllerScope, "process", "nack_errors", 1)
+			metrics.NamedCounter(controllerScope, opName, "nack_errors", 1)
 		} else {
-			metrics.NamedCounter(controllerScope, "process", "nack_count", 1)
-			metrics.NamedTimer(controllerScope, "process", "ack_nack_latency", time.Since(nackStart),
+			metrics.NamedCounter(controllerScope, opName, "nack_count", 1)
+			metrics.NamedTimer(controllerScope, opName, "ack_nack_latency", time.Since(nackStart),
 				metrics.NewTag("operation", "nack"),
 				metrics.NewTag("success", "true"),
 			)
@@ -443,17 +445,17 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 			"message_id", msg.ID,
 			"error", ackErr,
 		)
-		metrics.NamedCounter(controllerScope, "process", "ack_errors", 1)
-		metrics.NamedTimer(controllerScope, "process", "ack_nack_latency", time.Since(ackStart),
+		metrics.NamedCounter(controllerScope, opName, "ack_errors", 1)
+		metrics.NamedTimer(controllerScope, opName, "ack_nack_latency", time.Since(ackStart),
 			metrics.NewTag("operation", "ack"),
 			metrics.NewTag("success", "false"),
 		)
 		return
 	}
 
-	metrics.NamedCounter(controllerScope, "process", "messages_processed", 1)
-	metrics.NamedCounter(controllerScope, "process", "ack_count", 1)
-	metrics.NamedTimer(controllerScope, "process", "ack_nack_latency", time.Since(ackStart),
+	metrics.NamedCounter(controllerScope, opName, "messages_processed", 1)
+	metrics.NamedCounter(controllerScope, opName, "ack_count", 1)
+	metrics.NamedTimer(controllerScope, opName, "ack_nack_latency", time.Since(ackStart),
 		metrics.NewTag("operation", "ack"),
 		metrics.NewTag("success", "true"),
 	)

--- a/core/consumer/consumer.go
+++ b/core/consumer/consumer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/core/errs"
+	"github.com/uber/submitqueue/core/metrics"
 	"github.com/uber/submitqueue/extension/queue"
 	"go.uber.org/zap"
 )
@@ -330,7 +331,7 @@ func (m *consumer) processPartition(ctx context.Context, controller Controller, 
 // processDelivery calls the controller and performs ack/nack based on the result.
 func (m *consumer) processDelivery(ctx context.Context, controller Controller, delivery queue.Delivery, controllerScope tally.Scope) {
 	start := time.Now()
-	controllerScope.Counter("messages_received").Inc(1)
+	metrics.NamedCounter(controllerScope, "process", "messages_received", 1)
 
 	msg := delivery.Message()
 	topicKey := controller.TopicKey()
@@ -364,10 +365,7 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 		}
 	}
 
-	latencyScope := controllerScope.Tagged(map[string]string{
-		"success": successTag,
-	})
-	latencyScope.Timer("controller_latency").Record(elapsed)
+	metrics.NamedTimer(controllerScope, "process", "controller_latency", elapsed, metrics.NewTag("success", successTag))
 
 	if err != nil {
 		// Check if the error is non-retryable (poison pill message)
@@ -382,7 +380,7 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 				"elapsed_ms", elapsed.Milliseconds(),
 			)
 
-			controllerScope.Counter("non_retryable_errors").Inc(1)
+			metrics.NamedCounter(controllerScope, "process", "non_retryable_errors", 1)
 
 			// Reject moves to DLQ (or acks if DLQ disabled)
 			if rejectErr := delivery.Reject(ctx, err.Error()); rejectErr != nil {
@@ -392,7 +390,7 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 					"message_id", msg.ID,
 					"error", rejectErr,
 				)
-				controllerScope.Counter("reject_errors").Inc(1)
+				metrics.NamedCounter(controllerScope, "process", "reject_errors", 1)
 			}
 			return
 		}
@@ -414,7 +412,7 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 			"elapsed_ms", elapsed.Milliseconds(),
 		)
 
-		controllerScope.Counter("controller_errors").Inc(1)
+		metrics.NamedCounter(controllerScope, "process", "controller_errors", 1)
 
 		// Nack with no delay - let visibility timeout handle retry delay
 		nackStart := time.Now()
@@ -425,14 +423,13 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 				"message_id", msg.ID,
 				"error", nackErr,
 			)
-			controllerScope.Counter("nack_errors").Inc(1)
+			metrics.NamedCounter(controllerScope, "process", "nack_errors", 1)
 		} else {
-			controllerScope.Counter("nack_count").Inc(1)
-			nackScope := controllerScope.Tagged(map[string]string{
-				"operation": "nack",
-				"success":   "true",
-			})
-			nackScope.Timer("ack_nack_latency").Record(time.Since(nackStart))
+			metrics.NamedCounter(controllerScope, "process", "nack_count", 1)
+			metrics.NamedTimer(controllerScope, "process", "ack_nack_latency", time.Since(nackStart),
+				metrics.NewTag("operation", "nack"),
+				metrics.NewTag("success", "true"),
+			)
 		}
 		return
 	}
@@ -446,23 +443,20 @@ func (m *consumer) processDelivery(ctx context.Context, controller Controller, d
 			"message_id", msg.ID,
 			"error", ackErr,
 		)
-		controllerScope.Counter("ack_errors").Inc(1)
-		ackScope := controllerScope.Tagged(map[string]string{
-			"operation": "ack",
-			"success":   "false",
-		})
-		ackScope.Timer("ack_nack_latency").Record(time.Since(ackStart))
+		metrics.NamedCounter(controllerScope, "process", "ack_errors", 1)
+		metrics.NamedTimer(controllerScope, "process", "ack_nack_latency", time.Since(ackStart),
+			metrics.NewTag("operation", "ack"),
+			metrics.NewTag("success", "false"),
+		)
 		return
 	}
 
-	controllerScope.Counter("messages_processed").Inc(1)
-	controllerScope.Counter("ack_count").Inc(1)
-
-	ackScope := controllerScope.Tagged(map[string]string{
-		"operation": "ack",
-		"success":   "true",
-	})
-	ackScope.Timer("ack_nack_latency").Record(time.Since(ackStart))
+	metrics.NamedCounter(controllerScope, "process", "messages_processed", 1)
+	metrics.NamedCounter(controllerScope, "process", "ack_count", 1)
+	metrics.NamedTimer(controllerScope, "process", "ack_nack_latency", time.Since(ackStart),
+		metrics.NewTag("operation", "ack"),
+		metrics.NewTag("success", "true"),
+	)
 
 	m.logger.Debugw("message processed successfully",
 		"controller", controller.Name(),

--- a/extension/mergechecker/github/BUILD.bazel
+++ b/extension/mergechecker/github/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/uber/submitqueue/extension/mergechecker/github",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/metrics",
         "//entity",
         "//entity/github",
         "//extension/mergechecker",

--- a/extension/mergechecker/github/checker.go
+++ b/extension/mergechecker/github/checker.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/uber-go/tally/v4"
+	"github.com/uber/submitqueue/core/metrics"
 	"github.com/uber/submitqueue/entity"
 	entitygithub "github.com/uber/submitqueue/entity/github"
 	"github.com/uber/submitqueue/extension/mergechecker"
@@ -60,17 +61,17 @@ func NewMergeChecker(params Params) mergechecker.MergeChecker {
 }
 
 // Check assesses whether a change can merge cleanly using the GitHub GraphQL API.
-func (c *mergeChecker) Check(ctx context.Context, queue string, change entity.Change) (mergechecker.Result, error) {
-	c.metricsScope.Counter("check_started").Inc(1)
+func (c *mergeChecker) Check(ctx context.Context, queue string, change entity.Change) (result mergechecker.Result, retErr error) {
+	op := metrics.Begin(c.metricsScope, "check")
+	defer func() { op.Complete(retErr) }()
 
-	result := mergechecker.Result{}
 	// Parse all change IDs
 	// TODO: classify parse errors as user errors (non-retryable) vs system errors.
 	changeIDs := make([]entitygithub.ChangeID, 0, len(change.URIs))
 	for _, rawID := range change.URIs {
 		cid, err := entitygithub.ParseChangeID(rawID)
 		if err != nil {
-			c.metricsScope.Counter("parse_errors").Inc(1)
+			metrics.NamedCounter(c.metricsScope, "check", "parse_errors", 1)
 			return result, fmt.Errorf("failed to parse change ID %q: %w", rawID, err)
 		}
 		changeIDs = append(changeIDs, cid)
@@ -79,26 +80,26 @@ func (c *mergeChecker) Check(ctx context.Context, queue string, change entity.Ch
 	// Fetch PR info from GitHub GraphQL API
 	prInfoMap, err := c.fetchPRInfo(ctx, changeIDs)
 	if err != nil {
-		c.metricsScope.Counter("graphql_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "check", "graphql_errors", 1)
 		return result, fmt.Errorf("failed to fetch PR info: %w", err)
 	}
 
 	// Validate PR mergeability
 	mergeable, reason, err := validatePRs(changeIDs, prInfoMap)
 	if err != nil {
-		c.metricsScope.Counter("validation_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "check", "validation_errors", 1)
 		return result, err
 	}
 
 	if !mergeable {
-		c.metricsScope.Counter("not_mergeable").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "check", "not_mergeable", 1)
 		c.logger.Infow("change not mergeable",
 			"queue", queue,
 			"reason", reason,
 			"change_uris", change.URIs,
 		)
 	} else {
-		c.metricsScope.Counter("mergeable").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "check", "mergeable", 1)
 	}
 
 	result.Mergeable = mergeable

--- a/extension/mergechecker/github/checker.go
+++ b/extension/mergechecker/github/checker.go
@@ -62,7 +62,9 @@ func NewMergeChecker(params Params) mergechecker.MergeChecker {
 
 // Check assesses whether a change can merge cleanly using the GitHub GraphQL API.
 func (c *mergeChecker) Check(ctx context.Context, queue string, change entity.Change) (result mergechecker.Result, retErr error) {
-	op := metrics.Begin(c.metricsScope, "check")
+	const opName = "check"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	// Parse all change IDs
@@ -71,7 +73,7 @@ func (c *mergeChecker) Check(ctx context.Context, queue string, change entity.Ch
 	for _, rawID := range change.URIs {
 		cid, err := entitygithub.ParseChangeID(rawID)
 		if err != nil {
-			metrics.NamedCounter(c.metricsScope, "check", "parse_errors", 1)
+			metrics.NamedCounter(c.metricsScope, opName, "parse_errors", 1)
 			return result, fmt.Errorf("failed to parse change ID %q: %w", rawID, err)
 		}
 		changeIDs = append(changeIDs, cid)
@@ -80,26 +82,26 @@ func (c *mergeChecker) Check(ctx context.Context, queue string, change entity.Ch
 	// Fetch PR info from GitHub GraphQL API
 	prInfoMap, err := c.fetchPRInfo(ctx, changeIDs)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "check", "graphql_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "graphql_errors", 1)
 		return result, fmt.Errorf("failed to fetch PR info: %w", err)
 	}
 
 	// Validate PR mergeability
 	mergeable, reason, err := validatePRs(changeIDs, prInfoMap)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "check", "validation_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "validation_errors", 1)
 		return result, err
 	}
 
 	if !mergeable {
-		metrics.NamedCounter(c.metricsScope, "check", "not_mergeable", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "not_mergeable", 1)
 		c.logger.Infow("change not mergeable",
 			"queue", queue,
 			"reason", reason,
 			"change_uris", change.URIs,
 		)
 	} else {
-		metrics.NamedCounter(c.metricsScope, "check", "mergeable", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "mergeable", 1)
 	}
 
 	result.Mergeable = mergeable

--- a/gateway/controller/BUILD.bazel
+++ b/gateway/controller/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//core/consumer",
         "//core/errs",
+        "//core/metrics",
         "//entity",
         "//entity/queue",
         "//extension/counter",

--- a/gateway/controller/land.go
+++ b/gateway/controller/land.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/core/consumer"
 	"github.com/uber/submitqueue/core/errs"
+	"github.com/uber/submitqueue/core/metrics"
 	"github.com/uber/submitqueue/entity"
 	"github.com/uber/submitqueue/entity/queue"
 	"github.com/uber/submitqueue/extension/counter"
@@ -55,7 +55,7 @@ type LandController struct {
 func NewLandController(logger *zap.SugaredLogger, scope tally.Scope, counter counter.Counter, requestLogStore storage.RequestLogStore, registry consumer.TopicRegistry) *LandController {
 	return &LandController{
 		logger:          logger,
-		metricsScope:    scope,
+		metricsScope:    scope.SubScope("land_controller"),
 		counter:         counter,
 		requestLogStore: requestLogStore,
 		registry:        registry,
@@ -63,13 +63,9 @@ func NewLandController(logger *zap.SugaredLogger, scope tally.Scope, counter cou
 }
 
 // Land handles the land request and returns a response
-func (c *LandController) Land(ctx context.Context, req *pb.LandRequest) (*pb.LandResponse, error) {
-	start := time.Now()
-	defer func() {
-		c.metricsScope.Timer("land_request_latency").Record(time.Since(start))
-	}()
-
-	c.metricsScope.Counter("land_request_count").Inc(1)
+func (c *LandController) Land(ctx context.Context, req *pb.LandRequest) (resp *pb.LandResponse, retErr error) {
+	op := metrics.Begin(c.metricsScope, "land")
+	defer func() { op.Complete(retErr) }()
 
 	// Validate required fields.
 	if req.Queue == "" {
@@ -131,7 +127,7 @@ func (c *LandController) Land(ctx context.Context, req *pb.LandRequest) (*pb.Lan
 		"sqid", landRequest.ID,
 		"topic_key", consumer.TopicKeyStart,
 	)
-	c.metricsScope.Counter("publish_success").Inc(1)
+	metrics.NamedCounter(c.metricsScope, "land", "publish_success", 1)
 
 	return &pb.LandResponse{
 		Sqid: landRequest.ID,

--- a/gateway/controller/land.go
+++ b/gateway/controller/land.go
@@ -64,7 +64,9 @@ func NewLandController(logger *zap.SugaredLogger, scope tally.Scope, counter cou
 
 // Land handles the land request and returns a response
 func (c *LandController) Land(ctx context.Context, req *pb.LandRequest) (resp *pb.LandResponse, retErr error) {
-	op := metrics.Begin(c.metricsScope, "land")
+	const opName = "land"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	// Validate required fields.
@@ -127,7 +129,7 @@ func (c *LandController) Land(ctx context.Context, req *pb.LandRequest) (resp *p
 		"sqid", landRequest.ID,
 		"topic_key", consumer.TopicKeyStart,
 	)
-	metrics.NamedCounter(c.metricsScope, "land", "publish_success", 1)
+	metrics.NamedCounter(c.metricsScope, opName, "publish_success", 1)
 
 	return &pb.LandResponse{
 		Sqid: landRequest.ID,

--- a/orchestrator/controller/BUILD.bazel
+++ b/orchestrator/controller/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/uber/submitqueue/orchestrator/controller",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/metrics",
         "//orchestrator/protopb",
         "@com_github_uber_go_tally_v4//:tally",
         "@org_uber_go_zap//:zap",

--- a/orchestrator/controller/batch/BUILD.bazel
+++ b/orchestrator/controller/batch/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/consumer",
+        "//core/metrics",
         "//entity",
         "//entity/queue",
         "//extension/conflict",

--- a/orchestrator/controller/batch/batch.go
+++ b/orchestrator/controller/batch/batch.go
@@ -73,7 +73,9 @@ func NewController(
 // Deserializes the request, groups into batch, and publishes to the score topic.
 // Returns nil to ack (success), or error to nack (retry).
 func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
-	op := metrics.Begin(c.metricsScope, "process")
+	const opName = "process"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
@@ -81,14 +83,14 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Deserialize request ID from payload
 	rid, err := entity.RequestIDFromBytes(msg.Payload)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "deserialize_errors", 1)
 		return fmt.Errorf("failed to deserialize request ID: %w", err)
 	}
 
 	// Fetch request from storage
 	request, err := c.store.GetRequestStore().Get(ctx, rid.ID)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to get request %s: %w", rid.ID, err)
 	}
 
@@ -106,7 +108,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Generate a globally unique batch ID.
 	seq, err := c.counter.Next(ctx, "batch/"+request.Queue)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "counter_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "counter_errors", 1)
 		return fmt.Errorf("failed to generate batch ID for queue=%s: %w", request.Queue, err)
 	}
 
@@ -127,7 +129,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 		entity.BatchStateMerging,
 	})
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "batch_store_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "batch_store_errors", 1)
 		return fmt.Errorf("failed to get active batches for queue=%s: %w", request.Queue, err)
 	}
 
@@ -136,7 +138,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// apply; the dependency graph only tracks the relation.
 	conflicts, err := c.analyzer.Analyze(ctx, batch, activeBatches)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "conflict_analyzer_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "conflict_analyzer_errors", 1)
 		return fmt.Errorf("failed to analyze conflicts for batchID=%s: %w", batch.ID, err)
 	}
 
@@ -157,7 +159,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	for _, depID := range conflictingIDs {
 		existing, err := c.store.GetBatchDependentStore().Get(ctx, depID)
 		if err != nil {
-			metrics.NamedCounter(c.metricsScope, "process", "batch_dependent_store_errors", 1)
+			metrics.NamedCounter(c.metricsScope, opName, "batch_dependent_store_errors", 1)
 			return fmt.Errorf("failed to get batch dependent for batchID=%s: %w", depID, err)
 		}
 
@@ -165,7 +167,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 
 		newVersion := existing.Version + 1
 		if err := c.store.GetBatchDependentStore().UpdateDependents(ctx, depID, existing.Version, newVersion, dependents); err != nil {
-			metrics.NamedCounter(c.metricsScope, "process", "batch_dependent_store_errors", 1)
+			metrics.NamedCounter(c.metricsScope, opName, "batch_dependent_store_errors", 1)
 			return fmt.Errorf("failed to update batch dependent index for existing batchID=%s and new batchID=%s: %w", depID, batch.ID, err)
 		}
 	}
@@ -178,7 +180,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	}
 
 	if err := c.store.GetBatchDependentStore().Create(ctx, bd); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "batch_dependent_store_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "batch_dependent_store_errors", 1)
 		return fmt.Errorf("failed to create batch dependent index for new batchID=%s: %w", batch.ID, err)
 	}
 
@@ -186,7 +188,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// This is the final operation that concludes the batch creation process. If it fails, BatchDependents will be pointing to a batch id that does not exist.
 	// We do not reuse batch ids, a retry of this operation will create a new batch with a new ID. The downstream logic that operates on BatchDependent should be able to handle stale entries.
 	if err := c.store.GetBatchStore().Create(ctx, batch); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "batch_store_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "batch_store_errors", 1)
 		return fmt.Errorf("failed to create batch in batch store: %w", err)
 	}
 
@@ -201,7 +203,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// If it fails and the controller retries, a new batch will be created with the new batch ID but the same request ID.
 	// The downstream logic should be able to handle stale entries by looking at the state of the batch.
 	if err := c.publish(ctx, consumer.TopicKeyScore, batch.ID, batch.Queue); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish batch ID to score topic: %w", err)
 	}
 

--- a/orchestrator/controller/batch/batch.go
+++ b/orchestrator/controller/batch/batch.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/core/consumer"
+	"github.com/uber/submitqueue/core/metrics"
 	"github.com/uber/submitqueue/entity"
 	entityqueue "github.com/uber/submitqueue/entity/queue"
 	"github.com/uber/submitqueue/extension/conflict"
@@ -71,22 +72,23 @@ func NewController(
 // Process processes a batch delivery from the queue.
 // Deserializes the request, groups into batch, and publishes to the score topic.
 // Returns nil to ack (success), or error to nack (retry).
-func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) error {
-	c.metricsScope.Counter("received").Inc(1)
+func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
+	op := metrics.Begin(c.metricsScope, "process")
+	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
 
 	// Deserialize request ID from payload
 	rid, err := entity.RequestIDFromBytes(msg.Payload)
 	if err != nil {
-		c.metricsScope.Counter("deserialize_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
 		return fmt.Errorf("failed to deserialize request ID: %w", err)
 	}
 
 	// Fetch request from storage
 	request, err := c.store.GetRequestStore().Get(ctx, rid.ID)
 	if err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to get request %s: %w", rid.ID, err)
 	}
 
@@ -104,7 +106,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	// Generate a globally unique batch ID.
 	seq, err := c.counter.Next(ctx, "batch/"+request.Queue)
 	if err != nil {
-		c.metricsScope.Counter("counter_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "counter_errors", 1)
 		return fmt.Errorf("failed to generate batch ID for queue=%s: %w", request.Queue, err)
 	}
 
@@ -125,7 +127,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 		entity.BatchStateMerging,
 	})
 	if err != nil {
-		c.metricsScope.Counter("batch_store_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "batch_store_errors", 1)
 		return fmt.Errorf("failed to get active batches for queue=%s: %w", request.Queue, err)
 	}
 
@@ -134,7 +136,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	// apply; the dependency graph only tracks the relation.
 	conflicts, err := c.analyzer.Analyze(ctx, batch, activeBatches)
 	if err != nil {
-		c.metricsScope.Counter("conflict_analyzer_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "conflict_analyzer_errors", 1)
 		return fmt.Errorf("failed to analyze conflicts for batchID=%s: %w", batch.ID, err)
 	}
 
@@ -155,7 +157,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	for _, depID := range conflictingIDs {
 		existing, err := c.store.GetBatchDependentStore().Get(ctx, depID)
 		if err != nil {
-			c.metricsScope.Counter("batch_dependent_store_errors").Inc(1)
+			metrics.NamedCounter(c.metricsScope, "process", "batch_dependent_store_errors", 1)
 			return fmt.Errorf("failed to get batch dependent for batchID=%s: %w", depID, err)
 		}
 
@@ -163,7 +165,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 
 		newVersion := existing.Version + 1
 		if err := c.store.GetBatchDependentStore().UpdateDependents(ctx, depID, existing.Version, newVersion, dependents); err != nil {
-			c.metricsScope.Counter("batch_dependent_store_errors").Inc(1)
+			metrics.NamedCounter(c.metricsScope, "process", "batch_dependent_store_errors", 1)
 			return fmt.Errorf("failed to update batch dependent index for existing batchID=%s and new batchID=%s: %w", depID, batch.ID, err)
 		}
 	}
@@ -176,7 +178,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	}
 
 	if err := c.store.GetBatchDependentStore().Create(ctx, bd); err != nil {
-		c.metricsScope.Counter("batch_dependent_store_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "batch_dependent_store_errors", 1)
 		return fmt.Errorf("failed to create batch dependent index for new batchID=%s: %w", batch.ID, err)
 	}
 
@@ -184,7 +186,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	// This is the final operation that concludes the batch creation process. If it fails, BatchDependents will be pointing to a batch id that does not exist.
 	// We do not reuse batch ids, a retry of this operation will create a new batch with a new ID. The downstream logic that operates on BatchDependent should be able to handle stale entries.
 	if err := c.store.GetBatchStore().Create(ctx, batch); err != nil {
-		c.metricsScope.Counter("batch_store_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "batch_store_errors", 1)
 		return fmt.Errorf("failed to create batch in batch store: %w", err)
 	}
 
@@ -199,7 +201,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	// If it fails and the controller retries, a new batch will be created with the new batch ID but the same request ID.
 	// The downstream logic should be able to handle stale entries by looking at the state of the batch.
 	if err := c.publish(ctx, consumer.TopicKeyScore, batch.ID, batch.Queue); err != nil {
-		c.metricsScope.Counter("publish_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
 		return fmt.Errorf("failed to publish batch ID to score topic: %w", err)
 	}
 
@@ -207,8 +209,6 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 		"batch_id", batch.ID,
 		"topic_key", consumer.TopicKeyScore,
 	)
-
-	c.metricsScope.Counter("processed").Inc(1)
 
 	return nil // Success - message will be acked
 }

--- a/orchestrator/controller/build/BUILD.bazel
+++ b/orchestrator/controller/build/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/consumer",
+        "//core/metrics",
         "//entity",
         "//entity/queue",
         "//extension/storage",

--- a/orchestrator/controller/build/build.go
+++ b/orchestrator/controller/build/build.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/core/consumer"
+	"github.com/uber/submitqueue/core/metrics"
 	"github.com/uber/submitqueue/entity"
 	entityqueue "github.com/uber/submitqueue/entity/queue"
 	"github.com/uber/submitqueue/extension/storage"
@@ -63,22 +64,23 @@ func NewController(
 // Process processes a build delivery from the queue.
 // Deserializes the batch, triggers a build, and publishes a build entity to the build signal topic.
 // Returns nil to ack (success), or error to nack (retry).
-func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) error {
-	c.metricsScope.Counter("received").Inc(1)
+func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
+	op := metrics.Begin(c.metricsScope, "process")
+	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
 
 	// Deserialize batch ID from payload
 	bid, err := entity.BatchIDFromBytes(msg.Payload)
 	if err != nil {
-		c.metricsScope.Counter("deserialize_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
 		return fmt.Errorf("failed to deserialize batch ID: %w", err)
 	}
 
 	// Fetch batch from storage
 	batch, err := c.store.GetBatchStore().Get(ctx, bid.ID)
 	if err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to get batch %s: %w", bid.ID, err)
 	}
 
@@ -103,7 +105,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 
 	// Publish build to build signal topic
 	if err := c.publish(ctx, consumer.TopicKeyBuildSignal, build); err != nil {
-		c.metricsScope.Counter("publish_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
 		return fmt.Errorf("failed to publish to buildsignal: %w", err)
 	}
 
@@ -112,8 +114,6 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 		"build_id", build.ID,
 		"topic_key", consumer.TopicKeyBuildSignal,
 	)
-
-	c.metricsScope.Counter("processed").Inc(1)
 
 	return nil // Success - message will be acked
 }

--- a/orchestrator/controller/build/build.go
+++ b/orchestrator/controller/build/build.go
@@ -65,7 +65,9 @@ func NewController(
 // Deserializes the batch, triggers a build, and publishes a build entity to the build signal topic.
 // Returns nil to ack (success), or error to nack (retry).
 func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
-	op := metrics.Begin(c.metricsScope, "process")
+	const opName = "process"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
@@ -73,14 +75,14 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Deserialize batch ID from payload
 	bid, err := entity.BatchIDFromBytes(msg.Payload)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "deserialize_errors", 1)
 		return fmt.Errorf("failed to deserialize batch ID: %w", err)
 	}
 
 	// Fetch batch from storage
 	batch, err := c.store.GetBatchStore().Get(ctx, bid.ID)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to get batch %s: %w", bid.ID, err)
 	}
 
@@ -105,7 +107,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 
 	// Publish build to build signal topic
 	if err := c.publish(ctx, consumer.TopicKeyBuildSignal, build); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish to buildsignal: %w", err)
 	}
 

--- a/orchestrator/controller/buildsignal/BUILD.bazel
+++ b/orchestrator/controller/buildsignal/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/consumer",
+        "//core/metrics",
         "//entity",
         "//entity/queue",
         "//extension/storage",

--- a/orchestrator/controller/buildsignal/buildsignal.go
+++ b/orchestrator/controller/buildsignal/buildsignal.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/core/consumer"
+	"github.com/uber/submitqueue/core/metrics"
 	"github.com/uber/submitqueue/entity"
 	entityqueue "github.com/uber/submitqueue/entity/queue"
 	"github.com/uber/submitqueue/extension/storage"
@@ -63,15 +64,16 @@ func NewController(
 // Process processes a build signal delivery from the queue.
 // Deserializes the build and publishes a batch result to the speculate topic.
 // Returns nil to ack (success), or error to nack (retry).
-func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) error {
-	c.metricsScope.Counter("received").Inc(1)
+func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
+	op := metrics.Begin(c.metricsScope, "process")
+	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
 
 	// Deserialize build entity
 	build, err := entity.BuildFromBytes(msg.Payload)
 	if err != nil {
-		c.metricsScope.Counter("deserialize_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
 		// Non-retryable: malformed messages will never succeed regardless of retry count
 		return fmt.Errorf("failed to deserialize build: %w", err)
 	}
@@ -91,13 +93,13 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	// Fetch batch from storage to get the partition key (queue)
 	batch, err := c.store.GetBatchStore().Get(ctx, build.BatchID)
 	if err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to get batch %s: %w", build.BatchID, err)
 	}
 
 	// Publish batch to speculate topic
 	if err := c.publish(ctx, consumer.TopicKeySpeculate, batch.ID, batch.Queue); err != nil {
-		c.metricsScope.Counter("publish_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
 		return fmt.Errorf("failed to publish to speculate: %w", err)
 	}
 
@@ -106,8 +108,6 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 		"batch_id", batch.ID,
 		"topic_key", consumer.TopicKeySpeculate,
 	)
-
-	c.metricsScope.Counter("processed").Inc(1)
 
 	return nil // Success - message will be acked
 }

--- a/orchestrator/controller/buildsignal/buildsignal.go
+++ b/orchestrator/controller/buildsignal/buildsignal.go
@@ -65,7 +65,9 @@ func NewController(
 // Deserializes the build and publishes a batch result to the speculate topic.
 // Returns nil to ack (success), or error to nack (retry).
 func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
-	op := metrics.Begin(c.metricsScope, "process")
+	const opName = "process"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
@@ -73,7 +75,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Deserialize build entity
 	build, err := entity.BuildFromBytes(msg.Payload)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "deserialize_errors", 1)
 		// Non-retryable: malformed messages will never succeed regardless of retry count
 		return fmt.Errorf("failed to deserialize build: %w", err)
 	}
@@ -93,13 +95,13 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Fetch batch from storage to get the partition key (queue)
 	batch, err := c.store.GetBatchStore().Get(ctx, build.BatchID)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to get batch %s: %w", build.BatchID, err)
 	}
 
 	// Publish batch to speculate topic
 	if err := c.publish(ctx, consumer.TopicKeySpeculate, batch.ID, batch.Queue); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish to speculate: %w", err)
 	}
 

--- a/orchestrator/controller/log/BUILD.bazel
+++ b/orchestrator/controller/log/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/consumer",
+        "//core/metrics",
         "//entity",
         "//extension/storage",
         "@com_github_uber_go_tally_v4//:tally",

--- a/orchestrator/controller/log/log.go
+++ b/orchestrator/controller/log/log.go
@@ -61,7 +61,9 @@ func NewController(
 // Deserializes the request log entry and persists it to storage.
 // Returns nil to ack (success), or error to nack (retry).
 func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
-	op := metrics.Begin(c.metricsScope, "process")
+	const opName = "process"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
@@ -69,7 +71,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Deserialize request log entry
 	logEntry, err := entity.RequestLogFromBytes(msg.Payload)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "deserialize_errors", 1)
 		// Non-retryable: malformed messages will never succeed regardless of retry count
 		return fmt.Errorf("failed to deserialize request log: %w", err)
 	}
@@ -83,7 +85,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 
 	// Persist request log to storage
 	if err := c.store.GetRequestLogStore().Insert(ctx, logEntry); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to insert request log: %w", err)
 	}
 

--- a/orchestrator/controller/log/log.go
+++ b/orchestrator/controller/log/log.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/core/consumer"
+	"github.com/uber/submitqueue/core/metrics"
 	"github.com/uber/submitqueue/entity"
 	"github.com/uber/submitqueue/extension/storage"
 	"go.uber.org/zap"
@@ -59,15 +60,16 @@ func NewController(
 // Process processes a log delivery from the queue.
 // Deserializes the request log entry and persists it to storage.
 // Returns nil to ack (success), or error to nack (retry).
-func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) error {
-	c.metricsScope.Counter("received").Inc(1)
+func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
+	op := metrics.Begin(c.metricsScope, "process")
+	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
 
 	// Deserialize request log entry
 	logEntry, err := entity.RequestLogFromBytes(msg.Payload)
 	if err != nil {
-		c.metricsScope.Counter("deserialize_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
 		// Non-retryable: malformed messages will never succeed regardless of retry count
 		return fmt.Errorf("failed to deserialize request log: %w", err)
 	}
@@ -81,11 +83,9 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 
 	// Persist request log to storage
 	if err := c.store.GetRequestLogStore().Insert(ctx, logEntry); err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to insert request log: %w", err)
 	}
-
-	c.metricsScope.Counter("processed").Inc(1)
 
 	return nil // Success - message will be acked
 }

--- a/orchestrator/controller/ping.go
+++ b/orchestrator/controller/ping.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/uber-go/tally/v4"
+	"github.com/uber/submitqueue/core/metrics"
 	pb "github.com/uber/submitqueue/orchestrator/protopb"
 	"go.uber.org/zap"
 )
@@ -39,20 +40,16 @@ func NewPingController(logger *zap.Logger, scope tally.Scope) *PingController {
 }
 
 // Ping handles the ping request and returns a response
-func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (*pb.PingResponse, error) {
-	start := time.Now()
-	defer func() {
-		c.metricsScope.Timer("ping_latency").Record(time.Since(start))
-	}()
-
-	c.metricsScope.Counter("ping_requests_total").Inc(1)
+func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (resp *pb.PingResponse, retErr error) {
+	op := metrics.Begin(c.metricsScope, "ping")
+	defer func() { op.Complete(retErr) }()
 
 	message := "pong!"
 	isEcho := false
 	if req.Message != "" {
 		message = "echo: " + req.Message
 		isEcho = true
-		c.metricsScope.Counter("echo_requests_total").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "ping", "echo_requests", 1)
 	}
 
 	hostname, _ := os.Hostname()

--- a/orchestrator/controller/ping.go
+++ b/orchestrator/controller/ping.go
@@ -41,7 +41,9 @@ func NewPingController(logger *zap.Logger, scope tally.Scope) *PingController {
 
 // Ping handles the ping request and returns a response
 func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (resp *pb.PingResponse, retErr error) {
-	op := metrics.Begin(c.metricsScope, "ping")
+	const opName = "ping"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	message := "pong!"
@@ -49,7 +51,7 @@ func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (resp *p
 	if req.Message != "" {
 		message = "echo: " + req.Message
 		isEcho = true
-		metrics.NamedCounter(c.metricsScope, "ping", "echo_requests", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "echo_requests", 1)
 	}
 
 	hostname, _ := os.Hostname()

--- a/orchestrator/controller/score/BUILD.bazel
+++ b/orchestrator/controller/score/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/consumer",
+        "//core/metrics",
         "//core/request",
         "//entity",
         "//entity/queue",

--- a/orchestrator/controller/score/score.go
+++ b/orchestrator/controller/score/score.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/core/consumer"
+	"github.com/uber/submitqueue/core/metrics"
 	corerequest "github.com/uber/submitqueue/core/request"
 	"github.com/uber/submitqueue/entity"
 	entityqueue "github.com/uber/submitqueue/entity/queue"
@@ -71,22 +72,23 @@ func NewController(
 // persists the minimum score, publishes request log entries,
 // and publishes to the speculate topic.
 // Returns nil to ack (success), or error to nack (retry).
-func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) error {
-	c.metricsScope.Counter("received").Inc(1)
+func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
+	op := metrics.Begin(c.metricsScope, "process")
+	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
 
 	// Deserialize batch ID from payload
 	bid, err := entity.BatchIDFromBytes(msg.Payload)
 	if err != nil {
-		c.metricsScope.Counter("deserialize_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
 		return fmt.Errorf("failed to deserialize batch ID: %w", err)
 	}
 
 	// Fetch batch from storage
 	batch, err := c.store.GetBatchStore().Get(ctx, bid.ID)
 	if err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to get batch %s: %w", bid.ID, err)
 	}
 
@@ -102,14 +104,14 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	// Score each request's change and take the minimum (worst-case) as the batch score
 	batchScore, err := c.scoreBatch(ctx, batch)
 	if err != nil {
-		c.metricsScope.Counter("scorer_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "scorer_errors", 1)
 		return fmt.Errorf("failed to score batch %s: %w", batch.ID, err)
 	}
 
 	// Atomically update score and state to "scored" in the database
 	newVersion := batch.Version + 1
 	if err := c.store.GetBatchStore().UpdateScoreAndState(ctx, batch.ID, batch.Version, newVersion, batchScore, entity.BatchStateScored); err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to update score for batch %s: %w", batch.ID, err)
 	}
 	batch.Version = newVersion
@@ -124,13 +126,13 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 		"batch_id": batch.ID,
 		"score":    fmt.Sprintf("%.4f", batchScore),
 	}); err != nil {
-		c.metricsScope.Counter("request_log_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "request_log_errors", 1)
 		return fmt.Errorf("failed to publish request logs for batch %s: %w", batch.ID, err)
 	}
 
 	// Publish to speculate topic
 	if err := c.publish(ctx, consumer.TopicKeySpeculate, batch.ID, batch.Queue); err != nil {
-		c.metricsScope.Counter("publish_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
 		return fmt.Errorf("failed to publish to speculate: %w", err)
 	}
 
@@ -138,8 +140,6 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 		"batch_id", batch.ID,
 		"topic_key", consumer.TopicKeySpeculate,
 	)
-
-	c.metricsScope.Counter("processed").Inc(1)
 
 	return nil // Success - message will be acked
 }

--- a/orchestrator/controller/score/score.go
+++ b/orchestrator/controller/score/score.go
@@ -73,7 +73,9 @@ func NewController(
 // and publishes to the speculate topic.
 // Returns nil to ack (success), or error to nack (retry).
 func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
-	op := metrics.Begin(c.metricsScope, "process")
+	const opName = "process"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
@@ -81,14 +83,14 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Deserialize batch ID from payload
 	bid, err := entity.BatchIDFromBytes(msg.Payload)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "deserialize_errors", 1)
 		return fmt.Errorf("failed to deserialize batch ID: %w", err)
 	}
 
 	// Fetch batch from storage
 	batch, err := c.store.GetBatchStore().Get(ctx, bid.ID)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to get batch %s: %w", bid.ID, err)
 	}
 
@@ -104,14 +106,14 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Score each request's change and take the minimum (worst-case) as the batch score
 	batchScore, err := c.scoreBatch(ctx, batch)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "scorer_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "scorer_errors", 1)
 		return fmt.Errorf("failed to score batch %s: %w", batch.ID, err)
 	}
 
 	// Atomically update score and state to "scored" in the database
 	newVersion := batch.Version + 1
 	if err := c.store.GetBatchStore().UpdateScoreAndState(ctx, batch.ID, batch.Version, newVersion, batchScore, entity.BatchStateScored); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to update score for batch %s: %w", batch.ID, err)
 	}
 	batch.Version = newVersion
@@ -126,13 +128,13 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 		"batch_id": batch.ID,
 		"score":    fmt.Sprintf("%.4f", batchScore),
 	}); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "request_log_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "request_log_errors", 1)
 		return fmt.Errorf("failed to publish request logs for batch %s: %w", batch.ID, err)
 	}
 
 	// Publish to speculate topic
 	if err := c.publish(ctx, consumer.TopicKeySpeculate, batch.ID, batch.Queue); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish to speculate: %w", err)
 	}
 

--- a/orchestrator/controller/speculate/BUILD.bazel
+++ b/orchestrator/controller/speculate/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/consumer",
+        "//core/metrics",
         "//entity",
         "//entity/queue",
         "//extension/storage",

--- a/orchestrator/controller/speculate/speculate.go
+++ b/orchestrator/controller/speculate/speculate.go
@@ -57,6 +57,9 @@ type Controller struct {
 // Verify Controller implements consumer.Controller interface at compile time.
 var _ consumer.Controller = (*Controller)(nil)
 
+// opName is the metric operation name shared by every emit in this file.
+const opName = "process"
+
 // NewController creates a new speculate controller for the orchestrator.
 func NewController(
 	logger *zap.SugaredLogger,
@@ -79,20 +82,20 @@ func NewController(
 // Process advances a batch one step along the naive happy-path.
 // Returns nil to ack (success), or error to nack (retry).
 func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
-	op := metrics.Begin(c.metricsScope, "process")
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
 
 	bid, err := entity.BatchIDFromBytes(msg.Payload)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "deserialize_errors", 1)
 		return fmt.Errorf("failed to deserialize batch ID: %w", err)
 	}
 
 	batch, err := c.store.GetBatchStore().Get(ctx, bid.ID)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to get batch %s: %w", bid.ID, err)
 	}
 
@@ -101,13 +104,13 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// otherwise never reconcile. Re-publishing is safe because conclude is
 	// idempotent on the batch ID.
 	if batch.State.IsTerminal() {
-		metrics.NamedCounter(c.metricsScope, "process", "self_heal_terminal", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "self_heal_terminal", 1)
 		return c.fanout(ctx, batch.ID, batch.Queue)
 	}
 
 	// Merging is owned by the merge controller, which has its own self-heal.
 	if batch.State == entity.BatchStateMerging {
-		metrics.NamedCounter(c.metricsScope, "process", "noop_merging", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "noop_merging", 1)
 		return nil
 	}
 
@@ -117,7 +120,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	case entity.BatchStateSpeculating:
 		return c.tryFinalize(ctx, batch)
 	default:
-		metrics.NamedCounter(c.metricsScope, "process", "unexpected_state", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "unexpected_state", 1)
 		return fmt.Errorf("unexpected batch state %q for batch %s", batch.State, batch.ID)
 	}
 }
@@ -131,7 +134,7 @@ func (c *Controller) startSpeculation(ctx context.Context, batch entity.Batch) e
 	)
 
 	if err := c.publish(ctx, consumer.TopicKeyBuild, batch.ID, batch.Queue); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish to build: %w", err)
 	}
 
@@ -139,11 +142,11 @@ func (c *Controller) startSpeculation(ctx context.Context, batch entity.Batch) e
 	// the next event will see the new state and behave correctly.
 	newVersion := batch.Version + 1
 	if err := c.store.GetBatchStore().UpdateState(ctx, batch.ID, batch.Version, newVersion, entity.BatchStateSpeculating); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to update batch %s state to speculating: %w", batch.ID, err)
 	}
 
-	metrics.NamedCounter(c.metricsScope, "process", "started_speculation", 1)
+	metrics.NamedCounter(c.metricsScope, opName, "started_speculation", 1)
 	return nil
 }
 
@@ -176,7 +179,7 @@ func (c *Controller) tryFinalize(ctx context.Context, batch entity.Batch) error 
 	}
 
 	if len(pending) > 0 {
-		metrics.NamedCounter(c.metricsScope, "process", "waiting_on_deps", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "waiting_on_deps", 1)
 		c.logger.Debugw("dependencies still in flight; waiting",
 			"batch_id", batch.ID,
 			"pending_dependency_ids", pending,
@@ -185,13 +188,13 @@ func (c *Controller) tryFinalize(ctx context.Context, batch entity.Batch) error 
 	}
 
 	if err := c.publish(ctx, consumer.TopicKeyMerge, batch.ID, batch.Queue); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish to merge: %w", err)
 	}
 
 	newVersion := batch.Version + 1
 	if err := c.store.GetBatchStore().UpdateState(ctx, batch.ID, batch.Version, newVersion, entity.BatchStateMerging); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to update batch %s state to merging: %w", batch.ID, err)
 	}
 
@@ -204,7 +207,7 @@ func (c *Controller) tryFinalize(ctx context.Context, batch entity.Batch) error 
 // Without this transition the batch would sit in Speculating forever — no
 // downstream event ever fires for it again.
 func (c *Controller) failOnDependency(ctx context.Context, batch entity.Batch, dep entity.Batch) error {
-	metrics.NamedCounter(c.metricsScope, "process", "dependency_failed", 1)
+	metrics.NamedCounter(c.metricsScope, opName, "dependency_failed", 1)
 	c.logger.Warnw("dependency in non-succeeding terminal state; failing batch",
 		"batch_id", batch.ID,
 		"dependency_id", dep.ID,
@@ -213,12 +216,12 @@ func (c *Controller) failOnDependency(ctx context.Context, batch entity.Batch, d
 
 	newVersion := batch.Version + 1
 	if err := c.store.GetBatchStore().UpdateState(ctx, batch.ID, batch.Version, newVersion, entity.BatchStateFailed); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to update batch %s state to failed: %w", batch.ID, err)
 	}
 
 	if err := c.publish(ctx, consumer.TopicKeyConclude, batch.ID, batch.Queue); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish to conclude: %w", err)
 	}
 
@@ -234,7 +237,7 @@ func (c *Controller) fetchDependencies(ctx context.Context, batch entity.Batch) 
 	for _, depID := range batch.Dependencies {
 		d, err := c.store.GetBatchStore().Get(ctx, depID)
 		if err != nil {
-			metrics.NamedCounter(c.metricsScope, "process", "dependency_fetch_errors", 1)
+			metrics.NamedCounter(c.metricsScope, opName, "dependency_fetch_errors", 1)
 			return nil, fmt.Errorf("failed to get dependency batch %s of %s: %w", depID, batch.ID, err)
 		}
 		deps = append(deps, d)
@@ -247,7 +250,7 @@ func (c *Controller) fetchDependencies(ctx context.Context, batch entity.Batch) 
 // re-sending to conclude guarantees request-state reconciliation.
 func (c *Controller) fanout(ctx context.Context, batchID, partitionKey string) error {
 	if err := c.publish(ctx, consumer.TopicKeyConclude, batchID, partitionKey); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish to conclude: %w", err)
 	}
 	return nil

--- a/orchestrator/controller/speculate/speculate.go
+++ b/orchestrator/controller/speculate/speculate.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/core/consumer"
+	"github.com/uber/submitqueue/core/metrics"
 	"github.com/uber/submitqueue/entity"
 	entityqueue "github.com/uber/submitqueue/entity/queue"
 	"github.com/uber/submitqueue/extension/storage"
@@ -77,20 +78,21 @@ func NewController(
 
 // Process advances a batch one step along the naive happy-path.
 // Returns nil to ack (success), or error to nack (retry).
-func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) error {
-	c.metricsScope.Counter("received").Inc(1)
+func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
+	op := metrics.Begin(c.metricsScope, "process")
+	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
 
 	bid, err := entity.BatchIDFromBytes(msg.Payload)
 	if err != nil {
-		c.metricsScope.Counter("deserialize_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
 		return fmt.Errorf("failed to deserialize batch ID: %w", err)
 	}
 
 	batch, err := c.store.GetBatchStore().Get(ctx, bid.ID)
 	if err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to get batch %s: %w", bid.ID, err)
 	}
 
@@ -99,13 +101,13 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	// otherwise never reconcile. Re-publishing is safe because conclude is
 	// idempotent on the batch ID.
 	if batch.State.IsTerminal() {
-		c.metricsScope.Counter("self_heal_terminal").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "self_heal_terminal", 1)
 		return c.fanout(ctx, batch.ID, batch.Queue)
 	}
 
 	// Merging is owned by the merge controller, which has its own self-heal.
 	if batch.State == entity.BatchStateMerging {
-		c.metricsScope.Counter("noop_merging").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "noop_merging", 1)
 		return nil
 	}
 
@@ -115,7 +117,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	case entity.BatchStateSpeculating:
 		return c.tryFinalize(ctx, batch)
 	default:
-		c.metricsScope.Counter("unexpected_state").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "unexpected_state", 1)
 		return fmt.Errorf("unexpected batch state %q for batch %s", batch.State, batch.ID)
 	}
 }
@@ -129,7 +131,7 @@ func (c *Controller) startSpeculation(ctx context.Context, batch entity.Batch) e
 	)
 
 	if err := c.publish(ctx, consumer.TopicKeyBuild, batch.ID, batch.Queue); err != nil {
-		c.metricsScope.Counter("publish_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
 		return fmt.Errorf("failed to publish to build: %w", err)
 	}
 
@@ -137,11 +139,11 @@ func (c *Controller) startSpeculation(ctx context.Context, batch entity.Batch) e
 	// the next event will see the new state and behave correctly.
 	newVersion := batch.Version + 1
 	if err := c.store.GetBatchStore().UpdateState(ctx, batch.ID, batch.Version, newVersion, entity.BatchStateSpeculating); err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to update batch %s state to speculating: %w", batch.ID, err)
 	}
 
-	c.metricsScope.Counter("started_speculation").Inc(1)
+	metrics.NamedCounter(c.metricsScope, "process", "started_speculation", 1)
 	return nil
 }
 
@@ -174,7 +176,7 @@ func (c *Controller) tryFinalize(ctx context.Context, batch entity.Batch) error 
 	}
 
 	if len(pending) > 0 {
-		c.metricsScope.Counter("waiting_on_deps").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "waiting_on_deps", 1)
 		c.logger.Debugw("dependencies still in flight; waiting",
 			"batch_id", batch.ID,
 			"pending_dependency_ids", pending,
@@ -183,17 +185,16 @@ func (c *Controller) tryFinalize(ctx context.Context, batch entity.Batch) error 
 	}
 
 	if err := c.publish(ctx, consumer.TopicKeyMerge, batch.ID, batch.Queue); err != nil {
-		c.metricsScope.Counter("publish_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
 		return fmt.Errorf("failed to publish to merge: %w", err)
 	}
 
 	newVersion := batch.Version + 1
 	if err := c.store.GetBatchStore().UpdateState(ctx, batch.ID, batch.Version, newVersion, entity.BatchStateMerging); err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to update batch %s state to merging: %w", batch.ID, err)
 	}
 
-	c.metricsScope.Counter("processed").Inc(1)
 	return nil
 }
 
@@ -203,7 +204,7 @@ func (c *Controller) tryFinalize(ctx context.Context, batch entity.Batch) error 
 // Without this transition the batch would sit in Speculating forever — no
 // downstream event ever fires for it again.
 func (c *Controller) failOnDependency(ctx context.Context, batch entity.Batch, dep entity.Batch) error {
-	c.metricsScope.Counter("dependency_failed").Inc(1)
+	metrics.NamedCounter(c.metricsScope, "process", "dependency_failed", 1)
 	c.logger.Warnw("dependency in non-succeeding terminal state; failing batch",
 		"batch_id", batch.ID,
 		"dependency_id", dep.ID,
@@ -212,12 +213,12 @@ func (c *Controller) failOnDependency(ctx context.Context, batch entity.Batch, d
 
 	newVersion := batch.Version + 1
 	if err := c.store.GetBatchStore().UpdateState(ctx, batch.ID, batch.Version, newVersion, entity.BatchStateFailed); err != nil {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to update batch %s state to failed: %w", batch.ID, err)
 	}
 
 	if err := c.publish(ctx, consumer.TopicKeyConclude, batch.ID, batch.Queue); err != nil {
-		c.metricsScope.Counter("publish_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
 		return fmt.Errorf("failed to publish to conclude: %w", err)
 	}
 
@@ -233,7 +234,7 @@ func (c *Controller) fetchDependencies(ctx context.Context, batch entity.Batch) 
 	for _, depID := range batch.Dependencies {
 		d, err := c.store.GetBatchStore().Get(ctx, depID)
 		if err != nil {
-			c.metricsScope.Counter("dependency_fetch_errors").Inc(1)
+			metrics.NamedCounter(c.metricsScope, "process", "dependency_fetch_errors", 1)
 			return nil, fmt.Errorf("failed to get dependency batch %s of %s: %w", depID, batch.ID, err)
 		}
 		deps = append(deps, d)
@@ -246,7 +247,7 @@ func (c *Controller) fetchDependencies(ctx context.Context, batch entity.Batch) 
 // re-sending to conclude guarantees request-state reconciliation.
 func (c *Controller) fanout(ctx context.Context, batchID, partitionKey string) error {
 	if err := c.publish(ctx, consumer.TopicKeyConclude, batchID, partitionKey); err != nil {
-		c.metricsScope.Counter("publish_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
 		return fmt.Errorf("failed to publish to conclude: %w", err)
 	}
 	return nil

--- a/orchestrator/controller/start/BUILD.bazel
+++ b/orchestrator/controller/start/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//core/consumer",
+        "//core/metrics",
         "//core/request",
         "//entity",
         "//entity/queue",

--- a/orchestrator/controller/start/start.go
+++ b/orchestrator/controller/start/start.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/uber-go/tally/v4"
 	"github.com/uber/submitqueue/core/consumer"
+	"github.com/uber/submitqueue/core/metrics"
 	corerequest "github.com/uber/submitqueue/core/request"
 	"github.com/uber/submitqueue/entity"
 	entityqueue "github.com/uber/submitqueue/entity/queue"
@@ -73,14 +74,15 @@ func NewController(
 // Process processes a request delivery from the queue.
 // Persists the request, claims its URIs in the change store, and publishes to validate.
 // Returns nil to ack (success), or error to nack (retry).
-func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) error {
-	c.metricsScope.Counter("received").Inc(1)
+func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
+	op := metrics.Begin(c.metricsScope, "process")
+	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
 
 	landRequest, err := entity.LandRequestFromBytes(msg.Payload)
 	if err != nil {
-		c.metricsScope.Counter("deserialize_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
 		// Non-retryable: malformed messages will never succeed regardless of retry count
 		return fmt.Errorf("failed to deserialize land request: %w", err)
 	}
@@ -109,7 +111,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	// Persist request to storage. ErrAlreadyExists means a queue redelivery of the same
 	// request_id (an at-least-once retry of THIS message), not a cross-request collision.
 	if err := c.store.GetRequestStore().Create(ctx, request); err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
-		c.metricsScope.Counter("storage_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
@@ -118,19 +120,19 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	// collide on insert; the validate controller surfaces it via GetByURI + a
 	// liveness check against the request store.
 	if err := c.claimURIs(ctx, request); err != nil {
-		c.metricsScope.Counter("change_store_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "change_store_errors", 1)
 		return fmt.Errorf("failed to claim URIs for request %s: %w", request.ID, err)
 	}
 
 	// Record the "new" status in the request log.
 	logEntry := entity.NewRequestLog(request.ID, entity.RequestStatusStarted, request.Version, "", nil)
 	if err := corerequest.PublishLog(ctx, c.registry, logEntry, request.ID); err != nil {
-		c.metricsScope.Counter("request_log_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "request_log_errors", 1)
 		return fmt.Errorf("failed to publish request log: %w", err)
 	}
 
 	if err := c.publish(ctx, consumer.TopicKeyValidate, request.ID, request.Queue); err != nil {
-		c.metricsScope.Counter("publish_errors").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
 		return fmt.Errorf("failed to publish to validate: %w", err)
 	}
 
@@ -139,7 +141,6 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 		"topic_key", consumer.TopicKeyValidate,
 	)
 
-	c.metricsScope.Counter("processed").Inc(1)
 	return nil
 }
 

--- a/orchestrator/controller/start/start.go
+++ b/orchestrator/controller/start/start.go
@@ -75,14 +75,16 @@ func NewController(
 // Persists the request, claims its URIs in the change store, and publishes to validate.
 // Returns nil to ack (success), or error to nack (retry).
 func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
-	op := metrics.Begin(c.metricsScope, "process")
+	const opName = "process"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	msg := delivery.Message()
 
 	landRequest, err := entity.LandRequestFromBytes(msg.Payload)
 	if err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "deserialize_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "deserialize_errors", 1)
 		// Non-retryable: malformed messages will never succeed regardless of retry count
 		return fmt.Errorf("failed to deserialize land request: %w", err)
 	}
@@ -111,7 +113,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Persist request to storage. ErrAlreadyExists means a queue redelivery of the same
 	// request_id (an at-least-once retry of THIS message), not a cross-request collision.
 	if err := c.store.GetRequestStore().Create(ctx, request); err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
-		metrics.NamedCounter(c.metricsScope, "process", "storage_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
@@ -120,19 +122,19 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// collide on insert; the validate controller surfaces it via GetByURI + a
 	// liveness check against the request store.
 	if err := c.claimURIs(ctx, request); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "change_store_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "change_store_errors", 1)
 		return fmt.Errorf("failed to claim URIs for request %s: %w", request.ID, err)
 	}
 
 	// Record the "new" status in the request log.
 	logEntry := entity.NewRequestLog(request.ID, entity.RequestStatusStarted, request.Version, "", nil)
 	if err := corerequest.PublishLog(ctx, c.registry, logEntry, request.ID); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "request_log_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "request_log_errors", 1)
 		return fmt.Errorf("failed to publish request log: %w", err)
 	}
 
 	if err := c.publish(ctx, consumer.TopicKeyValidate, request.ID, request.Queue); err != nil {
-		metrics.NamedCounter(c.metricsScope, "process", "publish_errors", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish to validate: %w", err)
 	}
 

--- a/stovepipe/controller/BUILD.bazel
+++ b/stovepipe/controller/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/uber/submitqueue/stovepipe/controller",
     visibility = ["//visibility:public"],
     deps = [
+        "//core/metrics",
         "//stovepipe/protopb",
         "@com_github_uber_go_tally_v4//:tally",
         "@org_uber_go_zap//:zap",

--- a/stovepipe/controller/ping.go
+++ b/stovepipe/controller/ping.go
@@ -41,7 +41,9 @@ func NewPingController(logger *zap.Logger, scope tally.Scope) *PingController {
 
 // Ping handles the ping request and returns a response
 func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (resp *pb.PingResponse, retErr error) {
-	op := metrics.Begin(c.metricsScope, "ping")
+	const opName = "ping"
+
+	op := metrics.Begin(c.metricsScope, opName)
 	defer func() { op.Complete(retErr) }()
 
 	message := "pong!"
@@ -49,7 +51,7 @@ func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (resp *p
 	if req.Message != "" {
 		message = "echo: " + req.Message
 		isEcho = true
-		metrics.NamedCounter(c.metricsScope, "ping", "echo_requests", 1)
+		metrics.NamedCounter(c.metricsScope, opName, "echo_requests", 1)
 	}
 
 	hostname, _ := os.Hostname()

--- a/stovepipe/controller/ping.go
+++ b/stovepipe/controller/ping.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/uber-go/tally/v4"
+	"github.com/uber/submitqueue/core/metrics"
 	pb "github.com/uber/submitqueue/stovepipe/protopb"
 	"go.uber.org/zap"
 )
@@ -39,20 +40,16 @@ func NewPingController(logger *zap.Logger, scope tally.Scope) *PingController {
 }
 
 // Ping handles the ping request and returns a response
-func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (*pb.PingResponse, error) {
-	start := time.Now()
-	defer func() {
-		c.metricsScope.Timer("ping_latency").Record(time.Since(start))
-	}()
-
-	c.metricsScope.Counter("ping_requests_total").Inc(1)
+func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (resp *pb.PingResponse, retErr error) {
+	op := metrics.Begin(c.metricsScope, "ping")
+	defer func() { op.Complete(retErr) }()
 
 	message := "pong!"
 	isEcho := false
 	if req.Message != "" {
 		message = "echo: " + req.Message
 		isEcho = true
-		c.metricsScope.Counter("echo_requests_total").Inc(1)
+		metrics.NamedCounter(c.metricsScope, "ping", "echo_requests", 1)
 	}
 
 	hostname, _ := os.Hostname()


### PR DESCRIPTION
## Summary

Route every controller and the consumer framework through the `core/metrics` helpers so metric emission is consistent across the codebase.

## What changed

**Migrated to `metrics.Begin` / `op.Complete` + `metrics.NamedCounter`:**
- RPC controllers: `gateway/controller/land.go`, `orchestrator/controller/ping.go`, `stovepipe/controller/ping.go`
- Queue controllers: `orchestrator/controller/{batch,build,start,score,speculate,buildsignal,log}/*.go`
- Extension: `extension/mergechecker/github/checker.go`

Each migrated method now wraps its work with `op := metrics.Begin(scope, opName); defer func() { op.Complete(retErr) }()`, which emits `{scope}.{op}.called`, `{op}.succeeded` / `{op}.failed`, `{op}.latency`, and `{op}.latency_histogram` with automatic `error_origin`, `retryable`, and `dependency` classification tags via `core/errs`. Sub-event counters (`deserialize_errors`, `storage_errors`, `publish_errors`, …) go through `metrics.NamedCounter` so they share the same sub-scope prefix.

**Consumer framework — `core/consumer/consumer.go`:**
Migrated to `metrics.NamedCounter` / `metrics.NamedTimer` rather than `Begin`/`Complete` because the framework needs custom `success=true|false|cancel` and `operation=ack|nack` tags that the standard `Op` lifecycle can't express.

**Op-name de-duplication:**
Each migrated method declares `const opName = "..."` once and references it from every emit (file-level in `speculate.go` where emits span six helper methods).

## Wire-format change

Metric names move from flat keys to `{controller_subscope}.{op}.{event}`:

| Before | After |
| --- | --- |
| `land_request_count` | `land_controller.land.called` |
| `land_request_latency` | `land_controller.land.latency` |
| `received` (per controller) | `{controller}_controller.process.called` |
| `processed` | `{controller}_controller.process.succeeded` |
| `deserialize_errors` | `{controller}_controller.process.deserialize_errors` |
| `messages_received` (consumer) | `consumer.process.messages_received` |
| `controller_latency` (consumer) | `consumer.process.controller_latency` |
| `ack_count`, `nack_count`, … | `consumer.process.ack_count`, `consumer.process.nack_count`, … |

Dashboards keyed on the old flat names will need updating; the `success=true|false|cancel`, `operation=ack|nack`, and per-controller tags on consumer metrics are preserved.

## Test Plan

- `make build` — all 135 targets build clean.
- `make test` — all 34 test targets pass, including:
  - `//core/consumer:consumer_test` — verifies the migrated `processDelivery` still emits `controller_latency` (with `success=true|false`) and `ack_count` (substring matches survive the `process.` prefix).
  - `//extension/mergechecker/github:github_test`
  - `//gateway/controller:controller_test`, `//orchestrator/controller:controller_test`, `//stovepipe/controller:controller_test`
  - Per-stage controllers: `batch`, `build`, `buildsignal`, `log`, `score`, `speculate`, `start`
- `make gazelle`, `make fmt`, `make mocks`, `make tidy` — re-running on top of the diff produces zero further changes.
- `make lint-license` — clean.
- No test assertions on the renamed metrics needed updating (`consumer_test.go` uses `strings.Contains`, which still matches the new fully-qualified names).

## Issues

None.