### PR TITLE
ci: skip CI runs on draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - ready_for_review
   merge_group:
 
 permissions:
@@ -25,6 +26,7 @@ jobs:
   # ---------------------------------------------------------------------------
   lint:
     name: Lint
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +40,7 @@ jobs:
   # ---------------------------------------------------------------------------
   tidy:
     name: Tidy
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +57,7 @@ jobs:
   # ---------------------------------------------------------------------------
   build-and-unit-test:
     name: Build and Unit Test
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -70,6 +74,7 @@ jobs:
   # ---------------------------------------------------------------------------
   e2e:
     name: E2E Integration Test
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -80,6 +85,7 @@ jobs:
 
   gateway-integration-test:
     name: Gateway Integration Test
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -90,6 +96,7 @@ jobs:
 
   orchestrator-integration-test:
     name: Orchestrator Integration Test
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -103,6 +110,7 @@ jobs:
   # ---------------------------------------------------------------------------
   counter-integration-test:
     name: Counter Extension Test
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -113,6 +121,7 @@ jobs:
 
   queue-integration-test:
     name: Queue Extension Test
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -123,6 +132,7 @@ jobs:
 
   storage-integration-test:
     name: Storage Extension Test
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -136,6 +146,7 @@ jobs:
   # ---------------------------------------------------------------------------
   consumer-integration-test:
     name: Consumer Integration Test
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -155,7 +166,7 @@ jobs:
   # ---------------------------------------------------------------------------
   required-checks:
     name: Required Checks
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     needs:
       - lint


### PR DESCRIPTION
### Why?

Draft PRs are work-in-progress and don't need the full CI suite running
on every push. Running lint, build, unit, integration, and e2e jobs on
drafts wastes runner capacity and adds noise while the author is still
iterating.

### What?

- Guard every job (and the `required-checks` gate) with
  `github.event_name != 'pull_request' || github.event.pull_request.draft == false`.
  The `event_name` half keeps `push` (main) and `merge_group` (merge
  queue) running, since `pull_request.draft` is null for those events.
- Preserve the `required-checks` gate's `if: always()` by combining it
  with the draft guard, so draft PRs don't fail on the gate's
  treat-skipped-as-failure logic.
- Add `ready_for_review` to `pull_request.types` so CI triggers when a
  draft is marked ready — the existing opened/reopened/synchronize types
  don't fire on that transition.

### Test Plan

✅ YAML validated with `yaml.safe_load`. Behavior to confirm post-merge:
draft PRs run no jobs; marking a PR ready, pushes to main, and merge
queue all run the full suite.

