### PR TITLE
build(bazel): make Go SDK fully hermetic

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,23 +20,17 @@ GO_VERSION = "1.24.5"
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 
-# Download an SDK for the host OS & architecture as well as common remote execution
-# platforms, using the version given from the `go.mod` file.
+# Download a hermetic Go SDK for the host OS/arch and common remote execution
+# platforms using the version pinned in `go.mod`. No host Go install is required.
 go_sdk.from_file(go_mod = "//:go.mod")
 
-# Download an SDK for the host OS & architecture as well as common remote execution
-# platforms, with a specific version.
-go_sdk.download(version = GO_VERSION)
-
-# Alternatively, download an SDK for a fixed OS/architecture.
+# Also download a linux/amd64 SDK so the Docker images can be cross-compiled
+# (see the `build-*-linux` Make targets) from any host.
 go_sdk.download(
     goarch = "amd64",
     goos = "linux",
     version = GO_VERSION,
 )
-
-# Another alternative is to register the Go SDK installed on the host (see the nota bene below).
-go_sdk.host()
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")


### PR DESCRIPTION
## Summary
- Drop `go_sdk.host()` from `MODULE.bazel` so Bazel toolchain resolution no longer instantiates the host Go SDK, which fails with "Could not detect host go version" when `go` is not on `PATH`.
- Keep `go_sdk.from_file(go_mod = "//:go.mod")` (downloads the pinned `1.24.5` SDK for host + common RBE platforms) plus an explicit `linux/amd64` SDK for the `build-*-linux` Docker cross-compile targets.
- Remove the redundant version-pinned host `download` already covered by `from_file`.

With this, `make build` / `make test` / `make gazelle` work in a clean shell with no local Go install.

## Test plan
- [x] `make build` succeeds with `go` removed from `PATH` (hermetic)
- [x] `make gazelle` succeeds with `go` removed from `PATH`
- [x] `make test` — all unit tests pass

Made with [Cursor](https://cursor.com)

## Stack
1. @ #256
1. #257
1. #258
1. #259
