### PR TITLE
feat(entity): give speculation paths an assigned identity

### DIFF
--- a/submitqueue/entity/speculation_tree.go
+++ b/submitqueue/entity/speculation_tree.go
@@ -98,10 +98,17 @@ const (
 
 // SpeculationPathInfo is the per-path entry in a speculation tree: a path, its
 // latest predicted-success score, its controller-owned status, and a link to
-// the build dispatched for it (if any). Path is immutable once the entry is
-// persisted; Score, Status, and BuildID are updateable, written only by the
-// controller under the tree's Version optimistic lock.
+// the build dispatched for it (if any). ID and Path are immutable once the
+// entry is persisted; Score, Status, and BuildID are updateable, written only
+// by the controller under the tree's Version optimistic lock.
 type SpeculationPathInfo struct {
+	// ID identifies this path within its tree. It is assigned by the controller
+	// when the path entry is first persisted, immutable thereafter, and unique
+	// within the tree; its format is the controller's choice and carries no
+	// meaning — never parse it. Everything outside the tree names a path by this
+	// ID: seam outputs (path scores, path decisions) and durable links from
+	// other entities all refer to it rather than restating the Base/Head split.
+	ID string
 	// Path is the Base/Head split this entry covers. Immutable: it identifies
 	// the entry and never changes after the path is first persisted.
 	Path SpeculationPath


### PR DESCRIPTION
## Summary
### Why?

The speculation seams being introduced up-stack (path scorer, selector, prioritizer) and durable links from other entities (a path→build mapping) all need to refer to one specific path inside a batch's speculation tree. Restating the full Base/Head split in every seam output couples those contracts to path structure and forces consumers to compare ordered slices; a single opaque identity lets each seam return only what matters — a path ID plus its verdict — and gives durable links a stable key to hang on.

### What?

`entity.SpeculationPathInfo` gains `ID`: assigned by the controller when the path entry is first persisted, immutable thereafter, and unique within its tree. Its format is the controller's choice and carries no meaning — it is never parsed. Everything outside the tree names a path by this ID. The tree store persists it transparently through the JSON `paths` column, so the change is additive with no schema migration.

## Test Plan
✅ `bazel test //submitqueue/entity/...` — entity suite passes; the field rides the existing JSON round-trip in the tree store.

## Issues


## Stack
1. @ #337
1. #315
1. #316
1. #317
1. #320
1. #331
1. #332
1. #333
