### PR TITLE
ci(rebase-stack): use STACK_REBASE_TOKEN so rebased pushes trigger CI

### DIFF
--- a/.github/workflows/rebase-stack.yml
+++ b/.github/workflows/rebase-stack.yml
@@ -57,10 +57,16 @@ jobs:
         with:
           # Fetch full history so rebase --onto works correctly.
           fetch-depth: 0
+          # Use a personal access token (stored as STACK_REBASE_TOKEN) so the
+          # force-push below is attributed to a user and triggers downstream
+          # workflows (CI). Pushes authenticated with the default GITHUB_TOKEN
+          # are intentionally ignored by GitHub's workflow trigger to prevent
+          # recursive runs, which would leave rebased PRs without a CI signal.
+          token: ${{ secrets.STACK_REBASE_TOKEN }}
 
       - name: Rebase stacked PRs
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.STACK_REBASE_TOKEN }}
           MERGED_HEAD: ${{ github.event.pull_request.head.ref }}
           MERGED_BASE: ${{ github.event.pull_request.base.ref }}
           MERGED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -197,13 +203,6 @@ jobs:
 
                 return 1
               fi
-
-              # Pushes made with GITHUB_TOKEN don't trigger other workflows
-              # (GitHub's anti-recursion protection). Explicitly request a
-              # check suite so CI runs on the rebased branch.
-              echo "    requesting check suite for CI"
-              gh api "repos/${GITHUB_REPOSITORY}/check-suites" \
-                -X POST -f "head_sha=${new_child_tip}" --silent || true
 
               # Point the PR at the correct base branch in GitHub.
               gh pr edit "$pr_number" --base "$new_pr_base"


### PR DESCRIPTION
## Summary

`.github/workflows/rebase-stack.yml` was authenticating with the default `GITHUB_TOKEN` for both `actions/checkout` (which configures git credentials for the push) and the `gh` CLI. Pushes made with `GITHUB_TOKEN` are intentionally ignored by GitHub's workflow trigger (anti-recursion protection), so the force-pushed rebased branch never fired `pull_request.synchronize` and CI did not run on the rebased PR.

The repo already has a `STACK_REBASE_TOKEN` secret holding a personal access token but it was not referenced anywhere.

### Changes

- `actions/checkout@v4` now passes `token: ${{ secrets.STACK_REBASE_TOKEN }}` so `git push --force-with-lease` is attributed to a user.
- `GH_TOKEN` is set to the same secret so `gh pr edit` / `gh pr comment` are also user-attributed.
- Removed the `gh api .../check-suites` POST workaround. It was a band-aid for the `GITHUB_TOKEN` limitation and would now create a duplicate empty check suite alongside the real `pull_request.synchronize` run.

## Test Plan

- ✅ `make fmt` and `make lint` clean.
- Workflow change is exercised on PR merge; will be validated when the next stacked PR is merged and CI fires on the rebased child PR.

## Issues