### PR TITLE
feat(stovepipe): add start controller for the change ingress flow

### DIFF
--- a/stovepipe/entity/BUILD.bazel
+++ b/stovepipe/entity/BUILD.bazel
@@ -1,8 +1,23 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "entity",
-    srcs = ["entity.go"],
+    srcs = [
+        "entity.go",
+        "ingest_request.go",
+    ],
     importpath = "github.com/uber/submitqueue/stovepipe/entity",
     visibility = ["//visibility:public"],
+    deps = ["//platform/base/change"],
+)
+
+go_test(
+    name = "entity_test",
+    srcs = ["ingest_request_test.go"],
+    embed = [":entity"],
+    deps = [
+        "//platform/base/change",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/stovepipe/entity/ingest_request.go
+++ b/stovepipe/entity/ingest_request.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entity
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/uber/submitqueue/platform/base/change"
+)
+
+// IngestRequest is the gateway-owned contract for a Stovepipe ingest request as it
+// travels over the queue to the orchestrator. It carries the validated inputs and the
+// generated request ID (the "spid"); downstream stages resolve any further detail.
+type IngestRequest struct {
+	// ID is the globally unique identifier for the ingest request (the "spid").
+	// Format: "<queue>/<counter_value>".
+	ID string `json:"id"`
+	// Queue is the name of the queue processing the ingest request.
+	Queue string `json:"queue"`
+	// Change is the set of trunk commits to verify, identified by URI. The scheme names
+	// the VCS; the rest is provider-specific (e.g. git://remote/repo/ref/commit_sha).
+	Change change.Change `json:"change"`
+}
+
+// ToBytes serializes the IngestRequest to JSON bytes for queue message payload.
+func (r IngestRequest) ToBytes() ([]byte, error) {
+	return json.Marshal(r)
+}
+
+// Validate checks that the request carries the identity and change URIs the pipeline
+// needs to act on it. Selecting a resolver for each URI's scheme is the resolver/wiring
+// layer's job, so Validate stays VCS-agnostic and does not inspect the scheme.
+func (r IngestRequest) Validate() error {
+	if r.ID == "" {
+		return fmt.Errorf("ingest request requires an id")
+	}
+	if r.Queue == "" {
+		return fmt.Errorf("ingest request requires a queue")
+	}
+	if len(r.Change.URIs) == 0 {
+		return fmt.Errorf("ingest request requires at least one change URI")
+	}
+	for _, uri := range r.Change.URIs {
+		if uri == "" {
+			return fmt.Errorf("ingest request change URIs must be non-empty")
+		}
+	}
+	return nil
+}
+
+// IngestRequestFromBytes deserializes an IngestRequest from JSON bytes and validates it.
+func IngestRequestFromBytes(data []byte) (IngestRequest, error) {
+	var req IngestRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return IngestRequest{}, err
+	}
+	if err := req.Validate(); err != nil {
+		return IngestRequest{}, err
+	}
+	return req, nil
+}

--- a/stovepipe/entity/ingest_request_test.go
+++ b/stovepipe/entity/ingest_request_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/submitqueue/platform/base/change"
+)
+
+const (
+	testURI   = "git://git.example.com/uber/monorepo/refs%2Fheads%2Fmain/abcdef0123456789abcdef0123456789abcdef01"
+	testSPID  = "stovepipe-monorepo/1"
+	testQueue = "stovepipe-monorepo"
+)
+
+func validIngestRequest() IngestRequest {
+	return IngestRequest{
+		ID:     testSPID,
+		Queue:  testQueue,
+		Change: change.Change{URIs: []string{testURI}},
+	}
+}
+
+func TestIngestRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     IngestRequest
+		wantErr bool
+	}{
+		{name: "valid", req: validIngestRequest()},
+		{name: "missing id", req: IngestRequest{Queue: testQueue, Change: change.Change{URIs: []string{testURI}}}, wantErr: true},
+		{name: "missing queue", req: IngestRequest{ID: testSPID, Change: change.Change{URIs: []string{testURI}}}, wantErr: true},
+		{name: "no uris", req: IngestRequest{ID: testSPID, Queue: testQueue}, wantErr: true},
+		{name: "empty uri", req: IngestRequest{ID: testSPID, Queue: testQueue, Change: change.Change{URIs: []string{""}}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestIngestRequestFromBytes(t *testing.T) {
+	t.Run("round-trips a valid request", func(t *testing.T) {
+		original := validIngestRequest()
+		data, err := original.ToBytes()
+		require.NoError(t, err)
+
+		got, err := IngestRequestFromBytes(data)
+		require.NoError(t, err)
+		assert.Equal(t, original, got)
+	})
+
+	t.Run("rejects invalid json", func(t *testing.T) {
+		_, err := IngestRequestFromBytes([]byte(`{"invalid": json"}`))
+		require.Error(t, err)
+	})
+
+	t.Run("rejects a payload that fails validation", func(t *testing.T) {
+		_, err := IngestRequestFromBytes([]byte(`{"id":"x","queue":"q","change":{"uris":[]}}`))
+		require.Error(t, err)
+	})
+}

--- a/stovepipe/orchestrator/controller/start/BUILD.bazel
+++ b/stovepipe/orchestrator/controller/start/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "start",
+    srcs = ["start.go"],
+    importpath = "github.com/uber/submitqueue/stovepipe/orchestrator/controller/start",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//platform/base/messagequeue",
+        "//platform/consumer",
+        "//platform/metrics",
+        "//stovepipe/core/topickey",
+        "//stovepipe/entity",
+        "@com_github_uber_go_tally//:tally",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "start_test",
+    srcs = ["start_test.go"],
+    embed = [":start"],
+    deps = [
+        "//platform/base/change",
+        "//platform/base/messagequeue",
+        "//platform/consumer",
+        "//platform/extension/messagequeue/mock",
+        "//stovepipe/core/topickey",
+        "//stovepipe/entity",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@com_github_uber_go_tally//:tally",
+        "@org_uber_go_mock//gomock",
+        "@org_uber_go_zap//zaptest",
+    ],
+)

--- a/stovepipe/orchestrator/controller/start/start.go
+++ b/stovepipe/orchestrator/controller/start/start.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package start
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uber-go/tally"
+	entityqueue "github.com/uber/submitqueue/platform/base/messagequeue"
+	"github.com/uber/submitqueue/platform/consumer"
+	"github.com/uber/submitqueue/platform/metrics"
+	"github.com/uber/submitqueue/stovepipe/core/topickey"
+	entity "github.com/uber/submitqueue/stovepipe/entity"
+	"go.uber.org/zap"
+)
+
+// Controller handles start queue messages. It is the pipeline entry point: it
+// deserializes the gateway-produced ingest request and forwards it to the validate
+// stage, propagating the envelope partition key for ordering.
+//
+// The ordering key is decided once at ingestion and carried through the pipeline.
+//
+// Currently a forwarding stub. Per the Stovepipe workflow RFC, start will also record
+// each commit as `unknown` (keyed by SHA, making ingest idempotent across the webhook
+// and poll producers) and emit status + log events. Until a commit store exists it
+// forwards the full request downstream rather than a thin ID reference — submitqueue
+// persists the request here and forwards only the ID, but Stovepipe has no store yet.
+
+var _ consumer.Controller = (*Controller)(nil)
+
+type Controller struct {
+	logger        *zap.SugaredLogger
+	metricsScope  tally.Scope
+	registry      consumer.TopicRegistry
+	topicKey      consumer.TopicKey
+	consumerGroup string
+}
+
+// Params are the parameters for creating a new start controller.
+type Params struct {
+	Registry      consumer.TopicRegistry
+	TopicKey      consumer.TopicKey
+	ConsumerGroup string
+
+	Scope  tally.Scope
+	Logger *zap.SugaredLogger
+}
+
+// NewController creates a new start controller for the orchestrator.
+func NewController(p Params) *Controller {
+	return &Controller{
+		logger:        p.Logger.Named("start_controller"),
+		metricsScope:  p.Scope.SubScope("start_controller"),
+		registry:      p.Registry,
+		topicKey:      p.TopicKey,
+		consumerGroup: p.ConsumerGroup,
+	}
+}
+
+// Process deserializes the ingest request and forwards it to the validate stage.
+func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (retErr error) {
+	const opName = "process"
+
+	op := metrics.Begin(c.metricsScope, opName)
+	defer func() { op.Complete(retErr) }()
+
+	msg := delivery.Message()
+
+	request, err := entity.IngestRequestFromBytes(msg.Payload)
+	if err != nil {
+		metrics.NamedCounter(c.metricsScope, opName, "deserialize_errors", 1)
+		// Non-retryable: malformed messages will never succeed regardless of retry count.
+		return fmt.Errorf("failed to deserialize ingest request: %w", err)
+	}
+
+	// The ordering key lives on the message envelope, stamped by the gateway at
+	// ingestion; the controller propagates it verbatim to the next stage.
+	partitionKey := msg.PartitionKey
+	if partitionKey == "" {
+		metrics.NamedCounter(c.metricsScope, opName, "missing_partition_key", 1)
+		return fmt.Errorf("ingest request %s is missing a partition key (must be stamped by the producer)", request.ID)
+	}
+
+	c.logger.Infow("received ingest request",
+		"spid", request.ID,
+		"queue", request.Queue,
+		"change_uris", request.Change.URIs,
+		"change_count", len(request.Change.URIs),
+		"attempt", delivery.Attempt(),
+		"partition_key", partitionKey,
+	)
+
+	// Core logic to be added here:
+	// - Record each commit as `unknown` (keyed by SHA)
+	// - Emit status + log events
+
+	if err := c.publish(ctx, topickey.TopicKeyValidate, request, partitionKey); err != nil {
+		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
+		return fmt.Errorf("failed to publish to validate: %w", err)
+	}
+
+	c.logger.Infow("published ingest request to validate",
+		"spid", request.ID,
+		"topic_key", topickey.TopicKeyValidate,
+	)
+
+	return nil
+}
+
+func (c *Controller) publish(ctx context.Context, key consumer.TopicKey, request entity.IngestRequest, partitionKey string) error {
+	payload, err := request.ToBytes()
+	if err != nil {
+		return fmt.Errorf("failed to serialize ingest request: %w", err)
+	}
+
+	msg := entityqueue.NewMessage(request.ID, payload, partitionKey, nil)
+
+	q, ok := c.registry.Queue(key)
+	if !ok {
+		return fmt.Errorf("no queue registered for topic key %s", key)
+	}
+
+	topicName, ok := c.registry.TopicName(key)
+	if !ok {
+		return fmt.Errorf("no topic name registered for topic key %s", key)
+	}
+
+	if err := q.Publisher().Publish(ctx, topicName, msg); err != nil {
+		return fmt.Errorf("failed to publish message: %w", err)
+	}
+
+	return nil
+}
+
+// Name returns the controller name for logging and metrics.
+func (c *Controller) Name() string {
+	return "start"
+}
+
+// TopicKey returns the topic key this controller subscribes to.
+func (c *Controller) TopicKey() consumer.TopicKey {
+	return c.topicKey
+}
+
+// ConsumerGroup returns the consumer group for offset tracking.
+func (c *Controller) ConsumerGroup() string {
+	return c.consumerGroup
+}

--- a/stovepipe/orchestrator/controller/start/start_test.go
+++ b/stovepipe/orchestrator/controller/start/start_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package start
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"github.com/uber/submitqueue/platform/base/change"
+	entityqueue "github.com/uber/submitqueue/platform/base/messagequeue"
+	"github.com/uber/submitqueue/platform/consumer"
+	queuemock "github.com/uber/submitqueue/platform/extension/messagequeue/mock"
+	"github.com/uber/submitqueue/stovepipe/core/topickey"
+	entity "github.com/uber/submitqueue/stovepipe/entity"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
+)
+
+const (
+	testURI          = "git://git.example.com/uber/monorepo/refs%2Fheads%2Fmain/abcdef0123456789abcdef0123456789abcdef01"
+	testSPID         = "stovepipe-monorepo/1"
+	testQueue        = "stovepipe-monorepo"
+	testPartitionKey = "stovepipe-monorepo"
+)
+
+// captureRegistry builds a topic registry whose validate publisher records the
+// last message it received into captured (when non-nil) and returns publishErr.
+func captureRegistry(t *testing.T, ctrl *gomock.Controller, publishErr error, captured *entityqueue.Message) consumer.TopicRegistry {
+	t.Helper()
+
+	mockPub := queuemock.NewMockPublisher(ctrl)
+	mockPub.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, msg entityqueue.Message) error {
+			if captured != nil {
+				*captured = msg
+			}
+			return publishErr
+		},
+	).AnyTimes()
+
+	mockQ := queuemock.NewMockQueue(ctrl)
+	mockQ.EXPECT().Publisher().Return(mockPub).AnyTimes()
+
+	registry, err := consumer.NewTopicRegistry([]consumer.TopicConfig{
+		{Key: topickey.TopicKeyValidate, Name: "validate", Queue: mockQ},
+	})
+	require.NoError(t, err)
+	return registry
+}
+
+func newTestController(t *testing.T, ctrl *gomock.Controller, publishErr error, captured *entityqueue.Message) *Controller {
+	t.Helper()
+
+	return NewController(Params{
+		Logger:        zaptest.NewLogger(t).Sugar(),
+		Scope:         tally.NoopScope,
+		Registry:      captureRegistry(t, ctrl, publishErr, captured),
+		TopicKey:      topickey.TopicKeyStart,
+		ConsumerGroup: "orchestrator-start",
+	})
+}
+
+// makeDelivery builds a delivery whose envelope carries partitionKey, the
+// ordering key the producer stamps at ingestion.
+func makeDelivery(t *testing.T, ctrl *gomock.Controller, payload []byte, partitionKey string) *queuemock.MockDelivery {
+	t.Helper()
+
+	msg := entityqueue.NewMessage(testSPID, payload, partitionKey, nil)
+	delivery := queuemock.NewMockDelivery(ctrl)
+	delivery.EXPECT().Message().Return(msg).AnyTimes()
+	delivery.EXPECT().Attempt().Return(1).AnyTimes()
+	return delivery
+}
+
+// validPayload is an ingest request as the gateway produces it: identity, queue, and
+// the change URIs. The ordering key rides on the message envelope, not the payload.
+func validPayload(t *testing.T) []byte {
+	t.Helper()
+	payload, err := entity.IngestRequest{
+		ID:     testSPID,
+		Queue:  testQueue,
+		Change: change.Change{URIs: []string{testURI}},
+	}.ToBytes()
+	require.NoError(t, err)
+	return payload
+}
+
+func TestNewController(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	controller := newTestController(t, ctrl, nil, nil)
+
+	require.NotNil(t, controller)
+	assert.Equal(t, topickey.TopicKeyStart, controller.TopicKey())
+	assert.Equal(t, "orchestrator-start", controller.ConsumerGroup())
+	assert.Equal(t, "start", controller.Name())
+}
+
+func TestController_Process_PublishesToValidate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	var captured entityqueue.Message
+	controller := newTestController(t, ctrl, nil, &captured)
+	delivery := makeDelivery(t, ctrl, validPayload(t), testPartitionKey)
+
+	require.NoError(t, controller.Process(context.Background(), delivery))
+
+	// start forwards the request to validate, keyed by spid for idempotency and
+	// propagating the envelope partition key verbatim to the next hop.
+	assert.Equal(t, testSPID, captured.ID)
+	assert.Equal(t, testPartitionKey, captured.PartitionKey)
+
+	forwarded, err := entity.IngestRequestFromBytes(captured.Payload)
+	require.NoError(t, err)
+	assert.Equal(t, testSPID, forwarded.ID)
+	assert.Equal(t, []string{testURI}, forwarded.Change.URIs)
+}
+
+func TestController_Process_Errors(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      []byte
+		partitionKey string
+	}{
+		{name: "invalid json", payload: []byte(`{"invalid": json"}`), partitionKey: testPartitionKey},
+		{name: "missing id", payload: []byte(`{"queue":"q","change":{"uris":["git://x/y/z/sha"]}}`), partitionKey: testPartitionKey},
+		{name: "no uris", payload: []byte(`{"id":"q/1","queue":"q","change":{"uris":[]}}`), partitionKey: testPartitionKey},
+		// Valid request, but the producer failed to stamp an envelope partition key.
+		{name: "missing partition key", payload: validPayload(t), partitionKey: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			controller := newTestController(t, ctrl, nil, nil)
+			delivery := makeDelivery(t, ctrl, tt.payload, tt.partitionKey)
+
+			require.Error(t, controller.Process(context.Background(), delivery))
+		})
+	}
+}
+
+func TestController_Process_PublishError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	controller := newTestController(t, ctrl, assert.AnError, nil)
+	delivery := makeDelivery(t, ctrl, validPayload(t), testPartitionKey)
+
+	require.Error(t, controller.Process(context.Background(), delivery))
+}


### PR DESCRIPTION
Setting up start controller.  Per our discussions, the gateway will be responsible for polling and finding new commits, then enqueuing them in order for the orchestrator to pick up.

Start will kick off the rest of the workflow for a commit.  

Following SubmitQueue pattern of having Gateway set the partition key when creating the event, instead of deriving it internally within the orchestrator.

## Why?
Initial step for commit validation workflow

## What?
Setting up "start" step of this workflow: https://github.com/uber/submitqueue/blob/main/doc/rfc/stovepipe/workflow.md

## Test Plan
- Wire into example app
- Manually inject an event via sql, confirm that that the event triggers, and inserts a validate message


```
rchestrator-service-1  | 2026-06-16T14:31:29.811Z	DEBUG	queue_mysql.message_store	mysql/message_store.go:217	fetched messages	{"topic": "start", "partition_key": "git.example.com/uber/monorepo", "count": 1}
orchestrator-service-1  | 2026-06-16T14:31:29.815Z	DEBUG	consumer/consumer.go:351	processing delivery	{"controller": "start", "topic_key": "start", "message_id": "test-msg-1", "partition_key": "git.example.com/uber/monorepo", "attempt": 1}
orchestrator-service-1  | 2026-06-16T14:31:29.815Z	INFO	start_controller	start/start.go:85	received change event	{"uri": "git://git.example.com/uber/monorepo/refs%2Fheads%2Fmain/abcdef0123456789abcdef0123456789abcdef01", "attempt": 1, "partition_key": "git.example.com/uber/monorepo"}
orchestrator-service-1  | 2026-06-16T14:31:29.816Z	DEBUG	queue_mysql.message_store	mysql/message_store.go:72	inserting messages	{"topic": "validate", "count": 1, "visible_after": 0}
orchestrator-service-1  | 2026-06-16T14:31:29.821Z	DEBUG	queue_mysql.message_store	mysql/message_store.go:125	inserted messages	{"topic": "validate", "count": 1}
orchestrator-service-1  | 2026-06-16T14:31:29.821Z	DEBUG	queue_mysql.publisher	mysql/publisher.go:65	published message	{"topic": "validate", "message_id": "git://git.example.com/uber/monorepo/refs%2Fheads%2Fmain/abcdef0123456789abcdef0123456789abcdef01"}
orchestrator-service-1  | 2026-06-16T14:31:29.821Z	INFO	start_controller	start/start.go:96	published commit to validate	{"uri": "git://git.example.com/uber/monorepo/refs%2Fheads%2Fmain/abcdef0123456789abcdef0123456789abcdef01", "topic_key": "validate"}
orchestrator-service-1  | 2026-06-16T14:31:29.825Z	DEBUG	consumer/consumer.go:479	message processed successfully	{"controller": "start", "topic_key": "start", "message_id": "test-msg-1", "partition_key": "git.example.com/uber/monorepo", "attempt": 1, "elapsed_ms": 5}
orchestrator-service-1  | 2026-06-16T14:31:29.900Z	DEBUG	queue_mysql.partition_lease_store	mysql/partition_lease_store.go:191	retrieved leased partitions	{"topic": "start", "count": 1}
orchestrator-service-1  | 2026-06-16T14:31:29.900Z	DEBUG	queue_mysql.subscriber_heartbeat_store	mysql/subscriber_heartbeat_store.go:95	found active subscribers	{"topic": "start", "count": 1, "subscribers": ["orchestrator-dev"]}
orchestrator-service-1  | 2026-06-16T14:31:29.901Z	DEBUG	queue_mysql.partition_lease_store	mysql/partition_lease_store.go:232	discovered partitions	{"topic": "start", "count": 1}
orchestrator-service-1  | 2026-06-16T14:31:29.901Z	DEBUG	queue_mysql.partition_lease_store	mysql/partition_lease_store.go:83	acquired lease	{"topic": "start", "partition_key": "git.example.com/uber/monorepo"}

```