### PR TITLE
(fix)build: disable proto rule generation, rely on checked-in .pb.go for go-code compatibility

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,10 +8,17 @@ load("@gazelle//:def.bzl", "gazelle")
 
 # Disable Gazelle proto rule generation globally. We rely on the checked-in
 # .pb.go files in protopb/ dirs (plain go_library) rather than Bazel proto
-# compilation. This avoids proto_library → @protobuf// transitive loads that
-# break in consumers using newer Bazel versions (e.g. go-code's Bazel 8.5.1
-# removed native.java_proto_library), and eliminates the duplicate-importpath
-# aliases that required gazelle:resolve workarounds.
+# compilation. Rationale:
+#   - The checked-in .pb.go is the single source of truth. Generating proto
+#     via Bazel duplicates the same types under the same importpath, causing
+#     duplicate-importpath ambiguity that required gazelle:resolve workarounds.
+#   - Non-Bazel consumers (plain go build/go get, including OSS users) can only
+#     use the checked-in .pb.go, so that path must work regardless. The Bazel
+#     proto rules are a redundant second path that serves no one the checked-in
+#     files don't already serve.
+#   - proto_library forces a transitive load of @protobuf//, which breaks in
+#     consumers on newer Bazel versions (e.g. go-code's Bazel 8.5.1 removed
+#     native.java_proto_library).
 # gazelle:proto disable_global
 
 # Export marker files for test data dependencies (used by FindRepoRoot in tests)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,14 +6,13 @@ load("@gazelle//:def.bzl", "gazelle")
 # index them as duplicate rule definitions and corrupt the canonical BUILD files.
 # gazelle:exclude .claude
 
-# Resolve protobuf import ambiguities - use the actual protopb packages, not the proto aliases
-# gazelle:resolve go github.com/uber/submitqueue/api/base/change/protopb //api/base/change/protopb
-# gazelle:resolve go github.com/uber/submitqueue/api/base/mergestrategy/protopb //api/base/mergestrategy/protopb
-# gazelle:resolve go github.com/uber/submitqueue/api/runway/messagequeue/protopb //api/runway/messagequeue/protopb
-# gazelle:resolve go github.com/uber/submitqueue/api/runway/protopb //api/runway/protopb
-# gazelle:resolve go github.com/uber/submitqueue/api/submitqueue/gateway/protopb //api/submitqueue/gateway/protopb
-# gazelle:resolve go github.com/uber/submitqueue/api/submitqueue/orchestrator/protopb //api/submitqueue/orchestrator/protopb
-# gazelle:resolve go github.com/uber/submitqueue/api/stovepipe/protopb //api/stovepipe/protopb
+# Disable Gazelle proto rule generation globally. We rely on the checked-in
+# .pb.go files in protopb/ dirs (plain go_library) rather than Bazel proto
+# compilation. This avoids proto_library → @protobuf// transitive loads that
+# break in consumers using newer Bazel versions (e.g. go-code's Bazel 8.5.1
+# removed native.java_proto_library), and eliminates the duplicate-importpath
+# aliases that required gazelle:resolve workarounds.
+# gazelle:proto disable_global
 
 # Export marker files for test data dependencies (used by FindRepoRoot in tests)
 exports_files(

--- a/api/base/change/proto/BUILD.bazel
+++ b/api/base/change/proto/BUILD.bazel
@@ -1,39 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 exports_files(
     ["change.proto"],
     visibility = ["//tool/proto:__pkg__"],
-)
-
-proto_library(
-    name = "changepb_proto",
-    srcs = ["change.proto"],
-    visibility = ["//visibility:public"],
-)
-
-go_proto_library(
-    name = "changepb_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "@rules_go//proto:go_grpc_v2",
-    ],
-    importpath = "github.com/uber/submitqueue/api/base/change/proto",
-    proto = ":changepb_proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "proto",
-    embed = [":changepb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/base/change/proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "protopb",
-    embed = [":changepb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/base/change/protopb",
-    visibility = ["//visibility:public"],
 )

--- a/api/base/change/proto/BUILD.bazel
+++ b/api/base/change/proto/BUILD.bazel
@@ -13,7 +13,6 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
-# keep
 go_proto_library(
     name = "changepb_go_proto",
     compilers = [

--- a/api/base/mergestrategy/proto/BUILD.bazel
+++ b/api/base/mergestrategy/proto/BUILD.bazel
@@ -13,7 +13,6 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
-# keep
 go_proto_library(
     name = "mergestrategypb_go_proto",
     compilers = [

--- a/api/base/mergestrategy/proto/BUILD.bazel
+++ b/api/base/mergestrategy/proto/BUILD.bazel
@@ -1,39 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 exports_files(
     ["mergestrategy.proto"],
     visibility = ["//tool/proto:__pkg__"],
-)
-
-proto_library(
-    name = "mergestrategypb_proto",
-    srcs = ["mergestrategy.proto"],
-    visibility = ["//visibility:public"],
-)
-
-go_proto_library(
-    name = "mergestrategypb_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "@rules_go//proto:go_grpc_v2",
-    ],
-    importpath = "github.com/uber/submitqueue/api/base/mergestrategy/proto",
-    proto = ":mergestrategypb_proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "proto",
-    embed = [":mergestrategypb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/base/mergestrategy/proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "protopb",
-    embed = [":mergestrategypb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/base/mergestrategy/protopb",
-    visibility = ["//visibility:public"],
 )

--- a/api/base/messagequeue/proto/BUILD.bazel
+++ b/api/base/messagequeue/proto/BUILD.bazel
@@ -14,7 +14,6 @@ proto_library(
     deps = ["@protobuf//:descriptor_proto"],
 )
 
-# keep
 go_proto_library(
     name = "messagequeuepb_go_proto",
     compilers = [

--- a/api/base/messagequeue/proto/BUILD.bazel
+++ b/api/base/messagequeue/proto/BUILD.bazel
@@ -1,40 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 exports_files(
     ["messagequeue.proto"],
     visibility = ["//tool/proto:__pkg__"],
-)
-
-proto_library(
-    name = "messagequeuepb_proto",
-    srcs = ["messagequeue.proto"],
-    visibility = ["//visibility:public"],
-    deps = ["@protobuf//:descriptor_proto"],
-)
-
-go_proto_library(
-    name = "messagequeuepb_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "@rules_go//proto:go_grpc_v2",
-    ],
-    importpath = "github.com/uber/submitqueue/api/base/messagequeue/proto",
-    proto = ":messagequeuepb_proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "proto",
-    embed = [":messagequeuepb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/base/messagequeue/proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "protopb",
-    embed = [":messagequeuepb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/base/messagequeue/protopb",
-    visibility = ["//visibility:public"],
 )

--- a/api/runway/messagequeue/proto/BUILD.bazel
+++ b/api/runway/messagequeue/proto/BUILD.bazel
@@ -1,49 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 exports_files(
     ["merge.proto"],
     visibility = ["//tool/proto:__pkg__"],
-)
-
-proto_library(
-    name = "mergepb_proto",
-    srcs = ["merge.proto"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api/base/change/proto:changepb_proto",
-        "//api/base/mergestrategy/proto:mergestrategypb_proto",
-        "//api/base/messagequeue/proto:messagequeuepb_proto",
-    ],
-)
-
-go_proto_library(
-    name = "mergepb_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "@rules_go//proto:go_grpc_v2",
-    ],
-    importpath = "github.com/uber/submitqueue/api/runway/messagequeue/proto",
-    proto = ":mergepb_proto",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api/base/change/proto:changepb_go_proto",
-        "//api/base/mergestrategy/proto:mergestrategypb_go_proto",
-        "//api/base/messagequeue/proto:messagequeuepb_go_proto",
-    ],
-)
-
-go_library(
-    name = "proto",
-    embed = [":mergepb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/runway/messagequeue/proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "protopb",
-    embed = [":mergepb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/runway/messagequeue/protopb",
-    visibility = ["//visibility:public"],
 )

--- a/api/runway/messagequeue/proto/BUILD.bazel
+++ b/api/runway/messagequeue/proto/BUILD.bazel
@@ -18,7 +18,6 @@ proto_library(
     ],
 )
 
-# keep
 go_proto_library(
     name = "mergepb_go_proto",
     compilers = [
@@ -28,7 +27,6 @@ go_proto_library(
     importpath = "github.com/uber/submitqueue/api/runway/messagequeue/proto",
     proto = ":mergepb_proto",
     visibility = ["//visibility:public"],
-    # keep
     deps = [
         "//api/base/change/proto:changepb_go_proto",
         "//api/base/mergestrategy/proto:mergestrategypb_go_proto",

--- a/api/runway/proto/BUILD.bazel
+++ b/api/runway/proto/BUILD.bazel
@@ -13,7 +13,6 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
-# keep
 go_proto_library(
     name = "runwaypb_go_proto",
     compilers = [

--- a/api/runway/proto/BUILD.bazel
+++ b/api/runway/proto/BUILD.bazel
@@ -1,39 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 exports_files(
     ["runway.proto"],
     visibility = ["//tool/proto:__pkg__"],
-)
-
-proto_library(
-    name = "runwaypb_proto",
-    srcs = ["runway.proto"],
-    visibility = ["//visibility:public"],
-)
-
-go_proto_library(
-    name = "runwaypb_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "@rules_go//proto:go_grpc_v2",
-    ],
-    importpath = "github.com/uber/submitqueue/api/runway/proto",
-    proto = ":runwaypb_proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "proto",
-    embed = [":runwaypb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/runway/proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "protopb",
-    embed = [":runwaypb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/runway/protopb",
-    visibility = ["//visibility:public"],
 )

--- a/api/stovepipe/proto/BUILD.bazel
+++ b/api/stovepipe/proto/BUILD.bazel
@@ -1,39 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 exports_files(
     ["stovepipe.proto"],
     visibility = ["//tool/proto:__pkg__"],
-)
-
-proto_library(
-    name = "stovepipepb_proto",
-    srcs = ["stovepipe.proto"],
-    visibility = ["//visibility:public"],
-)
-
-go_proto_library(
-    name = "stovepipepb_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "@rules_go//proto:go_grpc_v2",
-    ],
-    importpath = "github.com/uber/submitqueue/api/stovepipe/proto",
-    proto = ":stovepipepb_proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "proto",
-    embed = [":stovepipepb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/stovepipe/proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "protopb",
-    embed = [":stovepipepb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/stovepipe/protopb",
-    visibility = ["//visibility:public"],
 )

--- a/api/stovepipe/proto/BUILD.bazel
+++ b/api/stovepipe/proto/BUILD.bazel
@@ -13,7 +13,6 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
-# keep
 go_proto_library(
     name = "stovepipepb_go_proto",
     compilers = [

--- a/api/submitqueue/gateway/proto/BUILD.bazel
+++ b/api/submitqueue/gateway/proto/BUILD.bazel
@@ -1,47 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 exports_files(
     ["gateway.proto"],
     visibility = ["//tool/proto:__pkg__"],
-)
-
-proto_library(
-    name = "gatewaypb_proto",
-    srcs = ["gateway.proto"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api/base/change/proto:changepb_proto",
-        "//api/base/mergestrategy/proto:mergestrategypb_proto",
-    ],
-)
-
-go_proto_library(
-    name = "gatewaypb_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "@rules_go//proto:go_grpc_v2",
-    ],
-    importpath = "github.com/uber/submitqueue/api/submitqueue/gateway/proto",
-    proto = ":gatewaypb_proto",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api/base/change/proto:changepb_go_proto",
-        "//api/base/mergestrategy/proto:mergestrategypb_go_proto",
-    ],
-)
-
-go_library(
-    name = "proto",
-    embed = [":gatewaypb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/submitqueue/gateway/proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "protopb",
-    embed = [":gatewaypb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/submitqueue/gateway/protopb",
-    visibility = ["//visibility:public"],
 )

--- a/api/submitqueue/gateway/proto/BUILD.bazel
+++ b/api/submitqueue/gateway/proto/BUILD.bazel
@@ -17,7 +17,6 @@ proto_library(
     ],
 )
 
-# keep
 go_proto_library(
     name = "gatewaypb_go_proto",
     compilers = [
@@ -27,7 +26,6 @@ go_proto_library(
     importpath = "github.com/uber/submitqueue/api/submitqueue/gateway/proto",
     proto = ":gatewaypb_proto",
     visibility = ["//visibility:public"],
-    # keep
     deps = [
         "//api/base/change/proto:changepb_go_proto",
         "//api/base/mergestrategy/proto:mergestrategypb_go_proto",

--- a/api/submitqueue/orchestrator/proto/BUILD.bazel
+++ b/api/submitqueue/orchestrator/proto/BUILD.bazel
@@ -13,7 +13,6 @@ proto_library(
     visibility = ["//visibility:public"],
 )
 
-# keep
 go_proto_library(
     name = "orchestratorpb_go_proto",
     compilers = [

--- a/api/submitqueue/orchestrator/proto/BUILD.bazel
+++ b/api/submitqueue/orchestrator/proto/BUILD.bazel
@@ -1,39 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 exports_files(
     ["orchestrator.proto"],
     visibility = ["//tool/proto:__pkg__"],
-)
-
-proto_library(
-    name = "orchestratorpb_proto",
-    srcs = ["orchestrator.proto"],
-    visibility = ["//visibility:public"],
-)
-
-go_proto_library(
-    name = "orchestratorpb_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "@rules_go//proto:go_grpc_v2",
-    ],
-    importpath = "github.com/uber/submitqueue/api/submitqueue/orchestrator/proto",
-    proto = ":orchestratorpb_proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "proto",
-    embed = [":orchestratorpb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/submitqueue/orchestrator/proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "protopb",
-    embed = [":orchestratorpb_go_proto"],
-    importpath = "github.com/uber/submitqueue/api/submitqueue/orchestrator/protopb",
-    visibility = ["//visibility:public"],
 )

--- a/stovepipe/core/messagequeue/proto/BUILD.bazel
+++ b/stovepipe/core/messagequeue/proto/BUILD.bazel
@@ -1,45 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
-load("@rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
 exports_files(
     ["process.proto"],
     visibility = ["//tool/proto:__pkg__"],
-)
-
-proto_library(
-    name = "processpb_proto",
-    srcs = ["process.proto"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api/base/messagequeue/proto:messagequeuepb_proto",
-    ],
-)
-
-go_proto_library(
-    name = "processpb_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "@rules_go//proto:go_grpc_v2",
-    ],
-    importpath = "github.com/uber/submitqueue/stovepipe/core/messagequeue/proto",
-    proto = ":processpb_proto",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//api/base/messagequeue/proto:messagequeuepb_go_proto",
-    ],
-)
-
-go_library(
-    name = "proto",
-    embed = [":processpb_go_proto"],
-    importpath = "github.com/uber/submitqueue/stovepipe/core/messagequeue/proto",
-    visibility = ["//visibility:public"],
-)
-
-go_library(
-    name = "protopb",
-    embed = [":processpb_go_proto"],
-    importpath = "github.com/uber/submitqueue/stovepipe/core/messagequeue/protopb",
-    visibility = ["//visibility:public"],
 )

--- a/stovepipe/core/messagequeue/proto/BUILD.bazel
+++ b/stovepipe/core/messagequeue/proto/BUILD.bazel
@@ -16,7 +16,6 @@ proto_library(
     ],
 )
 
-# keep
 go_proto_library(
     name = "processpb_go_proto",
     compilers = [
@@ -26,7 +25,6 @@ go_proto_library(
     importpath = "github.com/uber/submitqueue/stovepipe/core/messagequeue/proto",
     proto = ":processpb_proto",
     visibility = ["//visibility:public"],
-    # keep
     deps = [
         "//api/base/messagequeue/proto:messagequeuepb_go_proto",
     ],


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
We want the smoothest DX for consuming the OSS submitqueue repo in go-code. Today go-code's `go_repository` uses `build_file_generation = "on"`, so its Gazelle regenerates BUILD files for the vendored repo. This causes conflicts and mismatches, and every version bump risks new patching. 

The root issue is that OSS carries proto types twice: as checked-in `.pb.go` in `protopb/`, and as Bazel-generated code via `go_proto_library` in `proto/`. Removing the Bazel proto rules in favor of the checked-in `.pb.go` fixes several things at once:

- Eliminates duplicate proto definitions. The two generation paths share the same importpath, which caused the duplicate-importpath ambiguity and forced the `gazelle:resolve` workarounds. Collapsing to a single source removes that whole class of conflict.
- Serves non-Bazel consumers. The Bazel-generated code only exists inside a Bazel build graph. Anyone consuming submitqueue via plain `go build/go get` (including OSS users) can only use the checked-in .pb.go, so that path must work regardless. The Bazel proto rules are a redundant second path that serves no one the checked-in files don't already serve.

## What?
Disable Gazelle proto rule generation and remove all proto compilation rules, relying solely on checked-in `.pb.go` files.

- Add `# gazelle:proto disable_global` to prevent Gazelle from regenerating proto rules on future make gazelle runs
- Remove the `gazelle:resolve directives` that are no longer needed
- Remove `proto_library`, `go_proto_library`, and alias `go_library` rules
- Keep `exports_files` for `make proto` codegen (`tool/proto/BUILD.bazel`)

## Test Plan
- `make build` - pass
- `make test` - 65/65 unit tests pass (integration/e2e tests fail due to Docker dependency, pre-existing)
- `bazel build //tool/proto:generated` - proto codegen still works
- `make gazelle` - zero warnings, no duplicate-importpath ambiguity
- Validated in go-code with `--override_repository` pointing at this branch: all 71 targets build, all 20 tests pass across stovepipe, submitqueue/gateway, and submitqueue/orchestrator

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
