### PR TITLE
Split active batch states by controller use

### DIFF
--- a/submitqueue/entity/batch.go
+++ b/submitqueue/entity/batch.go
@@ -69,6 +69,38 @@ func IsBatchStateHalted(s BatchState) bool {
 	return s.IsTerminal() || s == BatchStateCancelling
 }
 
+// ActiveBatchStates returns every non-terminal batch state that must be considered in-flight.
+// Use this when callers need to find batches that still own a request, including Cancelling
+// batches that cancel redelivery must be able to resolve.
+func ActiveBatchStates() []BatchState {
+	return []BatchState{
+		BatchStateCreated,
+		BatchStateScored,
+		BatchStateSpeculating,
+		BatchStateMerging,
+		BatchStateCancelling,
+	}
+}
+
+// DependencyBatchStates returns the batch states that make an in-flight batch eligible
+// to be a dependency of a newly created batch. When a batch is created, the conflict
+// analyzer picks the existing batches it conflicts with as its dependencies; the new
+// batch then speculates on top of them — it "bases" its speculative changes on the
+// changes those batches are expected to land, so it must serialize behind them in the
+// speculation graph.
+//
+// Only batches still expected to land qualify. BatchStateCancelling is excluded (unlike
+// ActiveBatchStates): a cancelling batch may never land, so basing new speculation on its
+// changes would build on top of changes that can disappear.
+func DependencyBatchStates() []BatchState {
+	return []BatchState{
+		BatchStateCreated,
+		BatchStateScored,
+		BatchStateSpeculating,
+		BatchStateMerging,
+	}
+}
+
 // Batch represents a group of requests to land (merge into target branch of the source control repository).
 type Batch struct {
 	// ID is the globally unique identifier for the batch. Format: "<queue>/batch/<counter_value>".

--- a/submitqueue/orchestrator/controller/batch/batch.go
+++ b/submitqueue/orchestrator/controller/batch/batch.go
@@ -137,11 +137,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	// Get active batches for this queue and ask the conflict analyzer which
 	// of them the new batch must serialize behind. The dependency set drives
 	// the speculation graph downstream.
-	activeBatches, err := c.store.GetBatchStore().GetByQueueAndStates(ctx, request.Queue, []entity.BatchState{
-		entity.BatchStateCreated,
-		entity.BatchStateSpeculating,
-		entity.BatchStateMerging,
-	})
+	activeBatches, err := c.store.GetBatchStore().GetByQueueAndStates(ctx, request.Queue, entity.DependencyBatchStates())
 	if err != nil {
 		metrics.NamedCounter(c.metricsScope, opName, "batch_store_errors", 1)
 		return fmt.Errorf("failed to get active batches for queue=%s: %w", request.Queue, err)

--- a/submitqueue/orchestrator/controller/cancel/cancel.go
+++ b/submitqueue/orchestrator/controller/cancel/cancel.go
@@ -192,13 +192,7 @@ func (c *Controller) markCancelling(ctx context.Context, request entity.Request)
 // the publish.
 func (c *Controller) findActiveBatch(ctx context.Context, request entity.Request) (entity.Batch, bool, error) {
 	// TODO: Scans all the batches in flight - make it more efficient?
-	active, err := c.store.GetBatchStore().GetByQueueAndStates(ctx, request.Queue, []entity.BatchState{
-		entity.BatchStateCreated,
-		entity.BatchStateScored,
-		entity.BatchStateSpeculating,
-		entity.BatchStateMerging,
-		entity.BatchStateCancelling,
-	})
+	active, err := c.store.GetBatchStore().GetByQueueAndStates(ctx, request.Queue, entity.ActiveBatchStates())
 	if err != nil {
 		c.metricsScope.Counter("batch_store_errors").Inc(1)
 		return entity.Batch{}, false, fmt.Errorf("failed to get active batches for queue=%s: %w", request.Queue, err)


### PR DESCRIPTION
## Summary
Split active batch state helpers
    
Use separate active-state sets for cancellation and batch creation. Add the scoring request status so batches in scoring do not leave requests with stale log state.

## Test Plan
✅ make fmt && make build && make test && make check-mocks && make e2e-test

## Issues


## Stack
1. #284
1. @ #285
1. #287
1. #288
1. #289
