### PR TITLE
docs: specify conventional commits in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,10 @@ CI runs on every PR and enforces all checks via a `required-checks` gate. **Befo
 3. `make check-tidy` — ensure `go.mod` and `MODULE.bazel` are tidy
 4. `make check-gazelle` — ensure `BUILD.bazel` files are up to date
 
+### Commit Style
+
+1. Use conventional commits specification
+
 ### Code Style
 
 1. **Structured logging** — `zap.SugaredLogger` with `Debugw`/`Infow`/`Errorw(msg, key, val, ...)`. Never unstructured methods.


### PR DESCRIPTION
## Summary
Add a Commit Style section requiring the Conventional Commits specification for commit messages.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Test Plan
✅ make fmt && make build && make test && make check-mocks && make e2e-test

## Issues


## Stack
1. #287
1. #288
1. @ #289
