### PR TITLE
feat(build): add noop BuildManager implementation

### DIFF
--- a/extension/build/noop/BUILD.bazel
+++ b/extension/build/noop/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "noop",
+    srcs = ["noop.go"],
+    importpath = "github.com/uber/submitqueue/extension/build/noop",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//entity",
+        "//extension/build",
+    ],
+)
+
+go_test(
+    name = "noop_test",
+    srcs = ["noop_test.go"],
+    embed = [":noop"],
+    deps = [
+        "//entity",
+        "//extension/build",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/extension/build/noop/noop.go
+++ b/extension/build/noop/noop.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package noop provides a build.BuildManager that performs no real work:
+// every triggered build immediately succeeds. It is intended as a stub for
+// wiring tests and as a best-case baseline where every build passes.
+package noop
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/uber/submitqueue/entity"
+	"github.com/uber/submitqueue/extension/build"
+)
+
+// manager is a build.BuildManager that does no real work and reports every
+// build as immediately succeeded. The atomic counter hands out unique build
+// IDs and makes the type safe for concurrent use.
+type manager struct {
+	counter atomic.Uint64
+}
+
+// New returns a build.BuildManager that performs no real work.
+func New() build.BuildManager {
+	return &manager{}
+}
+
+// Trigger returns a unique build ID and BuildStatusSucceeded without
+// contacting any provider. Inputs are ignored.
+func (m *manager) Trigger(_ context.Context, _ string, _ []entity.BuildChange) (string, entity.BuildStatus, error) {
+	return fmt.Sprintf("noop-%d", m.counter.Add(1)), entity.BuildStatusSucceeded, nil
+}
+
+// Status always reports BuildStatusSucceeded with no metadata.
+func (m *manager) Status(_ context.Context, _ string) (entity.BuildStatus, entity.BuildMetadata, error) {
+	return entity.BuildStatusSucceeded, nil, nil
+}
+
+// Cancel is a no-op.
+func (m *manager) Cancel(_ context.Context, _ string) error {
+	return nil
+}
+
+// Close is a no-op.
+func (m *manager) Close() error {
+	return nil
+}

--- a/extension/build/noop/noop_test.go
+++ b/extension/build/noop/noop_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/submitqueue/entity"
+	"github.com/uber/submitqueue/extension/build"
+)
+
+func TestNew_ImplementsInterface(t *testing.T) {
+	var _ build.BuildManager = New()
+}
+
+func TestManager_Trigger(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	id1, status, err := m.Trigger(ctx, "queueA", []entity.BuildChange{
+		{Action: entity.ChangeActionValidate},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, id1)
+	assert.Equal(t, entity.BuildStatusSucceeded, status)
+
+	// IDs are unique across calls, even with no changes.
+	id2, _, err := m.Trigger(ctx, "queueA", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, id1, id2)
+}
+
+func TestManager_Status(t *testing.T) {
+	m := New()
+
+	status, meta, err := m.Status(context.Background(), "any-id")
+	require.NoError(t, err)
+	assert.Equal(t, entity.BuildStatusSucceeded, status)
+	assert.Empty(t, meta)
+}
+
+func TestManager_Cancel(t *testing.T) {
+	m := New()
+	assert.NoError(t, m.Cancel(context.Background(), "any-id"))
+}
+
+func TestManager_Close(t *testing.T) {
+	m := New()
+	assert.NoError(t, m.Close())
+}


### PR DESCRIPTION
## Summary
Adds `extension/build/noop`, the first implementation of the
`build.BuildManager` interface. It performs no real work: `Trigger`
hands back a unique build ID and `BuildStatusSucceeded` without
contacting any provider, `Status` always reports succeeded, and
`Cancel`/`Close` are no-ops. An atomic counter generates unique IDs
and keeps the type safe for concurrent use.

Intended as a stub for wiring tests and as a best-case baseline where
every build passes instantly — mirrors the role of
`extension/conflict/none` for the conflict analyzer.

## Test Plan
- ✅ \`make gazelle && make fmt && make lint\`
- ✅ \`make check-gazelle && make check-tidy\`
- ✅ \`bazel test //extension/build/noop/...\`

## Issues


## Stack
1. #167
1. @ #168
1. #169
