### PR TITLE
fix(build): remove duplicate protopb alias from api/base/messagequeue proto BUILD

### DIFF
--- a/api/base/messagequeue/proto/BUILD.bazel
+++ b/api/base/messagequeue/proto/BUILD.bazel
@@ -33,9 +33,3 @@ go_library(
     visibility = ["//visibility:public"],
 )
 
-go_library(
-    name = "protopb",
-    embed = [":messagequeuepb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/base/messagequeue/protopb",
-    visibility = ["//visibility:public"],
-)


### PR DESCRIPTION
Remove duplicate protopb alias from api/base/messagequeue proto BUILD

## Why?
api/base/messagequeue/proto/BUILD.bazel defines a go_library(name = "protopb") alias with the same Go importpath as api/base/messagequeue/protopb/BUILD.bazel. This creates two Bazel targets mapping to github.com/uber/submitqueue/api/base/messagequeue/protopb, causing Gazelle to warn "multiple rules may be imported" and leaving importpath resolution ambiguous. For external consumers importing this repo (i.e. go-code monorepo), Gazelle may resolve to the proto:protopb alias, which transitively loads @rules_proto//proto:defs.bzl and breaks builds in workspaces that don't support that ruleset.

## What?
- Removes the duplicate go_library(name = "protopb", embed = [":messagequeuepb_go_proto"]) stanza from api/base/messagequeue/proto/BUILD.bazel. The proto compilation targets (proto_library, go_proto_library) and the :proto alias are untouched.
- Adds the missing # gazelle:resolve go github.com/uber/submitqueue/api/base/messagequeue/protopb //api/base/messagequeue/protopb directive to the root BUILD.bazel, consistent with how all other api/*/protopb packages are already pinned.

## Test Plan
./tool/bazel build //api/base/messagequeue/...  passed

## Issue
