### PR TITLE
refactor(api/base): name the message queue option topic_keys

### DIFF
--- a/api/base/messagequeue/proto/messagequeue.proto
+++ b/api/base/messagequeue/proto/messagequeue.proto
@@ -23,18 +23,20 @@ option java_multiple_files = true;
 option java_outer_classname = "MessageQueueProto";
 option java_package = "com.uber.submitqueue.base.messagequeue";
 
-// Topic-binding option: the shared wire contract annotation that binds a queue
-// payload message to the topic(s) that carry it. A message queue payload — in
-// any domain — annotates itself with the canonical wire topic name(s), making
-// the topic-to-payload binding part of the language-neutral proto contract
-// rather than out-of-band Go wiring. A single payload may list several topics
-// (one shape can serve a queue pair, e.g. a dry-run check and a committing
-// merge). Domains import this rather than redefining their own.
+// Topic-key-binding option: the shared contract annotation that binds a queue
+// payload message to the topic key(s) that carry it. A message queue payload —
+// in any domain — annotates itself with stable logical topic key(s), making the
+// key-to-payload binding part of the language-neutral proto contract rather than
+// out-of-band Go wiring. A single payload may list several keys (one shape can
+// serve a queue pair, e.g. a dry-run check and a committing merge). Domains
+// import this rather than redefining their own.
 extend google.protobuf.MessageOptions {
-    // topics are the canonical wire topic names that carry this message. The
-    // reverse index (topic -> message) is derivable; this is the single source
-    // of truth. The strings match the consumer.TopicKey values used in Go
-    // wiring. Extension field 50001 is in the 50000-99999 range reserved for
+    // topic_keys are the stable logical topic keys that carry this message — not
+    // concrete wire names. Each implementer maps a key to whatever topic name its
+    // broker/queue requires (subject to that backend's naming constraints); our
+    // Go wiring maps it via consumer.TopicRegistry. The reverse index
+    // (key -> message) is derivable; this is the single source of truth.
+    // Extension field 50001 is in the 50000-99999 range reserved for
     // organization-internal use.
-    repeated string topics = 50001;
+    repeated string topic_keys = 50001;
 }

--- a/api/base/messagequeue/protopb/messagequeue.pb.go
+++ b/api/base/messagequeue/protopb/messagequeue.pb.go
@@ -41,37 +41,40 @@ var file_messagequeue_proto_extTypes = []protoimpl.ExtensionInfo{
 		ExtendedType:  (*descriptorpb.MessageOptions)(nil),
 		ExtensionType: ([]string)(nil),
 		Field:         50001,
-		Name:          "uber.base.messagequeue.topics",
-		Tag:           "bytes,50001,rep,name=topics",
+		Name:          "uber.base.messagequeue.topic_keys",
+		Tag:           "bytes,50001,rep,name=topic_keys",
 		Filename:      "messagequeue.proto",
 	},
 }
 
 // Extension fields to descriptorpb.MessageOptions.
 var (
-	// topics are the canonical wire topic names that carry this message. The
-	// reverse index (topic -> message) is derivable; this is the single source
-	// of truth. The strings match the consumer.TopicKey values used in Go
-	// wiring. Extension field 50001 is in the 50000-99999 range reserved for
+	// topic_keys are the stable logical topic keys that carry this message — not
+	// concrete wire names. Each implementer maps a key to whatever topic name its
+	// broker/queue requires (subject to that backend's naming constraints); our
+	// Go wiring maps it via consumer.TopicRegistry. The reverse index
+	// (key -> message) is derivable; this is the single source of truth.
+	// Extension field 50001 is in the 50000-99999 range reserved for
 	// organization-internal use.
 	//
-	// repeated string topics = 50001;
-	E_Topics = &file_messagequeue_proto_extTypes[0]
+	// repeated string topic_keys = 50001;
+	E_TopicKeys = &file_messagequeue_proto_extTypes[0]
 )
 
 var File_messagequeue_proto protoreflect.FileDescriptor
 
 const file_messagequeue_proto_rawDesc = "" +
 	"\n" +
-	"\x12messagequeue.proto\x12\x16uber.base.messagequeue\x1a google/protobuf/descriptor.proto:9\n" +
-	"\x06topics\x12\x1f.google.protobuf.MessageOptions\x18ц\x03 \x03(\tR\x06topicsBx\n" +
+	"\x12messagequeue.proto\x12\x16uber.base.messagequeue\x1a google/protobuf/descriptor.proto:@\n" +
+	"\n" +
+	"topic_keys\x12\x1f.google.protobuf.MessageOptions\x18ц\x03 \x03(\tR\ttopicKeysBx\n" +
 	"&com.uber.submitqueue.base.messagequeueB\x11MessageQueueProtoP\x01Z9github.com/uber/submitqueue/api/base/messagequeue/protopbb\x06proto3"
 
 var file_messagequeue_proto_goTypes = []any{
 	(*descriptorpb.MessageOptions)(nil), // 0: google.protobuf.MessageOptions
 }
 var file_messagequeue_proto_depIdxs = []int32{
-	0, // 0: uber.base.messagequeue.topics:extendee -> google.protobuf.MessageOptions
+	0, // 0: uber.base.messagequeue.topic_keys:extendee -> google.protobuf.MessageOptions
 	1, // [1:1] is the sub-list for method output_type
 	1, // [1:1] is the sub-list for method input_type
 	1, // [1:1] is the sub-list for extension type_name


### PR DESCRIPTION
## Summary
### Why?

The message queue topic-binding proto option was named `topics`, which reads as a concrete wire topic name. It is not — it carries a stable **logical topic key**. Each implementer maps the key to whatever topic name its broker/queue requires (subject to that backend's naming constraints); on our Go side the keys are `consumer.TopicKey` values, mapped to concrete names through `TopicRegistry`. The name `topics` invited the wrong mental model.

### What?

Rename the `google.protobuf.MessageOptions` extension `topics` → `topic_keys` (field number `50001` unchanged, so the wire/extension layout is identical) and reframe its doc comment to say it carries a logical key, not a wire name. Regenerated `messagequeue.pb.go` (`E_Topics` → `E_TopicKeys`).

This is the base of a stack; the runway contract and the contract RFC that consume the option are updated in the branches stacked on top.

## Test Plan
✅ `make proto` — descriptor field renamed (`name=topics` → `name=topic_keys`), field number `50001` unchanged
✅ `./tool/bazel build //...`

## Issues


## Stack
1. @ #264
1. #259
1. #260
1. #245
1. #247
