### PR TITLE
build(proto): use prebuilt protoc toolchain instead of compiling from source

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,6 @@
 common --disk_cache=~/.cache/bazel-disk-cache
 common --repository_cache=~/.cache/bazel-repo-cache
+
+# Resolve protoc from a registered toolchain (toolchains_protoc provides a
+# prebuilt binary) instead of compiling protoc from source. Introduced in Bazel 7.
+common --incompatible_enable_proto_toolchain_resolution

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,17 @@
+# Listed first so its protoc toolchain wins resolution over the protobuf module's,
+# which is pulled in transitively by rules_go/rules_proto.
+bazel_dep(name = "toolchains_protoc", version = "0.6.1")
 bazel_dep(name = "rules_go", version = "0.57.0")
 bazel_dep(name = "gazelle", version = "0.45.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
+
+# Use a prebuilt protoc binary instead of compiling protoc (and its abseil/upb
+# dependencies) from source on every cold build. Requires
+# --incompatible_enable_proto_toolchain_resolution (set in .bazelrc).
+protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
+use_repo(protoc, "toolchains_protoc_hub")
+
+register_toolchains("@toolchains_protoc_hub//:all")
 
 GO_VERSION = "1.24.5"
 


### PR DESCRIPTION
## Summary
Updates bazel such that the proto rules resolve a downloaded protoc binary instead of building `@protobuf//:protoc` (and its `abseil/upb` C++ deps) from source on every cold build.

Before this code change, 30k lines of noise was being dumped to terminal on `make test`, because the proto rules were compiling protoc and abseil from source which caused issues depending on host `clang` version (mine was newer than that was required which led to hundreds of deprecation warnings).

After this code change, we no longer build protoc and abseil from source and no longer see deprecation warnings. It's also faster since we don't need to build protoc from scratch.

Cold `make test` (after `bazel clean`):

| Metric                              | Before  | After |
|-------------------------------------|---------|-------|
| make test output                    | 30,868  | 69    |
| abseil deprecation warnings         | 802     | 0     |
| protobuf/abseil `[for tool]` compiles | ~250+ | 0     |
| `external/` lines                   | 9,741   | 1     |
| tests passing                       | 35      | 35    |
| cold wall time                      | ~84s    | ~11s  |

## Test Plan
✅`make test && make fmt && make lint`
✅`bazel clean && make test` produces clean output without compile warnings

## Issues


## Stack
1. #164
1. @ #165
