### PR TITLE
refactor(entity): promote RequestLandStrategy to shared entity/mergestrategy

### DIFF
--- a/entity/mergestrategy/BUILD.bazel
+++ b/entity/mergestrategy/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mergestrategy",
+    srcs = ["mergestrategy.go"],
+    importpath = "github.com/uber/submitqueue/entity/mergestrategy",
+    visibility = ["//visibility:public"],
+)

--- a/entity/mergestrategy/mergestrategy.go
+++ b/entity/mergestrategy/mergestrategy.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mergestrategy holds the shared source-control integration strategy
+// used across SubmitQueue, runway, and other repo-local domains. It names how a
+// change is integrated into the target branch (rebase, squash-rebase, merge).
+package mergestrategy
+
+// MergeStrategy defines the possible source control integration methods.
+type MergeStrategy string
+
+const (
+	// MergeStrategyUnknown is the unknown strategy. It is set by default when the structure is initialized. It should never be seen in the system and is used for error control.
+	MergeStrategyUnknown MergeStrategy = ""
+	// MergeStrategyRebase rebases commits onto the target branch before landing.
+	MergeStrategyRebase MergeStrategy = "rebase"
+	// MergeStrategySquashRebase squashes commits into a single commit before rebasing on top of the target branch.
+	MergeStrategySquashRebase MergeStrategy = "squash_rebase"
+	// MergeStrategyMerge merges commits into the target branch by creating a separate merge commit, preserving the commit history along with hashes.
+	MergeStrategyMerge MergeStrategy = "merge"
+)

--- a/submitqueue/entity/BUILD.bazel
+++ b/submitqueue/entity/BUILD.bazel
@@ -21,7 +21,10 @@ go_library(
     ],
     importpath = "github.com/uber/submitqueue/submitqueue/entity",
     visibility = ["//visibility:public"],
-    deps = ["//entity/change"],
+    deps = [
+        "//entity/change",
+        "//entity/mergestrategy",
+    ],
 )
 
 go_test(
@@ -37,6 +40,7 @@ go_test(
     embed = [":entity"],
     deps = [
         "//entity/change",
+        "//entity/mergestrategy",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/submitqueue/entity/land_request.go
+++ b/submitqueue/entity/land_request.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/uber/submitqueue/entity/change"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 )
 
 // LandRequest represents the gateway-owned fields of a land request sent over the queue
@@ -31,7 +32,7 @@ type LandRequest struct {
 	// Change is the set of code changes to land.
 	Change change.Change `json:"change"`
 	// LandStrategy is the source control integration strategy to use for this land operation.
-	LandStrategy RequestLandStrategy `json:"land_strategy"`
+	LandStrategy mergestrategy.MergeStrategy `json:"land_strategy"`
 }
 
 // ToBytes serializes the LandRequest to JSON bytes for queue message payload.

--- a/submitqueue/entity/land_request_test.go
+++ b/submitqueue/entity/land_request_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/submitqueue/entity/change"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 )
 
 func TestLandRequest_ToBytes(t *testing.T) {
@@ -30,7 +31,7 @@ func TestLandRequest_ToBytes(t *testing.T) {
 			"github://uber/submitqueue/pull/456/abcdef0123456789abcdef0123456789abcdef01",
 			"github://uber/submitqueue/pull/789/0123456789abcdef0123456789abcdef01234567",
 		}},
-		LandStrategy: RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 	}
 
 	data, err := req.ToBytes()
@@ -49,7 +50,7 @@ func TestLandRequestFromBytes(t *testing.T) {
 		ID:           "my-queue/999",
 		Queue:        "my-queue",
 		Change:       change.Change{URIs: []string{"code.uber.internal.com/D111"}},
-		LandStrategy: RequestLandStrategyMerge,
+		LandStrategy: mergestrategy.MergeStrategyMerge,
 	}
 
 	// Serialize
@@ -83,7 +84,7 @@ func TestLandRequestFromBytes_EmptyData(t *testing.T) {
 	// Empty JSON should deserialize with zero values
 	assert.Empty(t, req.ID)
 	assert.Empty(t, req.Queue)
-	assert.Equal(t, RequestLandStrategyUnknown, req.LandStrategy)
+	assert.Equal(t, mergestrategy.MergeStrategyUnknown, req.LandStrategy)
 }
 
 func TestLandRequest_SerializationRoundTrip(t *testing.T) {
@@ -101,7 +102,7 @@ func TestLandRequest_SerializationRoundTrip(t *testing.T) {
 					"github://uber/repo-a/pull/102/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 					"github://uber/repo-a/pull/103/cccccccccccccccccccccccccccccccccccccccc",
 				}},
-				LandStrategy: RequestLandStrategySquashRebase,
+				LandStrategy: mergestrategy.MergeStrategySquashRebase,
 			},
 		},
 		{
@@ -110,7 +111,7 @@ func TestLandRequest_SerializationRoundTrip(t *testing.T) {
 				ID:           "queue2/200",
 				Queue:        "queue2",
 				Change:       change.Change{URIs: []string{"code.uber.internal.com/D12345"}},
-				LandStrategy: RequestLandStrategyRebase,
+				LandStrategy: mergestrategy.MergeStrategyRebase,
 			},
 		},
 		{
@@ -119,7 +120,7 @@ func TestLandRequest_SerializationRoundTrip(t *testing.T) {
 				ID:           "queue3/300",
 				Queue:        "queue3",
 				Change:       change.Change{URIs: []string{"github.uber.com/internal/service/999/deadbeef12"}},
-				LandStrategy: RequestLandStrategyMerge,
+				LandStrategy: mergestrategy.MergeStrategyMerge,
 			},
 		},
 	}

--- a/submitqueue/entity/request.go
+++ b/submitqueue/entity/request.go
@@ -18,20 +18,7 @@ import (
 	"encoding/json"
 
 	"github.com/uber/submitqueue/entity/change"
-)
-
-// RequestLandStrategy defines the possible source control integration methods.
-type RequestLandStrategy string
-
-const (
-	// RequestLandStrategyUnknown is the unknown strategy. It is set by default when the structure is initialized. It should never be seen in the system and used for error control.
-	RequestLandStrategyUnknown RequestLandStrategy = ""
-	// RequestLandStrategyRebase rebases commits onto the target branch before landing.
-	RequestLandStrategyRebase RequestLandStrategy = "rebase"
-	// RequestLandStrategySquashRebase squashes commits into a single commit before rebasing on top of the target branch.
-	RequestLandStrategySquashRebase RequestLandStrategy = "squash_rebase"
-	// RequestLandStrategyMerge merges commits into the target branch by creating a separate merge commit, preserving the commit history along with hashes.
-	RequestLandStrategyMerge RequestLandStrategy = "merge"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 )
 
 // RequestState defines the possible states of a land request. They are internal and used to implement a state machine. A separate RequestStatus type is used to track the customer-friendly status of a request.
@@ -96,7 +83,7 @@ type Request struct {
 	// Change is a number of code changes (such as pull requests) to land into the target branch. Target branch is defined by the queue configuration.
 	Change change.Change `json:"change"`
 	// LandStrategy is the source control integration strategy to use for this land operation.
-	LandStrategy RequestLandStrategy `json:"land_strategy"`
+	LandStrategy mergestrategy.MergeStrategy `json:"land_strategy"`
 
 	// ****************
 	// Following fields could be changed throughout the lifecycle of the request

--- a/submitqueue/entity/request_test.go
+++ b/submitqueue/entity/request_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/submitqueue/entity/change"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 )
 
 func TestRequest_ToBytes(t *testing.T) {
@@ -30,7 +31,7 @@ func TestRequest_ToBytes(t *testing.T) {
 			"github://uber/submitqueue/pull/456/abcdef0123456789abcdef0123456789abcdef01",
 			"github://uber/submitqueue/pull/789/0123456789abcdef0123456789abcdef01234567",
 		}},
-		LandStrategy: RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        RequestStateStarted,
 		Version:      1,
 	}
@@ -52,7 +53,7 @@ func TestRequestFromBytes(t *testing.T) {
 		ID:           "my-queue/999",
 		Queue:        "my-queue",
 		Change:       change.Change{URIs: []string{"code.uber.internal.com/D111"}},
-		LandStrategy: RequestLandStrategyMerge,
+		LandStrategy: mergestrategy.MergeStrategyMerge,
 		State:        RequestStateProcessing,
 		Version:      3,
 	}
@@ -91,7 +92,7 @@ func TestRequestFromBytes_EmptyData(t *testing.T) {
 	assert.Empty(t, req.ID)
 	assert.Empty(t, req.Queue)
 	assert.Equal(t, RequestStateUnknown, req.State)
-	assert.Equal(t, RequestLandStrategyUnknown, req.LandStrategy)
+	assert.Equal(t, mergestrategy.MergeStrategyUnknown, req.LandStrategy)
 	assert.Equal(t, int32(0), req.Version)
 }
 
@@ -152,7 +153,7 @@ func TestRequest_SerializationRoundTrip(t *testing.T) {
 					"github://uber/repo-a/pull/102/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 					"github://uber/repo-a/pull/103/cccccccccccccccccccccccccccccccccccccccc",
 				}},
-				LandStrategy: RequestLandStrategySquashRebase,
+				LandStrategy: mergestrategy.MergeStrategySquashRebase,
 				State:        RequestStateLanded,
 				Version:      5,
 			},
@@ -163,7 +164,7 @@ func TestRequest_SerializationRoundTrip(t *testing.T) {
 				ID:           "queue2/200",
 				Queue:        "queue2",
 				Change:       change.Change{URIs: []string{"code.uber.internal.com/D12345"}},
-				LandStrategy: RequestLandStrategyRebase,
+				LandStrategy: mergestrategy.MergeStrategyRebase,
 				State:        RequestStateStarted,
 				Version:      1,
 			},
@@ -174,7 +175,7 @@ func TestRequest_SerializationRoundTrip(t *testing.T) {
 				ID:           "queue3/300",
 				Queue:        "queue3",
 				Change:       change.Change{URIs: []string{"github.uber.com/internal/service/999/deadbeef12"}},
-				LandStrategy: RequestLandStrategyMerge,
+				LandStrategy: mergestrategy.MergeStrategyMerge,
 				State:        RequestStateError,
 				Version:      10,
 			},

--- a/submitqueue/gateway/controller/BUILD.bazel
+++ b/submitqueue/gateway/controller/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//core/errs",
         "//core/metrics",
         "//entity/change",
+        "//entity/mergestrategy",
         "//entity/messagequeue",
         "//extension/counter",
         "//submitqueue/core/request",
@@ -40,6 +41,7 @@ go_test(
     deps = [
         "//core/consumer",
         "//core/errs",
+        "//entity/mergestrategy",
         "//entity/messagequeue",
         "//extension/counter/mock",
         "//extension/messagequeue/mock",

--- a/submitqueue/gateway/controller/land.go
+++ b/submitqueue/gateway/controller/land.go
@@ -24,6 +24,7 @@ import (
 	"github.com/uber/submitqueue/core/errs"
 	"github.com/uber/submitqueue/core/metrics"
 	"github.com/uber/submitqueue/entity/change"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 	entityqueue "github.com/uber/submitqueue/entity/messagequeue"
 	"github.com/uber/submitqueue/extension/counter"
 	"github.com/uber/submitqueue/submitqueue/core/topickey"
@@ -113,7 +114,7 @@ func (c *LandController) Land(ctx context.Context, req *pb.LandRequest) (resp *p
 	}
 
 	// TODO: pass default queue land strategy to resolver function to process a default.
-	strategy, err := resolveRequestLandStrategy(req.Strategy)
+	strategy, err := resolveMergeStrategy(req.Strategy)
 	if err != nil {
 		return nil, fmt.Errorf("LandController failed to map strategy for queue=%s: %w", req.Queue, err)
 	}
@@ -195,19 +196,19 @@ func (c *LandController) publishToQueue(ctx context.Context, landRequest entity.
 	return nil
 }
 
-// protoStrategyToEntity maps a proto Strategy enum to the entity RequestLandStrategy.
-func resolveRequestLandStrategy(s pb.Strategy) (entity.RequestLandStrategy, error) {
+// resolveMergeStrategy maps a proto Strategy enum to the shared mergestrategy.MergeStrategy.
+func resolveMergeStrategy(s pb.Strategy) (mergestrategy.MergeStrategy, error) {
 	switch s {
 	case pb.Strategy_DEFAULT:
 		// TODO: resolve default strategy based on queue configuration
-		return entity.RequestLandStrategyRebase, nil
+		return mergestrategy.MergeStrategyRebase, nil
 	case pb.Strategy_REBASE:
-		return entity.RequestLandStrategyRebase, nil
+		return mergestrategy.MergeStrategyRebase, nil
 	case pb.Strategy_SQUASH_REBASE:
-		return entity.RequestLandStrategySquashRebase, nil
+		return mergestrategy.MergeStrategySquashRebase, nil
 	case pb.Strategy_MERGE:
-		return entity.RequestLandStrategyMerge, nil
+		return mergestrategy.MergeStrategyMerge, nil
 	default:
-		return entity.RequestLandStrategyUnknown, fmt.Errorf("unknown land strategy in proto message: %v", s)
+		return mergestrategy.MergeStrategyUnknown, fmt.Errorf("unknown land strategy in proto message: %v", s)
 	}
 }

--- a/submitqueue/gateway/controller/land_test.go
+++ b/submitqueue/gateway/controller/land_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/uber-go/tally"
 	"github.com/uber/submitqueue/core/consumer"
 	"github.com/uber/submitqueue/core/errs"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 	entityqueue "github.com/uber/submitqueue/entity/messagequeue"
 	countermock "github.com/uber/submitqueue/extension/counter/mock"
 	queuemock "github.com/uber/submitqueue/extension/messagequeue/mock"
@@ -289,7 +290,7 @@ func TestLand_PublishesToQueue(t *testing.T) {
 	assert.Equal(t, "test-queue/123", deserializedReq.ID)
 	assert.Equal(t, "test-queue", deserializedReq.Queue)
 	assert.Equal(t, []string{"github://uber/backend/pull/456/fedcba9876543210fedcba9876543210fedcba98"}, deserializedReq.Change.URIs)
-	assert.Equal(t, entity.RequestLandStrategyRebase, deserializedReq.LandStrategy)
+	assert.Equal(t, mergestrategy.MergeStrategyRebase, deserializedReq.LandStrategy)
 }
 
 func TestLand_ContinuesWhenPublishFails(t *testing.T) {

--- a/submitqueue/orchestrator/controller/batch/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/batch/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     deps = [
         "//core/consumer",
         "//entity/change",
+        "//entity/mergestrategy",
         "//entity/messagequeue",
         "//extension/counter/mock",
         "//extension/messagequeue/mock",

--- a/submitqueue/orchestrator/controller/batch/batch_test.go
+++ b/submitqueue/orchestrator/controller/batch/batch_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/uber-go/tally"
 	"github.com/uber/submitqueue/core/consumer"
 	"github.com/uber/submitqueue/entity/change"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 	entityqueue "github.com/uber/submitqueue/entity/messagequeue"
 	countermock "github.com/uber/submitqueue/extension/counter/mock"
 	queuemock "github.com/uber/submitqueue/extension/messagequeue/mock"
@@ -65,7 +66,7 @@ func testRequest() entity.Request {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/456/abcdef0123456789abcdef0123456789abcdef01"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        entity.RequestStateStarted,
 		Version:      1,
 	}
@@ -206,7 +207,7 @@ func TestController_Process_WithDependencies(t *testing.T) {
 		ID:           "test-queue/456",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/789/789abc1234567890abcdef1234567890abcdef12"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        entity.RequestStateStarted,
 		Version:      1,
 	}

--- a/submitqueue/orchestrator/controller/start/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/start/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//core/consumer",
         "//core/errs",
         "//entity/change",
+        "//entity/mergestrategy",
         "//entity/messagequeue",
         "//extension/messagequeue/mock",
         "//submitqueue/core/topickey",

--- a/submitqueue/orchestrator/controller/start/start_test.go
+++ b/submitqueue/orchestrator/controller/start/start_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/uber/submitqueue/core/consumer"
 	"github.com/uber/submitqueue/core/errs"
 	"github.com/uber/submitqueue/entity/change"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 	entityqueue "github.com/uber/submitqueue/entity/messagequeue"
 	queuemock "github.com/uber/submitqueue/extension/messagequeue/mock"
 	"github.com/uber/submitqueue/submitqueue/core/topickey"
@@ -106,7 +107,7 @@ func TestController_Process_Success(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/456/abcdef0123456789abcdef0123456789abcdef01"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 	})
 
 	require.NoError(t, controller.Process(context.Background(), delivery))
@@ -147,7 +148,7 @@ func TestController_Process_ConstructsRequestWithStateAndVersion(t *testing.T) {
 		ID:           "test-queue/42",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/1/abcdef0123456789abcdef0123456789abcdef01"}},
-		LandStrategy: entity.RequestLandStrategySquashRebase,
+		LandStrategy: mergestrategy.MergeStrategySquashRebase,
 	}
 	delivery := makeDelivery(t, ctrl, landRequest)
 	require.NoError(t, controller.Process(context.Background(), delivery))
@@ -163,11 +164,11 @@ func TestController_Process_ConstructsRequestWithStateAndVersion(t *testing.T) {
 func TestController_Process_AllStrategies(t *testing.T) {
 	tests := []struct {
 		name     string
-		strategy entity.RequestLandStrategy
+		strategy mergestrategy.MergeStrategy
 	}{
-		{"rebase", entity.RequestLandStrategyRebase},
-		{"squash rebase", entity.RequestLandStrategySquashRebase},
-		{"merge", entity.RequestLandStrategyMerge},
+		{"rebase", mergestrategy.MergeStrategyRebase},
+		{"squash rebase", mergestrategy.MergeStrategySquashRebase},
+		{"merge", mergestrategy.MergeStrategyMerge},
 	}
 
 	for _, tt := range tests {
@@ -195,7 +196,7 @@ func TestController_Process_PublishFailure(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/1/789abc1234567890abcdef1234567890abcdef12"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 	})
 
 	assert.Error(t, controller.Process(context.Background(), delivery))
@@ -215,7 +216,7 @@ func TestController_Process_StorageFailure(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/1/789abc1234567890abcdef1234567890abcdef12"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 	})
 
 	err := controller.Process(context.Background(), delivery)
@@ -237,7 +238,7 @@ func TestController_Process_AlreadyExistsSucceeds(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/1/789abc1234567890abcdef1234567890abcdef12"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 	})
 
 	require.NoError(t, controller.Process(context.Background(), delivery))

--- a/submitqueue/orchestrator/controller/validate/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/validate/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//core/consumer",
         "//core/errs",
         "//entity/change",
+        "//entity/mergestrategy",
         "//entity/messagequeue",
         "//extension/messagequeue/mock",
         "//submitqueue/core/topickey",

--- a/submitqueue/orchestrator/controller/validate/validate_test.go
+++ b/submitqueue/orchestrator/controller/validate/validate_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/uber/submitqueue/core/consumer"
 	"github.com/uber/submitqueue/core/errs"
 	"github.com/uber/submitqueue/entity/change"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 	entityqueue "github.com/uber/submitqueue/entity/messagequeue"
 	queuemock "github.com/uber/submitqueue/extension/messagequeue/mock"
 	"github.com/uber/submitqueue/submitqueue/core/topickey"
@@ -139,7 +140,7 @@ func TestNewController(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/456/abcdef0123456789abcdef0123456789abcdef01"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        entity.RequestStateStarted,
 		Version:      1,
 	}
@@ -160,7 +161,7 @@ func TestController_Process_Success(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/456/abcdef0123456789abcdef0123456789abcdef01"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        entity.RequestStateStarted,
 		Version:      1,
 	}
@@ -189,7 +190,7 @@ func TestController_Process_ClaimsChangeRecordsWithDetails(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{uri}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        entity.RequestStateStarted,
 		Version:      1,
 	}
@@ -252,7 +253,7 @@ func TestController_Process_PublishFailure(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/1/789abc1234567890abcdef1234567890abcdef12"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        entity.RequestStateStarted,
 		Version:      1,
 	}
@@ -288,7 +289,7 @@ func TestController_Process_NotMergeable(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/repo/pull/1/abcdef0123456789abcdef0123456789abcdef01"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        entity.RequestStateStarted,
 		Version:      1,
 	}
@@ -315,7 +316,7 @@ func TestController_Process_MergeCheckError(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/repo/pull/1/abcdef0123456789abcdef0123456789abcdef01"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        entity.RequestStateStarted,
 		Version:      1,
 	}
@@ -455,7 +456,7 @@ func TestController_Process_DuplicateDetection(t *testing.T) {
 				ID:           newRequestID,
 				Queue:        queueName,
 				Change:       change.Change{URIs: uris},
-				LandStrategy: entity.RequestLandStrategyRebase,
+				LandStrategy: mergestrategy.MergeStrategyRebase,
 				State:        entity.RequestStateStarted,
 				Version:      1,
 			}
@@ -515,7 +516,7 @@ func TestController_Process_ChangeStoreQueryFailure(t *testing.T) {
 		ID:           "test-queue/123",
 		Queue:        "test-queue",
 		Change:       change.Change{URIs: []string{"github://uber/service/pull/1/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
-		LandStrategy: entity.RequestLandStrategyRebase,
+		LandStrategy: mergestrategy.MergeStrategyRebase,
 		State:        entity.RequestStateStarted,
 		Version:      1,
 	}

--- a/test/integration/submitqueue/extension/storage/BUILD.bazel
+++ b/test/integration/submitqueue/extension/storage/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//entity/change",
+        "//entity/mergestrategy",
         "//submitqueue/entity",
         "//submitqueue/extension/storage",
         "//test/testutil",

--- a/test/integration/submitqueue/extension/storage/suite.go
+++ b/test/integration/submitqueue/extension/storage/suite.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/submitqueue/entity/change"
+	"github.com/uber/submitqueue/entity/mergestrategy"
 	"github.com/uber/submitqueue/submitqueue/entity"
 	"github.com/uber/submitqueue/submitqueue/extension/storage"
 	"github.com/uber/submitqueue/test/testutil"
@@ -64,7 +65,7 @@ func (s *StorageContractSuite) TestStorage_CreateAndGet() {
 		Change: change.Change{
 			URIs: []string{"github://uber/storage-test/pull/123/abcdef0123456789abcdef0123456789abcdef01"},
 		},
-		LandStrategy: entity.RequestLandStrategyMerge,
+		LandStrategy: mergestrategy.MergeStrategyMerge,
 		Version:      1,
 	}
 
@@ -107,7 +108,7 @@ func (s *StorageContractSuite) TestStorage_CreateAndGet_StackedPRs() {
 		Change: change.Change{
 			URIs: stackedURIs,
 		},
-		LandStrategy: entity.RequestLandStrategySquashRebase,
+		LandStrategy: mergestrategy.MergeStrategySquashRebase,
 		Version:      1,
 	}
 
@@ -136,7 +137,7 @@ func (s *StorageContractSuite) TestStorage_UpdateState() {
 		ID:           "test/update",
 		Queue:        "test-queue",
 		State:        entity.RequestStateStarted,
-		LandStrategy: entity.RequestLandStrategyMerge,
+		LandStrategy: mergestrategy.MergeStrategyMerge,
 		Version:      1,
 	}
 
@@ -166,7 +167,7 @@ func (s *StorageContractSuite) TestStorage_OptimisticLocking() {
 		ID:           "test/optimistic-lock",
 		Queue:        "test-queue",
 		State:        entity.RequestStateStarted,
-		LandStrategy: entity.RequestLandStrategyMerge,
+		LandStrategy: mergestrategy.MergeStrategyMerge,
 		Version:      1,
 	}
 
@@ -214,7 +215,7 @@ func (s *StorageContractSuite) TestStorage_CreateDuplicate() {
 		ID:           "test/duplicate",
 		Queue:        "test-queue",
 		State:        entity.RequestStateStarted,
-		LandStrategy: entity.RequestLandStrategyMerge,
+		LandStrategy: mergestrategy.MergeStrategyMerge,
 		Version:      1,
 	}
 


### PR DESCRIPTION
## Summary
### Why?

The land-merge strategy enum lived in `submitqueue/entity` as `RequestLandStrategy`, but the upcoming runway merge-conflict contract needs the same type, and runway must not import `submitqueue/entity`. Mirroring the `Change` promotion in #240, the strategy belongs in the shared top-level `entity/` so both domains reference one type with no per-domain enum or mapping.

### What?

Moves `RequestLandStrategy` and its constants out of `submitqueue/entity/request.go` into a new top-level `entity/mergestrategy` package as `MergeStrategy` (`MergeStrategyUnknown/Rebase/SquashRebase/Merge`). `Request.LandStrategy` now has type `mergestrategy.MergeStrategy`. All references across the gateway and orchestrator controllers, entities, and tests are updated to the shared type. Pure mechanical refactor — no behavior change.

## Test Plan
✅ `bazel build //...`
✅ `bazel test //... --test_tag_filters=-integration,-e2e` (51 tests pass)
✅ `make gazelle` clean

## Issues


## Stack
1. @ #243
1. #244
1. #245
1. #247
