### PR TITLE
feat(api/base): add PROMOTE merge strategy

### DIFF
--- a/api/base/mergestrategy/proto/mergestrategy.proto
+++ b/api/base/mergestrategy/proto/mergestrategy.proto
@@ -36,4 +36,8 @@ enum Strategy {
     SQUASH_REBASE = 2;
     // Merge commits into the target branch by creating a separate merge commit, preserving commit history along with hashes.
     MERGE = 3;
+    // Integrate the exact revision as-is, with no content transform — advance the target branch to an already-existing
+    // commit rather than producing new revisions. The implementer maps it to its backend: git fast-forward, Mercurial
+    // bookmark advance, Subversion/Perforce copy. Used to promote an already-landed/verified commit onto another branch.
+    PROMOTE = 4;
 }

--- a/api/base/mergestrategy/protopb/mergestrategy.pb.go
+++ b/api/base/mergestrategy/protopb/mergestrategy.pb.go
@@ -53,6 +53,10 @@ const (
 	Strategy_SQUASH_REBASE Strategy = 2
 	// Merge commits into the target branch by creating a separate merge commit, preserving commit history along with hashes.
 	Strategy_MERGE Strategy = 3
+	// Integrate the exact revision as-is, with no content transform — advance the target branch to an already-existing
+	// commit rather than producing new revisions. The implementer maps it to its backend: git fast-forward, Mercurial
+	// bookmark advance, Subversion/Perforce copy. Used to promote an already-landed/verified commit onto another branch.
+	Strategy_PROMOTE Strategy = 4
 )
 
 // Enum value maps for Strategy.
@@ -62,12 +66,14 @@ var (
 		1: "REBASE",
 		2: "SQUASH_REBASE",
 		3: "MERGE",
+		4: "PROMOTE",
 	}
 	Strategy_value = map[string]int32{
 		"DEFAULT":       0,
 		"REBASE":        1,
 		"SQUASH_REBASE": 2,
 		"MERGE":         3,
+		"PROMOTE":       4,
 	}
 )
 
@@ -102,13 +108,14 @@ var File_mergestrategy_proto protoreflect.FileDescriptor
 
 const file_mergestrategy_proto_rawDesc = "" +
 	"\n" +
-	"\x13mergestrategy.proto\x12\x17uber.base.mergestrategy*A\n" +
+	"\x13mergestrategy.proto\x12\x17uber.base.mergestrategy*N\n" +
 	"\bStrategy\x12\v\n" +
 	"\aDEFAULT\x10\x00\x12\n" +
 	"\n" +
 	"\x06REBASE\x10\x01\x12\x11\n" +
 	"\rSQUASH_REBASE\x10\x02\x12\t\n" +
-	"\x05MERGE\x10\x03B{\n" +
+	"\x05MERGE\x10\x03\x12\v\n" +
+	"\aPROMOTE\x10\x04B{\n" +
 	"'com.uber.submitqueue.base.mergestrategyB\x12MergeStrategyProtoP\x01Z:github.com/uber/submitqueue/api/base/mergestrategy/protopbb\x06proto3"
 
 var (

--- a/api/runway/messagequeue/README.md
+++ b/api/runway/messagequeue/README.md
@@ -6,6 +6,10 @@ Payloads are defined as proto3 messages in [`proto/merge.proto`](proto/merge.pro
 
 The shared field types `Change` and `MergeStrategy` come from `api/base/change` and `api/base/mergestrategy`, imported by the contract.
 
+## Merge strategy
+
+Each `MergeStep` carries a `Strategy` (from `api/base/mergestrategy`) naming how that step is integrated into the target branch. `REBASE`, `SQUASH_REBASE`, and `MERGE` *transform* the change onto the branch tip and produce new revisions. `PROMOTE` is different: it integrates the exact revision **as-is**, advancing the target branch to an already-existing commit with no content transform and no new revision. Each backend realizes `PROMOTE` natively — git fast-forward, Mercurial bookmark advance, Subversion/Perforce copy — so for `PROMOTE` a step's `StepOutput.id` is the same revision the request named rather than a freshly created one. It is the strategy a post-merge verifier (e.g. Stovepipe) uses to advance a verified branch like `verified/main` to an already-landed, already-verified commit. `DEFAULT` lets the server pick per queue configuration.
+
 ## Topic keys
 
 The binding between a topic key and its payload lives in each message's `topic_keys` option (defined in `api/base/messagequeue`); `TopicKeys` reads it back by reflection. A topic key is a stable logical name, not a concrete wire topic — each implementer maps the key to whatever topic name its broker/queue requires. Our Go wiring maps it via `consumer.TopicRegistry`.

--- a/platform/base/mergestrategy/mergestrategy.go
+++ b/platform/base/mergestrategy/mergestrategy.go
@@ -14,7 +14,8 @@
 
 // Package mergestrategy holds the shared source-control integration strategy
 // used across SubmitQueue, runway, and other repo-local domains. It names how a
-// change is integrated into the target branch (rebase, squash-rebase, merge).
+// change is integrated into the target branch (rebase, squash-rebase, merge,
+// promote).
 package mergestrategy
 
 // MergeStrategy defines the possible source control integration methods.
@@ -29,4 +30,6 @@ const (
 	MergeStrategySquashRebase MergeStrategy = "squash_rebase"
 	// MergeStrategyMerge merges commits into the target branch by creating a separate merge commit, preserving the commit history along with hashes.
 	MergeStrategyMerge MergeStrategy = "merge"
+	// MergeStrategyPromote integrates the exact revision as-is, with no content transform — it advances the target branch to an already-existing commit rather than producing new revisions. The implementer maps it to its backend (git fast-forward, Mercurial bookmark advance, Subversion/Perforce copy). Used to promote an already-landed/verified commit onto another branch.
+	MergeStrategyPromote MergeStrategy = "promote"
 )


### PR DESCRIPTION
## Summary

### Why?

Stovepipe promotes an already-verified commit onto a verified branch (e.g. `verified/main`) as-is. The existing `REBASE`/`SQUASH_REBASE`/`MERGE` strategies cannot express this — they all transform the change and produce new revisions. We need a shared, VCS-neutral way for a client to ask Runway to advance a branch to an already-existing commit.

### What?

Adds `PROMOTE` (= 4) to the shared `Strategy` enum in `api/base/mergestrategy` and the matching `MergeStrategyPromote` Go entity constant in `platform/base/mergestrategy`. `PROMOTE` means "integrate the exact revision as-is, with no content transform": each backend realizes it natively (git fast-forward, Mercurial bookmark advance, Subversion/Perforce copy), so a step's output revision is the same commit the request named rather than a freshly created one. The Runway merge-queue contract README gains a "Merge strategy" section documenting the semantics.

This is contract + docs only — no producer or consumer wiring is added yet.

## Test Plan

✅ `make proto` (regenerated `api/base/mergestrategy/protopb`)
✅ `bazel build //api/base/mergestrategy/protopb //platform/base/mergestrategy`

Co-authored-by: Cursor <cursoragent@cursor.com>


