### PR TITLE
chore(bazel): add go_default_library alias for downstream naming compatibility

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,13 @@ load("@gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/uber/submitqueue
 
+# Add a go_default_library alias next to every native-named Go target so
+# consumers pinning go-code's naming convention (e.g. go-code's own
+# go_repository consumption with build_file_generation="off") can depend on
+# ":go_default_library" without renaming our own targets or breaking existing
+# consumers that use the native short names.
+# gazelle:go_naming_convention import_alias
+
 # Exclude nested worktrees (created under .claude/worktrees) so gazelle does not
 # index them as duplicate rule definitions and corrupt the canonical BUILD files.
 # gazelle:exclude .claude

--- a/api/base/change/protopb/BUILD.bazel
+++ b/api/base/change/protopb/BUILD.bazel
@@ -10,3 +10,9 @@ go_library(
         "@org_golang_google_protobuf//runtime/protoimpl",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":protopb",
+    visibility = ["//visibility:public"],
+)

--- a/api/base/mergestrategy/protopb/BUILD.bazel
+++ b/api/base/mergestrategy/protopb/BUILD.bazel
@@ -10,3 +10,9 @@ go_library(
         "@org_golang_google_protobuf//runtime/protoimpl",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":protopb",
+    visibility = ["//visibility:public"],
+)

--- a/api/base/messagequeue/protopb/BUILD.bazel
+++ b/api/base/messagequeue/protopb/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_golang_google_protobuf//types/descriptorpb",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":protopb",
+    visibility = ["//visibility:public"],
+)

--- a/api/runway/messagequeue/BUILD.bazel
+++ b/api/runway/messagequeue/BUILD.bazel
@@ -30,3 +30,9 @@ go_test(
         "@org_golang_google_protobuf//proto",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":messagequeue",
+    visibility = ["//visibility:public"],
+)

--- a/api/runway/messagequeue/protopb/BUILD.bazel
+++ b/api/runway/messagequeue/protopb/BUILD.bazel
@@ -13,3 +13,9 @@ go_library(
         "@org_golang_google_protobuf//runtime/protoimpl",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":protopb",
+    visibility = ["//visibility:public"],
+)

--- a/api/runway/protopb/BUILD.bazel
+++ b/api/runway/protopb/BUILD.bazel
@@ -24,3 +24,9 @@ go_library(
         "@org_uber_go_yarpc//encoding/protobuf/v2:protobuf",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":protopb",
+    visibility = ["//visibility:public"],
+)

--- a/api/stovepipe/protopb/BUILD.bazel
+++ b/api/stovepipe/protopb/BUILD.bazel
@@ -24,3 +24,9 @@ go_library(
         "@org_uber_go_yarpc//encoding/protobuf/v2:protobuf",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":protopb",
+    visibility = ["//visibility:public"],
+)

--- a/api/submitqueue/gateway/protopb/BUILD.bazel
+++ b/api/submitqueue/gateway/protopb/BUILD.bazel
@@ -26,3 +26,9 @@ go_library(
         "@org_uber_go_yarpc//encoding/protobuf/v2:protobuf",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":protopb",
+    visibility = ["//visibility:public"],
+)

--- a/api/submitqueue/orchestrator/protopb/BUILD.bazel
+++ b/api/submitqueue/orchestrator/protopb/BUILD.bazel
@@ -24,3 +24,9 @@ go_library(
         "@org_uber_go_yarpc//encoding/protobuf/v2:protobuf",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":protopb",
+    visibility = ["//visibility:public"],
+)

--- a/platform/base/BUILD.bazel
+++ b/platform/base/BUILD.bazel
@@ -6,3 +6,9 @@ go_library(
     importpath = "github.com/uber/submitqueue/platform/base",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":base",
+    visibility = ["//visibility:public"],
+)

--- a/platform/base/change/BUILD.bazel
+++ b/platform/base/change/BUILD.bazel
@@ -6,3 +6,9 @@ go_library(
     importpath = "github.com/uber/submitqueue/platform/base/change",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":change",
+    visibility = ["//visibility:public"],
+)

--- a/platform/base/change/changeutil/BUILD.bazel
+++ b/platform/base/change/changeutil/BUILD.bazel
@@ -13,3 +13,9 @@ go_test(
     embed = [":changeutil"],
     deps = ["@com_github_stretchr_testify//assert"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":changeutil",
+    visibility = ["//visibility:public"],
+)

--- a/platform/base/change/git/BUILD.bazel
+++ b/platform/base/change/git/BUILD.bazel
@@ -17,3 +17,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":git",
+    visibility = ["//visibility:public"],
+)

--- a/platform/base/change/github/BUILD.bazel
+++ b/platform/base/change/github/BUILD.bazel
@@ -17,3 +17,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":github",
+    visibility = ["//visibility:public"],
+)

--- a/platform/base/change/phabricator/BUILD.bazel
+++ b/platform/base/change/phabricator/BUILD.bazel
@@ -16,3 +16,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":phabricator",
+    visibility = ["//visibility:public"],
+)

--- a/platform/base/mergestrategy/BUILD.bazel
+++ b/platform/base/mergestrategy/BUILD.bazel
@@ -6,3 +6,9 @@ go_library(
     importpath = "github.com/uber/submitqueue/platform/base/mergestrategy",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mergestrategy",
+    visibility = ["//visibility:public"],
+)

--- a/platform/base/messagequeue/BUILD.bazel
+++ b/platform/base/messagequeue/BUILD.bazel
@@ -13,3 +13,9 @@ go_test(
     embed = [":messagequeue"],
     deps = ["@com_github_stretchr_testify//assert"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":messagequeue",
+    visibility = ["//visibility:public"],
+)

--- a/platform/base/page/BUILD.bazel
+++ b/platform/base/page/BUILD.bazel
@@ -6,3 +6,9 @@ go_library(
     importpath = "github.com/uber/submitqueue/platform/base/page",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":page",
+    visibility = ["//visibility:public"],
+)

--- a/platform/consumer/BUILD.bazel
+++ b/platform/consumer/BUILD.bazel
@@ -40,3 +40,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":consumer",
+    visibility = ["//visibility:public"],
+)

--- a/platform/consumer/mock/BUILD.bazel
+++ b/platform/consumer/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/platform/errs/BUILD.bazel
+++ b/platform/errs/BUILD.bazel
@@ -22,3 +22,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":errs",
+    visibility = ["//visibility:public"],
+)

--- a/platform/errs/generic/BUILD.bazel
+++ b/platform/errs/generic/BUILD.bazel
@@ -17,3 +17,9 @@ go_test(
         "@com_github_stretchr_testify//assert",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":generic",
+    visibility = ["//visibility:public"],
+)

--- a/platform/errs/mysql/BUILD.bazel
+++ b/platform/errs/mysql/BUILD.bazel
@@ -21,3 +21,9 @@ go_test(
         "@com_github_stretchr_testify//assert",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mysql",
+    visibility = ["//visibility:public"],
+)

--- a/platform/extension/BUILD.bazel
+++ b/platform/extension/BUILD.bazel
@@ -6,3 +6,9 @@ go_library(
     importpath = "github.com/uber/submitqueue/platform/extension",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":extension",
+    visibility = ["//visibility:public"],
+)

--- a/platform/extension/counter/BUILD.bazel
+++ b/platform/extension/counter/BUILD.bazel
@@ -6,3 +6,9 @@ go_library(
     importpath = "github.com/uber/submitqueue/platform/extension/counter",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":counter",
+    visibility = ["//visibility:public"],
+)

--- a/platform/extension/counter/mock/BUILD.bazel
+++ b/platform/extension/counter/mock/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["@org_uber_go_mock//gomock"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/platform/extension/counter/mysql/BUILD.bazel
+++ b/platform/extension/counter/mysql/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@com_github_uber_go_tally//:tally",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mysql",
+    visibility = ["//visibility:public"],
+)

--- a/platform/extension/messagequeue/BUILD.bazel
+++ b/platform/extension/messagequeue/BUILD.bazel
@@ -23,3 +23,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":messagequeue",
+    visibility = ["//visibility:public"],
+)

--- a/platform/extension/messagequeue/mock/BUILD.bazel
+++ b/platform/extension/messagequeue/mock/BUILD.bazel
@@ -16,3 +16,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/platform/extension/messagequeue/mysql/BUILD.bazel
+++ b/platform/extension/messagequeue/mysql/BUILD.bazel
@@ -52,3 +52,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mysql",
+    visibility = ["//visibility:public"],
+)

--- a/platform/extension/messagequeue/mysql/ctl/lib/BUILD.bazel
+++ b/platform/extension/messagequeue/mysql/ctl/lib/BUILD.bazel
@@ -21,3 +21,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":lib",
+    visibility = ["//visibility:public"],
+)

--- a/platform/http/BUILD.bazel
+++ b/platform/http/BUILD.bazel
@@ -16,3 +16,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":http",
+    visibility = ["//visibility:public"],
+)

--- a/platform/metrics/BUILD.bazel
+++ b/platform/metrics/BUILD.bazel
@@ -21,3 +21,9 @@ go_test(
         "@com_github_uber_go_tally//:tally",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":metrics",
+    visibility = ["//visibility:public"],
+)

--- a/runway/controller/BUILD.bazel
+++ b/runway/controller/BUILD.bazel
@@ -25,3 +25,9 @@ go_test(
         "@org_uber_go_zap//:zap",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":controller",
+    visibility = ["//visibility:public"],
+)

--- a/runway/controller/merge/BUILD.bazel
+++ b/runway/controller/merge/BUILD.bazel
@@ -36,3 +36,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":merge",
+    visibility = ["//visibility:public"],
+)

--- a/runway/controller/mergeconflictcheck/BUILD.bazel
+++ b/runway/controller/mergeconflictcheck/BUILD.bazel
@@ -36,3 +36,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mergeconflictcheck",
+    visibility = ["//visibility:public"],
+)

--- a/runway/extension/BUILD.bazel
+++ b/runway/extension/BUILD.bazel
@@ -6,3 +6,9 @@ go_library(
     importpath = "github.com/uber/submitqueue/runway/extension",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":extension",
+    visibility = ["//visibility:public"],
+)

--- a/runway/extension/merger/BUILD.bazel
+++ b/runway/extension/merger/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//api/runway/messagequeue"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":merger",
+    visibility = ["//visibility:public"],
+)

--- a/runway/extension/merger/mock/BUILD.bazel
+++ b/runway/extension/merger/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/runway/extension/merger/noop/BUILD.bazel
+++ b/runway/extension/merger/noop/BUILD.bazel
@@ -25,3 +25,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":noop",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/controller/BUILD.bazel
+++ b/stovepipe/controller/BUILD.bazel
@@ -49,3 +49,9 @@ go_test(
         "@org_uber_go_zap//:zap",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":controller",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/controller/process/BUILD.bazel
+++ b/stovepipe/controller/process/BUILD.bazel
@@ -36,3 +36,9 @@ go_test(
         "@org_uber_go_zap//:zap",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":process",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/core/messagequeue/BUILD.bazel
+++ b/stovepipe/core/messagequeue/BUILD.bazel
@@ -27,3 +27,9 @@ go_test(
         "@org_golang_google_protobuf//proto",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":messagequeue",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/core/messagequeue/protopb/BUILD.bazel
+++ b/stovepipe/core/messagequeue/protopb/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_golang_google_protobuf//runtime/protoimpl",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":protopb",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/entity/BUILD.bazel
+++ b/stovepipe/entity/BUILD.bazel
@@ -16,3 +16,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":entity",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/extension/sourcecontrol/BUILD.bazel
+++ b/stovepipe/extension/sourcecontrol/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//platform/base/page"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":sourcecontrol",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/extension/sourcecontrol/fake/BUILD.bazel
+++ b/stovepipe/extension/sourcecontrol/fake/BUILD.bazel
@@ -21,3 +21,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fake",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/extension/sourcecontrol/mock/BUILD.bazel
+++ b/stovepipe/extension/sourcecontrol/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/extension/storage/BUILD.bazel
+++ b/stovepipe/extension/storage/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//stovepipe/entity"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":storage",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/extension/storage/mock/BUILD.bazel
+++ b/stovepipe/extension/storage/mock/BUILD.bazel
@@ -15,3 +15,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/stovepipe/extension/storage/mysql/BUILD.bazel
+++ b/stovepipe/extension/storage/mysql/BUILD.bazel
@@ -17,3 +17,9 @@ go_library(
         "@com_github_uber_go_tally//:tally",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mysql",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/core/BUILD.bazel
+++ b/submitqueue/core/BUILD.bazel
@@ -6,3 +6,9 @@ go_library(
     importpath = "github.com/uber/submitqueue/submitqueue/core",
     visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":core",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/core/changeset/BUILD.bazel
+++ b/submitqueue/core/changeset/BUILD.bazel
@@ -28,3 +28,9 @@ go_test(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":changeset",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/core/changeset/fake/BUILD.bazel
+++ b/submitqueue/core/changeset/fake/BUILD.bazel
@@ -23,3 +23,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fake",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/core/changeset/mock/BUILD.bazel
+++ b/submitqueue/core/changeset/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/core/fakemarker/BUILD.bazel
+++ b/submitqueue/core/fakemarker/BUILD.bazel
@@ -17,3 +17,9 @@ go_test(
         "@com_github_stretchr_testify//assert",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fakemarker",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/core/request/BUILD.bazel
+++ b/submitqueue/core/request/BUILD.bazel
@@ -37,3 +37,9 @@ go_test(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":request",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/core/topickey/BUILD.bazel
+++ b/submitqueue/core/topickey/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//platform/consumer"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":topickey",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/entity/BUILD.bazel
+++ b/submitqueue/entity/BUILD.bazel
@@ -45,3 +45,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":entity",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/buildrunner/BUILD.bazel
+++ b/submitqueue/extension/buildrunner/BUILD.bazel
@@ -14,3 +14,9 @@ go_library(
         "//submitqueue/entity",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":buildrunner",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/buildrunner/buildkite/BUILD.bazel
+++ b/submitqueue/extension/buildrunner/buildkite/BUILD.bazel
@@ -33,3 +33,9 @@ go_test(
         "@org_uber_go_zap//:zap",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":buildkite",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/buildrunner/fake/BUILD.bazel
+++ b/submitqueue/extension/buildrunner/fake/BUILD.bazel
@@ -26,3 +26,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fake",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/buildrunner/githubactions/BUILD.bazel
+++ b/submitqueue/extension/buildrunner/githubactions/BUILD.bazel
@@ -33,3 +33,9 @@ go_test(
         "@org_uber_go_zap//:zap",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":githubactions",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/buildrunner/mock/BUILD.bazel
+++ b/submitqueue/extension/buildrunner/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/changeprovider/BUILD.bazel
+++ b/submitqueue/extension/changeprovider/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//submitqueue/entity"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":changeprovider",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/changeprovider/fake/BUILD.bazel
+++ b/submitqueue/extension/changeprovider/fake/BUILD.bazel
@@ -24,3 +24,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fake",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/changeprovider/github/BUILD.bazel
+++ b/submitqueue/extension/changeprovider/github/BUILD.bazel
@@ -40,3 +40,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":github",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/changeprovider/mock/BUILD.bazel
+++ b/submitqueue/extension/changeprovider/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/changeprovider/phabricator/BUILD.bazel
+++ b/submitqueue/extension/changeprovider/phabricator/BUILD.bazel
@@ -38,3 +38,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":phabricator",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/changeprovider/routing/BUILD.bazel
+++ b/submitqueue/extension/changeprovider/routing/BUILD.bazel
@@ -28,3 +28,9 @@ go_test(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":routing",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/conflict/BUILD.bazel
+++ b/submitqueue/extension/conflict/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//submitqueue/entity"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":conflict",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/conflict/all/BUILD.bazel
+++ b/submitqueue/extension/conflict/all/BUILD.bazel
@@ -21,3 +21,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":all",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/conflict/fake/BUILD.bazel
+++ b/submitqueue/extension/conflict/fake/BUILD.bazel
@@ -24,3 +24,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fake",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/conflict/fileoverlap/BUILD.bazel
+++ b/submitqueue/extension/conflict/fileoverlap/BUILD.bazel
@@ -23,3 +23,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fileoverlap",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/conflict/mock/BUILD.bazel
+++ b/submitqueue/extension/conflict/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/conflict/none/BUILD.bazel
+++ b/submitqueue/extension/conflict/none/BUILD.bazel
@@ -21,3 +21,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":none",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/mergechecker/BUILD.bazel
+++ b/submitqueue/extension/mergechecker/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//submitqueue/entity"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mergechecker",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/mergechecker/fake/BUILD.bazel
+++ b/submitqueue/extension/mergechecker/fake/BUILD.bazel
@@ -24,3 +24,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fake",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/mergechecker/github/BUILD.bazel
+++ b/submitqueue/extension/mergechecker/github/BUILD.bazel
@@ -39,3 +39,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":github",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/mergechecker/mock/BUILD.bazel
+++ b/submitqueue/extension/mergechecker/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/pusher/BUILD.bazel
+++ b/submitqueue/extension/pusher/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//submitqueue/entity"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":pusher",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/pusher/fake/BUILD.bazel
+++ b/submitqueue/extension/pusher/fake/BUILD.bazel
@@ -27,3 +27,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fake",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/pusher/git/BUILD.bazel
+++ b/submitqueue/extension/pusher/git/BUILD.bazel
@@ -32,3 +32,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":git",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/pusher/mock/BUILD.bazel
+++ b/submitqueue/extension/pusher/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/queueconfig/BUILD.bazel
+++ b/submitqueue/extension/queueconfig/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//submitqueue/entity"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":queueconfig",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/queueconfig/mock/BUILD.bazel
+++ b/submitqueue/extension/queueconfig/mock/BUILD.bazel
@@ -10,3 +10,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/queueconfig/yaml/BUILD.bazel
+++ b/submitqueue/extension/queueconfig/yaml/BUILD.bazel
@@ -22,3 +22,9 @@ go_test(
         "@com_github_stretchr_testify//require",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":yaml",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/scorer/BUILD.bazel
+++ b/submitqueue/extension/scorer/BUILD.bazel
@@ -7,3 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//submitqueue/entity"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":scorer",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/scorer/composite/BUILD.bazel
+++ b/submitqueue/extension/scorer/composite/BUILD.bazel
@@ -25,3 +25,9 @@ go_test(
         "@com_github_uber_go_tally//:tally",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":composite",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/scorer/fake/BUILD.bazel
+++ b/submitqueue/extension/scorer/fake/BUILD.bazel
@@ -28,3 +28,9 @@ go_test(
         "@com_github_uber_go_tally//:tally",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":fake",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/scorer/heuristic/BUILD.bazel
+++ b/submitqueue/extension/scorer/heuristic/BUILD.bazel
@@ -26,3 +26,9 @@ go_test(
         "@com_github_uber_go_tally//:tally",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":heuristic",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/scorer/mock/BUILD.bazel
+++ b/submitqueue/extension/scorer/mock/BUILD.bazel
@@ -11,3 +11,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/storage/BUILD.bazel
+++ b/submitqueue/extension/storage/BUILD.bazel
@@ -16,3 +16,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = ["//submitqueue/entity"],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":storage",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/storage/mock/BUILD.bazel
+++ b/submitqueue/extension/storage/mock/BUILD.bazel
@@ -20,3 +20,9 @@ go_library(
         "@org_uber_go_mock//gomock",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mock",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/extension/storage/mysql/BUILD.bazel
+++ b/submitqueue/extension/storage/mysql/BUILD.bazel
@@ -22,3 +22,9 @@ go_library(
         "@com_github_uber_go_tally//:tally",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mysql",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/gateway/controller/BUILD.bazel
+++ b/submitqueue/gateway/controller/BUILD.bazel
@@ -62,3 +62,9 @@ go_test(
         "@org_uber_go_zap//:zap",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":controller",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/gateway/controller/log/BUILD.bazel
+++ b/submitqueue/gateway/controller/log/BUILD.bazel
@@ -31,3 +31,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":log",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/BUILD.bazel
@@ -25,3 +25,9 @@ go_test(
         "@org_uber_go_zap//:zap",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":controller",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/batch/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/batch/BUILD.bazel
@@ -45,3 +45,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":batch",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/build/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/build/BUILD.bazel
@@ -42,3 +42,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":build",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/buildsignal/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/buildsignal/BUILD.bazel
@@ -38,3 +38,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":buildsignal",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/cancel/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/cancel/BUILD.bazel
@@ -36,3 +36,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":cancel",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/conclude/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/conclude/BUILD.bazel
@@ -36,3 +36,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":conclude",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/dlq/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/dlq/BUILD.bazel
@@ -54,3 +54,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":dlq",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/merge/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/merge/BUILD.bazel
@@ -43,3 +43,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":merge",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/mergeconflictsignal/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/mergeconflictsignal/BUILD.bazel
@@ -40,3 +40,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mergeconflictsignal",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/mergesignal/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/mergesignal/BUILD.bazel
@@ -39,3 +39,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":mergesignal",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/score/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/score/BUILD.bazel
@@ -40,3 +40,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":score",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/speculate/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/speculate/BUILD.bazel
@@ -37,3 +37,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":speculate",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/start/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/start/BUILD.bazel
@@ -40,3 +40,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":start",
+    visibility = ["//visibility:public"],
+)

--- a/submitqueue/orchestrator/controller/validate/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/validate/BUILD.bazel
@@ -47,3 +47,9 @@ go_test(
         "@org_uber_go_zap//zaptest",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":validate",
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/extension/counter/BUILD.bazel
+++ b/test/integration/extension/counter/BUILD.bazel
@@ -13,3 +13,9 @@ go_library(
         "@com_github_stretchr_testify//suite",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":counter",
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/submitqueue/extension/storage/BUILD.bazel
+++ b/test/integration/submitqueue/extension/storage/BUILD.bazel
@@ -16,3 +16,9 @@ go_library(
         "@com_github_stretchr_testify//suite",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":storage",
+    visibility = ["//visibility:public"],
+)

--- a/test/testutil/BUILD.bazel
+++ b/test/testutil/BUILD.bazel
@@ -16,3 +16,9 @@ go_library(
         "@org_golang_google_grpc//credentials/insecure",
     ],
 )
+
+alias(
+    name = "go_default_library",
+    actual = ":testutil",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
<!-- Provide a summary in the Title above. Example: "Feature: add user authentication" -->

## Why?
Some Bazel-based downstream consumers of this repo enforce their own naming convention where Go targets must be named `go_default_library`/`go_default_test`. When such a consumer uses our checked-in BUILD files directly (rather than regenerating them), our native target names don't satisfy that convention, so their consumer labels fail to resolve.

We need a fix that satisfies that requirement without renaming our own targets or breaking any other Bazel consumer relying on the native names.

This PR is addressing the same issue as #295 but use alias approach which is cheaper and less invasive.

## What?
Adds `# gazelle:go_naming_convention import_alias` to the root `BUILD.bazel` and regenerates all BUILD files via `make gazelle`.

## Test Plan
<!-- How did you test this? Provide evidence (screenshots, logs, or steps to reproduce). -->
- make gazelle - clean; re-running make gazelle produces no further diff (idempotent).
- make build - all 337 targets build.
- make test - 65/65 tests pass, with hand-authored test targets keeping their original native names (e.g. buildsignal_test, not renamed to go_default_test).
- Verified consumption from a downstream Bazel workspace using this repo directly (checked-in BUILD files, no regeneration): with a local override pointed at this checkout, successfully built and tested downstream targets against the new go_default_library alias â confirming consumer labels resolve correctly end-to-end.

## Issue
<!-- 
Link the issue here. 
- Use 'Closes #123' if this is the final fix. 
- Use 'Part of #123' or just '#123' if the feature is still in progress. 
-->
