### PR TITLE
feat(pushqueue): add land and ping controllers with tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,7 @@ load("@gazelle//:def.bzl", "gazelle")
 # gazelle:resolve go github.com/uber/submitqueue/submitqueue/orchestrator/protopb //submitqueue/orchestrator/protopb
 # gazelle:resolve go github.com/uber/submitqueue/stovepipe/gateway/protopb //stovepipe/gateway/protopb
 # gazelle:resolve go github.com/uber/submitqueue/stovepipe/orchestrator/protopb //stovepipe/orchestrator/protopb
+# gazelle:resolve go github.com/uber/submitqueue/pushqueue/gateway/protopb //pushqueue/gateway/protopb
 
 # Export marker files for test data dependencies (used by FindRepoRoot in tests)
 exports_files(

--- a/pushqueue/gateway/controller/BUILD.bazel
+++ b/pushqueue/gateway/controller/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "controller",
+    srcs = [
+        "land.go",
+        "ping.go",
+    ],
+    importpath = "github.com/uber/submitqueue/pushqueue/gateway/controller",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//core/errs",
+        "//core/metrics",
+        "//pushqueue/entity",
+        "//pushqueue/extension/landqueue",
+        "//pushqueue/extension/vcs",
+        "//pushqueue/gateway/protopb",
+        "@com_github_uber_go_tally//:tally",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "controller_test",
+    srcs = [
+        "land_test.go",
+        "ping_test.go",
+    ],
+    embed = [":controller"],
+    deps = [
+        "//core/errs",
+        "//pushqueue/entity",
+        "//pushqueue/extension/landqueue/mock",
+        "//pushqueue/extension/vcs",
+        "//pushqueue/extension/vcs/mock",
+        "//pushqueue/gateway/protopb",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@com_github_uber_go_tally//:tally",
+        "@org_uber_go_mock//gomock",
+        "@org_uber_go_zap//:zap",
+        "@org_uber_go_zap//zaptest",
+    ],
+)

--- a/pushqueue/gateway/controller/land.go
+++ b/pushqueue/gateway/controller/land.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/uber-go/tally"
+	"github.com/uber/submitqueue/core/errs"
+	"github.com/uber/submitqueue/core/metrics"
+	"github.com/uber/submitqueue/pushqueue/entity"
+	"github.com/uber/submitqueue/pushqueue/extension/landqueue"
+	"github.com/uber/submitqueue/pushqueue/extension/vcs"
+	pb "github.com/uber/submitqueue/pushqueue/gateway/protopb"
+	"go.uber.org/zap"
+)
+
+// LandController handles land and mergeability business logic for the
+// pushqueue gateway.
+type LandController struct {
+	logger       *zap.SugaredLogger
+	metricsScope tally.Scope
+	vcs          vcs.VCS
+	queue        landqueue.Queue
+}
+
+// NewLandController creates a new instance of the pushqueue land controller.
+func NewLandController(logger *zap.SugaredLogger, scope tally.Scope, v vcs.VCS, q landqueue.Queue) *LandController {
+	return &LandController{
+		logger:       logger.Named("land_controller"),
+		metricsScope: scope.SubScope("land_controller"),
+		vcs:          v,
+		queue:        q,
+	}
+}
+
+// Land enqueues items for landing, waits for head-of-queue, pushes via VCS,
+// and finalizes. Preparation is handled by the queue's Preparer.
+func (c *LandController) Land(ctx context.Context, req *pb.LandRequest) (resp *pb.LandResponse, retErr error) {
+	const opName = "land"
+
+	op := metrics.Begin(c.metricsScope, opName)
+	defer func() { op.Complete(retErr) }()
+
+	target := entity.QueueTarget{
+		Name:    req.Queue.GetName(),
+		Address: req.Queue.GetAddress(),
+		Target:  req.Queue.GetTarget(),
+	}
+
+	items := make([]entity.LandItem, 0, len(req.Items))
+	for _, item := range req.Items {
+		items = append(items, entity.LandItem{
+			URIs:     item.GetUris(),
+			Strategy: resolveStrategy(item.GetStrategy()),
+		})
+	}
+
+	if err := c.queue.Enqueue(ctx, target, items); err != nil {
+		return nil, fmt.Errorf("enqueue: %w", err)
+	}
+	defer c.queue.Dequeue(ctx, target)
+
+	if err := c.queue.Wait(ctx, target); err != nil {
+		return nil, fmt.Errorf("wait: %w", err)
+	}
+
+	result, pushErr := c.vcs.Push(ctx, target, items)
+	switch {
+	case pushErr == nil:
+	case errors.Is(pushErr, vcs.ErrConflict):
+		return nil, errs.NewUserError(fmt.Errorf("conflict: %w", pushErr))
+	case errors.Is(pushErr, vcs.ErrStaleHead):
+		return nil, errs.NewRetryableError(fmt.Errorf("stale head: %w", pushErr))
+	default:
+		return nil, fmt.Errorf("push: %w", pushErr)
+	}
+
+	resp = &pb.LandResponse{
+		Success:  true,
+		Outcomes: make([]*pb.ItemOutcome, 0, len(result.Outcomes)),
+	}
+	for _, o := range result.Outcomes {
+		resp.Outcomes = append(resp.Outcomes, &pb.ItemOutcome{
+			Status:      outcomeStatusToProto(o.Status),
+			RevisionIds: o.RevisionIDs,
+		})
+	}
+
+	if err := c.vcs.Finalize(ctx, target, items); err != nil {
+		resp.FinalizeError = err.Error()
+	}
+
+	return resp, nil
+}
+
+// CheckMergeability checks whether items can be landed on the target.
+func (c *LandController) CheckMergeability(ctx context.Context, req *pb.CheckMergeabilityRequest) (resp *pb.CheckMergeabilityResponse, retErr error) {
+	const opName = "check_mergeability"
+
+	op := metrics.Begin(c.metricsScope, opName)
+	defer func() { op.Complete(retErr) }()
+
+	target := entity.QueueTarget{
+		Name:    req.Queue.GetName(),
+		Address: req.Queue.GetAddress(),
+		Target:  req.Queue.GetTarget(),
+	}
+
+	items := make([]entity.LandItem, 0, len(req.Items))
+	for _, item := range req.Items {
+		items = append(items, entity.LandItem{
+			URIs:     item.GetUris(),
+			Strategy: resolveStrategy(item.GetStrategy()),
+		})
+	}
+
+	results, err := c.vcs.CheckMergeability(ctx, target, items)
+	if err != nil {
+		return nil, fmt.Errorf("check mergeability: %w", err)
+	}
+
+	allMergeable := true
+	protoResults := make([]*pb.MergeabilityItemResult, 0, len(results))
+	for _, r := range results {
+		if !r.Mergeable {
+			allMergeable = false
+		}
+		protoResults = append(protoResults, &pb.MergeabilityItemResult{
+			Mergeable: r.Mergeable,
+			Reason:    r.Reason,
+		})
+	}
+
+	return &pb.CheckMergeabilityResponse{
+		Mergeable: allMergeable,
+		Results:   protoResults,
+	}, nil
+}
+
+func resolveStrategy(s pb.Strategy) entity.LandStrategy {
+	switch s {
+	case pb.Strategy_STRATEGY_REBASE:
+		return entity.LandStrategyRebase
+	case pb.Strategy_STRATEGY_SQUASH_REBASE:
+		return entity.LandStrategySquashRebase
+	case pb.Strategy_STRATEGY_MERGE:
+		return entity.LandStrategyMerge
+	default:
+		return entity.LandStrategyUnknown
+	}
+}
+
+func outcomeStatusToProto(s vcs.OutcomeStatus) pb.OutcomeStatus {
+	switch s {
+	case vcs.OutcomeStatusCommitted:
+		return pb.OutcomeStatus_OUTCOME_STATUS_COMMITTED
+	case vcs.OutcomeStatusAlreadyExisted:
+		return pb.OutcomeStatus_OUTCOME_STATUS_ALREADY_EXISTED
+	default:
+		return pb.OutcomeStatus_OUTCOME_STATUS_UNSPECIFIED
+	}
+}

--- a/pushqueue/gateway/controller/land_test.go
+++ b/pushqueue/gateway/controller/land_test.go
@@ -1,0 +1,321 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/uber/submitqueue/core/errs"
+	"github.com/uber/submitqueue/pushqueue/entity"
+	landqueuemock "github.com/uber/submitqueue/pushqueue/extension/landqueue/mock"
+	"github.com/uber/submitqueue/pushqueue/extension/vcs"
+	vcsmock "github.com/uber/submitqueue/pushqueue/extension/vcs/mock"
+	pb "github.com/uber/submitqueue/pushqueue/gateway/protopb"
+)
+
+func newTestLandController(t *testing.T, v vcs.VCS, q *landqueuemock.MockQueue) *LandController {
+	return NewLandController(zaptest.NewLogger(t).Sugar(), tally.NoopScope, v, q)
+}
+
+func testQueue() *pb.Queue {
+	return &pb.Queue{
+		Name:    "test-queue",
+		Address: "git@github.com:uber/repo.git",
+		Target:  "main",
+	}
+}
+
+func testTarget() entity.QueueTarget {
+	return entity.QueueTarget{
+		Name:    "test-queue",
+		Address: "git@github.com:uber/repo.git",
+		Target:  "main",
+	}
+}
+
+func TestNewLandController(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	c := newTestLandController(t, vcsmock.NewMockVCS(ctrl), landqueuemock.NewMockQueue(ctrl))
+	require.NotNil(t, c)
+}
+
+func TestLand_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	target := testTarget()
+	items := []entity.LandItem{{
+		URIs:     []string{"github://uber/repo/pull/1/abc123"},
+		Strategy: entity.LandStrategyRebase,
+	}}
+
+	gomock.InOrder(
+		mockQueue.EXPECT().Enqueue(gomock.Any(), target, items).Return(nil),
+		mockQueue.EXPECT().Wait(gomock.Any(), target).Return(nil),
+		mockVCS.EXPECT().Push(gomock.Any(), target, items).Return(vcs.PushResult{
+			Outcomes: []vcs.ItemOutcome{{
+				Status:      vcs.OutcomeStatusCommitted,
+				RevisionIDs: []string{"deadbeef"},
+			}},
+		}, nil),
+		mockVCS.EXPECT().Finalize(gomock.Any(), target, items).Return(nil),
+		mockQueue.EXPECT().Dequeue(gomock.Any(), target).Return(nil),
+	)
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	resp, err := c.Land(context.Background(), &pb.LandRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{{
+			Uris:     []string{"github://uber/repo/pull/1/abc123"},
+			Strategy: pb.Strategy_STRATEGY_REBASE,
+		}},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+	require.Len(t, resp.Outcomes, 1)
+	assert.Equal(t, pb.OutcomeStatus_OUTCOME_STATUS_COMMITTED, resp.Outcomes[0].Status)
+	assert.Equal(t, []string{"deadbeef"}, resp.Outcomes[0].RevisionIds)
+	assert.Empty(t, resp.FinalizeError)
+}
+
+func TestLand_FinalizeErrorRecordedButNotFatal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	target := testTarget()
+
+	mockQueue.EXPECT().Enqueue(gomock.Any(), target, gomock.Any()).Return(nil)
+	mockQueue.EXPECT().Wait(gomock.Any(), target).Return(nil)
+	mockVCS.EXPECT().Push(gomock.Any(), target, gomock.Any()).Return(vcs.PushResult{
+		Outcomes: []vcs.ItemOutcome{{Status: vcs.OutcomeStatusCommitted, RevisionIDs: []string{"abc"}}},
+	}, nil)
+	mockVCS.EXPECT().Finalize(gomock.Any(), target, gomock.Any()).Return(fmt.Errorf("GitHub API down"))
+	mockQueue.EXPECT().Dequeue(gomock.Any(), target).Return(nil)
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	resp, err := c.Land(context.Background(), &pb.LandRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{{Uris: []string{"github://uber/repo/pull/1/abc"}}},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+	assert.Equal(t, "GitHub API down", resp.FinalizeError)
+}
+
+func TestLand_PushConflictReturnsUserError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	target := testTarget()
+
+	mockQueue.EXPECT().Enqueue(gomock.Any(), target, gomock.Any()).Return(nil)
+	mockQueue.EXPECT().Wait(gomock.Any(), target).Return(nil)
+	mockVCS.EXPECT().Push(gomock.Any(), target, gomock.Any()).Return(vcs.PushResult{}, fmt.Errorf("apply: %w", vcs.ErrConflict))
+	mockQueue.EXPECT().Dequeue(gomock.Any(), target).Return(nil)
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	_, err := c.Land(context.Background(), &pb.LandRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{{Uris: []string{"github://uber/repo/pull/1/abc"}}},
+	})
+
+	require.Error(t, err)
+	assert.True(t, errs.IsUserError(err))
+	assert.False(t, errs.IsRetryable(err))
+}
+
+func TestLand_StaleHeadReturnsRetryableError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	target := testTarget()
+
+	mockQueue.EXPECT().Enqueue(gomock.Any(), target, gomock.Any()).Return(nil)
+	mockQueue.EXPECT().Wait(gomock.Any(), target).Return(nil)
+	mockVCS.EXPECT().Push(gomock.Any(), target, gomock.Any()).Return(vcs.PushResult{}, vcs.ErrStaleHead)
+	mockQueue.EXPECT().Dequeue(gomock.Any(), target).Return(nil)
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	_, err := c.Land(context.Background(), &pb.LandRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{{Uris: []string{"github://uber/repo/pull/1/abc"}}},
+	})
+
+	require.Error(t, err)
+	assert.True(t, errs.IsRetryable(err))
+}
+
+func TestLand_InfraErrorPropagates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	target := testTarget()
+
+	mockQueue.EXPECT().Enqueue(gomock.Any(), target, gomock.Any()).Return(nil)
+	mockQueue.EXPECT().Wait(gomock.Any(), target).Return(nil)
+	mockVCS.EXPECT().Push(gomock.Any(), target, gomock.Any()).Return(vcs.PushResult{}, fmt.Errorf("ssh: connection refused"))
+	mockQueue.EXPECT().Dequeue(gomock.Any(), target).Return(nil)
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	_, err := c.Land(context.Background(), &pb.LandRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{{Uris: []string{"github://uber/repo/pull/1/abc"}}},
+	})
+
+	require.Error(t, err)
+	assert.False(t, errs.IsUserError(err))
+	assert.False(t, errs.IsRetryable(err))
+}
+
+func TestLand_EnqueueFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	mockQueue.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("queue full"))
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	_, err := c.Land(context.Background(), &pb.LandRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{{Uris: []string{"github://uber/repo/pull/1/abc"}}},
+	})
+
+	require.Error(t, err)
+}
+
+func TestLand_WaitFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	mockQueue.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockQueue.EXPECT().Wait(gomock.Any(), gomock.Any()).Return(fmt.Errorf("context cancelled"))
+	mockQueue.EXPECT().Dequeue(gomock.Any(), gomock.Any()).Return(nil)
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	_, err := c.Land(context.Background(), &pb.LandRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{{Uris: []string{"github://uber/repo/pull/1/abc"}}},
+	})
+
+	require.Error(t, err)
+}
+
+func TestLand_StrategyMapping(t *testing.T) {
+	testCases := []struct {
+		name     string
+		proto    pb.Strategy
+		expected entity.LandStrategy
+	}{
+		{"rebase", pb.Strategy_STRATEGY_REBASE, entity.LandStrategyRebase},
+		{"squash_rebase", pb.Strategy_STRATEGY_SQUASH_REBASE, entity.LandStrategySquashRebase},
+		{"merge", pb.Strategy_STRATEGY_MERGE, entity.LandStrategyMerge},
+		{"unspecified", pb.Strategy_STRATEGY_UNSPECIFIED, entity.LandStrategyUnknown},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, resolveStrategy(tc.proto))
+		})
+	}
+}
+
+func TestCheckMergeability_AllMergeable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	target := testTarget()
+
+	mockVCS.EXPECT().CheckMergeability(gomock.Any(), target, gomock.Any()).Return([]vcs.MergeabilityResult{
+		{Mergeable: true},
+		{Mergeable: true},
+	}, nil)
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	resp, err := c.CheckMergeability(context.Background(), &pb.CheckMergeabilityRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{
+			{Uris: []string{"github://uber/repo/pull/1/abc"}},
+			{Uris: []string{"github://uber/repo/pull/2/def"}},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, resp.Mergeable)
+	require.Len(t, resp.Results, 2)
+	assert.True(t, resp.Results[0].Mergeable)
+	assert.True(t, resp.Results[1].Mergeable)
+}
+
+func TestCheckMergeability_SomeNotMergeable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	target := testTarget()
+
+	mockVCS.EXPECT().CheckMergeability(gomock.Any(), target, gomock.Any()).Return([]vcs.MergeabilityResult{
+		{Mergeable: true},
+		{Mergeable: false, Reason: "conflicts with target"},
+	}, nil)
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	resp, err := c.CheckMergeability(context.Background(), &pb.CheckMergeabilityRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{
+			{Uris: []string{"github://uber/repo/pull/1/abc"}},
+			{Uris: []string{"github://uber/repo/pull/2/def"}},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.False(t, resp.Mergeable)
+	require.Len(t, resp.Results, 2)
+	assert.True(t, resp.Results[0].Mergeable)
+	assert.False(t, resp.Results[1].Mergeable)
+	assert.Equal(t, "conflicts with target", resp.Results[1].Reason)
+}
+
+func TestCheckMergeability_VCSError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockVCS := vcsmock.NewMockVCS(ctrl)
+	mockQueue := landqueuemock.NewMockQueue(ctrl)
+
+	mockVCS.EXPECT().CheckMergeability(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("VCS unavailable"))
+
+	c := newTestLandController(t, mockVCS, mockQueue)
+	_, err := c.CheckMergeability(context.Background(), &pb.CheckMergeabilityRequest{
+		Queue: testQueue(),
+		Items: []*pb.LandItem{{Uris: []string{"github://uber/repo/pull/1/abc"}}},
+	})
+
+	require.Error(t, err)
+}

--- a/pushqueue/gateway/controller/ping.go
+++ b/pushqueue/gateway/controller/ping.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/uber-go/tally"
+	"github.com/uber/submitqueue/core/metrics"
+	pb "github.com/uber/submitqueue/pushqueue/gateway/protopb"
+	"go.uber.org/zap"
+)
+
+// PingController handles ping business logic for the pushqueue gateway.
+type PingController struct {
+	logger       *zap.SugaredLogger
+	metricsScope tally.Scope
+}
+
+// NewPingController creates a new instance of the pushqueue ping controller.
+func NewPingController(logger *zap.SugaredLogger, scope tally.Scope) *PingController {
+	return &PingController{
+		logger:       logger.Named("ping_controller"),
+		metricsScope: scope,
+	}
+}
+
+// Ping handles the ping request and returns a response.
+func (c *PingController) Ping(ctx context.Context, req *pb.PingRequest) (resp *pb.PingResponse, retErr error) {
+	const opName = "ping"
+
+	op := metrics.Begin(c.metricsScope, opName)
+	defer func() { op.Complete(retErr) }()
+
+	message := "pong!"
+	isEcho := false
+	if req.Message != "" {
+		message = "echo: " + req.Message
+		isEcho = true
+		metrics.NamedCounter(c.metricsScope, opName, "echo_requests", 1)
+	}
+
+	hostname, _ := os.Hostname()
+
+	c.logger.Infow("ping request received",
+		"message", req.Message,
+		"is_echo", isEcho,
+		"hostname", hostname,
+	)
+
+	return &pb.PingResponse{
+		Message:     message,
+		ServiceName: "pushqueue-gateway",
+		Timestamp:   time.Now().Unix(),
+		Hostname:    hostname,
+	}, nil
+}

--- a/pushqueue/gateway/controller/ping_test.go
+++ b/pushqueue/gateway/controller/ping_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	pb "github.com/uber/submitqueue/pushqueue/gateway/protopb"
+	"go.uber.org/zap"
+)
+
+func TestNewPingController(t *testing.T) {
+	controller := NewPingController(zap.NewNop().Sugar(), tally.NoopScope)
+	require.NotNil(t, controller)
+}
+
+func TestPing_DefaultMessage(t *testing.T) {
+	controller := NewPingController(zap.NewNop().Sugar(), tally.NoopScope)
+	ctx := context.Background()
+
+	req := &pb.PingRequest{}
+	resp, err := controller.Ping(ctx, req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "pong!", resp.Message)
+}
+
+func TestPing_CustomMessage(t *testing.T) {
+	controller := NewPingController(zap.NewNop().Sugar(), tally.NoopScope)
+	ctx := context.Background()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"simple message", "hello", "echo: hello"},
+		{"message with spaces", "hello world", "echo: hello world"},
+		{"special characters", "test!@#", "echo: test!@#"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &pb.PingRequest{Message: tc.input}
+			resp, err := controller.Ping(ctx, req)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, resp.Message)
+		})
+	}
+}
+
+func TestPing_ServiceName(t *testing.T) {
+	controller := NewPingController(zap.NewNop().Sugar(), tally.NoopScope)
+	ctx := context.Background()
+
+	req := &pb.PingRequest{}
+	resp, err := controller.Ping(ctx, req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "pushqueue-gateway", resp.ServiceName)
+}
+
+func TestPing_Timestamp(t *testing.T) {
+	controller := NewPingController(zap.NewNop().Sugar(), tally.NoopScope)
+	ctx := context.Background()
+
+	before := time.Now().Unix()
+	req := &pb.PingRequest{}
+	resp, err := controller.Ping(ctx, req)
+	after := time.Now().Unix()
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, resp.Timestamp, before)
+	assert.LessOrEqual(t, resp.Timestamp, after)
+}
+
+func TestPing_Hostname(t *testing.T) {
+	controller := NewPingController(zap.NewNop().Sugar(), tally.NoopScope)
+	ctx := context.Background()
+
+	req := &pb.PingRequest{}
+	resp, err := controller.Ping(ctx, req)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Hostname)
+}


### PR DESCRIPTION
## Summary
Land controller orchestrates enqueue → wait → push → finalize flow
with error classification (conflict=user, stale head=retryable).
Ping controller uses SugaredLogger. Regenerates mocks with
go.uber.org/mock and fixes proto BUILD disambiguation.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Test Plan


## Issues

