### PR TITLE
refactor(gateway): make StatusController operate on entities

### DIFF
--- a/service/submitqueue/gateway/server/main.go
+++ b/service/submitqueue/gateway/server/main.go
@@ -86,9 +86,14 @@ func (s *GatewayServer) Cancel(ctx context.Context, req *pb.CancelRequest) (*pb.
 	return &pb.CancelResponse{}, nil
 }
 
-// Status delegates to the controller
+// Status maps the wire request to an entity, delegates to the controller, and
+// maps the read-model result back to the wire response.
 func (s *GatewayServer) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {
-	return s.statusController.Status(ctx, req)
+	state, err := s.statusController.Status(ctx, mapper.ProtoToStatusRequest(req))
+	if err != nil {
+		return nil, err
+	}
+	return mapper.CurrentStateToProto(state), nil
 }
 
 func main() {

--- a/service/submitqueue/gateway/server/mapper/BUILD.bazel
+++ b/service/submitqueue/gateway/server/mapper/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cancel.go",
         "land.go",
+        "status.go",
     ],
     importpath = "github.com/uber/submitqueue/service/submitqueue/gateway/server/mapper",
     visibility = ["//visibility:public"],
@@ -13,6 +14,7 @@ go_library(
         "//api/submitqueue/gateway/protopb:go_default_library",
         "//platform/base/change:go_default_library",
         "//platform/base/mergestrategy:go_default_library",
+        "//submitqueue/core/request:go_default_library",
         "//submitqueue/entity:go_default_library",
     ],
 )
@@ -22,6 +24,7 @@ go_test(
     srcs = [
         "cancel_test.go",
         "land_test.go",
+        "status_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
@@ -30,6 +33,7 @@ go_test(
         "//api/submitqueue/gateway/protopb:go_default_library",
         "//platform/base/change:go_default_library",
         "//platform/base/mergestrategy:go_default_library",
+        "//submitqueue/core/request:go_default_library",
         "//submitqueue/entity:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/service/submitqueue/gateway/server/mapper/status.go
+++ b/service/submitqueue/gateway/server/mapper/status.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapper
+
+import (
+	pb "github.com/uber/submitqueue/api/submitqueue/gateway/protopb"
+	"github.com/uber/submitqueue/submitqueue/core/request"
+	"github.com/uber/submitqueue/submitqueue/entity"
+)
+
+// ProtoToStatusRequest maps the wire StatusRequest to the entity.StatusRequest
+// the controller operates on.
+func ProtoToStatusRequest(req *pb.StatusRequest) entity.StatusRequest {
+	return entity.StatusRequest{
+		ID: req.GetSqid(),
+	}
+}
+
+// CurrentStateToProto maps the domain read model to the wire StatusResponse.
+func CurrentStateToProto(state request.CurrentState) *pb.StatusResponse {
+	return &pb.StatusResponse{
+		Status:    string(state.Status),
+		LastError: state.LastError,
+		Metadata:  state.Metadata,
+	}
+}

--- a/service/submitqueue/gateway/server/mapper/status_test.go
+++ b/service/submitqueue/gateway/server/mapper/status_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	pb "github.com/uber/submitqueue/api/submitqueue/gateway/protopb"
+	"github.com/uber/submitqueue/submitqueue/core/request"
+	"github.com/uber/submitqueue/submitqueue/entity"
+)
+
+func TestProtoToStatusRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      *pb.StatusRequest
+		expected entity.StatusRequest
+	}{
+		{
+			name:     "maps sqid to ID",
+			req:      &pb.StatusRequest{Sqid: "test-queue/42"},
+			expected: entity.StatusRequest{ID: "test-queue/42"},
+		},
+		{
+			name:     "empty request yields zero value",
+			req:      &pb.StatusRequest{},
+			expected: entity.StatusRequest{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ProtoToStatusRequest(tt.req)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestCurrentStateToProto(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    request.CurrentState
+		expected *pb.StatusResponse
+	}{
+		{
+			name: "maps all fields",
+			state: request.CurrentState{
+				Status:    entity.RequestStatusValidating,
+				LastError: "validation failed",
+				Metadata:  map[string]string{"step": "lint"},
+			},
+			expected: &pb.StatusResponse{
+				Status:    string(entity.RequestStatusValidating),
+				LastError: "validation failed",
+				Metadata:  map[string]string{"step": "lint"},
+			},
+		},
+		{
+			name:  "zero value state maps to empty response",
+			state: request.CurrentState{},
+			expected: &pb.StatusResponse{
+				Status: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CurrentStateToProto(tt.state)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/submitqueue/entity/BUILD.bazel
+++ b/submitqueue/entity/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "request_summary.go",
         "speculation_path_build.go",
         "speculation_tree.go",
+        "status.go",
     ],
     importpath = "github.com/uber/submitqueue/submitqueue/entity",
     visibility = ["//visibility:public"],

--- a/submitqueue/entity/status.go
+++ b/submitqueue/entity/status.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entity
+
+// StatusRequest identifies a request whose current status is being queried.
+type StatusRequest struct {
+	// ID is the globally unique identifier of the request. Format: "<queue>/<counter_value>".
+	ID string
+}

--- a/submitqueue/gateway/controller/status.go
+++ b/submitqueue/gateway/controller/status.go
@@ -21,9 +21,9 @@ import (
 	"time"
 
 	"github.com/uber-go/tally"
-	pb "github.com/uber/submitqueue/api/submitqueue/gateway/protopb"
 	"github.com/uber/submitqueue/platform/errs"
 	"github.com/uber/submitqueue/submitqueue/core/request"
+	"github.com/uber/submitqueue/submitqueue/entity"
 	"github.com/uber/submitqueue/submitqueue/extension/storage"
 	"go.uber.org/zap"
 )
@@ -64,7 +64,7 @@ func NewStatusController(logger *zap.SugaredLogger, scope tally.Scope, requestLo
 }
 
 // Status returns the current reconciled status of a request identified by its sqid.
-func (c *StatusController) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusResponse, error) {
+func (c *StatusController) Status(ctx context.Context, req entity.StatusRequest) (request.CurrentState, error) {
 	start := time.Now()
 	defer func() {
 		c.metricsScope.Timer("status_latency").Record(time.Since(start))
@@ -72,26 +72,22 @@ func (c *StatusController) Status(ctx context.Context, req *pb.StatusRequest) (*
 
 	c.metricsScope.Counter("status_count").Inc(1)
 
-	if req.Sqid == "" {
-		return nil, fmt.Errorf("StatusController requires the request to have a sqid specified: %w", ErrInvalidRequest)
+	if req.ID == "" {
+		return request.CurrentState{}, fmt.Errorf("StatusController requires the request to have a sqid specified: %w", ErrInvalidRequest)
 	}
 
-	state, err := request.GetCurrentStateFromRequestLog(ctx, c.requestLogStore, req.Sqid)
+	state, err := request.GetCurrentStateFromRequestLog(ctx, c.requestLogStore, req.ID)
 	if err != nil {
 		if storage.IsNotFound(err) {
-			return nil, errs.NewUserError(&RequestNotFoundError{Sqid: req.Sqid})
+			return request.CurrentState{}, errs.NewUserError(&RequestNotFoundError{Sqid: req.ID})
 		}
-		return nil, fmt.Errorf("StatusController failed to get current state for sqid=%s: %w", req.Sqid, err)
+		return request.CurrentState{}, fmt.Errorf("StatusController failed to get current state for sqid=%s: %w", req.ID, err)
 	}
 
 	c.logger.Debugw("request status retrieved",
-		"sqid", req.Sqid,
+		"sqid", req.ID,
 		"status", string(state.Status),
 	)
 
-	return &pb.StatusResponse{
-		Status:    string(state.Status),
-		LastError: state.LastError,
-		Metadata:  state.Metadata,
-	}, nil
+	return state, nil
 }

--- a/submitqueue/gateway/controller/status_test.go
+++ b/submitqueue/gateway/controller/status_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
-	pb "github.com/uber/submitqueue/api/submitqueue/gateway/protopb"
 	"github.com/uber/submitqueue/platform/errs"
 	"github.com/uber/submitqueue/submitqueue/entity"
 	"github.com/uber/submitqueue/submitqueue/extension/storage"
@@ -42,12 +41,12 @@ func TestStatus_ReturnsCurrentState(t *testing.T) {
 
 	controller := NewStatusController(zap.NewNop().Sugar(), tally.NoopScope, store)
 
-	resp, err := controller.Status(context.Background(), &pb.StatusRequest{Sqid: "test-queue/1"})
+	state, err := controller.Status(context.Background(), entity.StatusRequest{ID: "test-queue/1"})
 
 	require.NoError(t, err)
-	assert.Equal(t, string(entity.RequestStatusValidating), resp.Status)
-	assert.Equal(t, "boom", resp.LastError)
-	assert.Equal(t, map[string]string{"k": "v"}, resp.Metadata)
+	assert.Equal(t, entity.RequestStatusValidating, state.Status)
+	assert.Equal(t, "boom", state.LastError)
+	assert.Equal(t, map[string]string{"k": "v"}, state.Metadata)
 }
 
 func TestStatus_Errors(t *testing.T) {
@@ -93,12 +92,9 @@ func TestStatus_Errors(t *testing.T) {
 
 			controller := NewStatusController(zap.NewNop().Sugar(), tally.NoopScope, store)
 
-			_, err := controller.Status(context.Background(), &pb.StatusRequest{Sqid: tt.sqid})
+			_, err := controller.Status(context.Background(), entity.StatusRequest{ID: tt.sqid})
 
 			require.Error(t, err)
-			// IsRequestNotFound is a precise type check; IsInvalidRequest matches any
-			// user error (see errs.userError.Is), so only assert it where it is the
-			// defining classification.
 			assert.Equal(t, tt.wantNotFound, IsRequestNotFound(err))
 			assert.Equal(t, tt.wantUserError, errs.IsUserError(err))
 			assert.False(t, errs.IsRetryable(err))


### PR DESCRIPTION
## Summary
Remove proto coupling from StatusController.Status by changing its signature
to accept entity.StatusRequest and return request.CurrentState directly.

Add mapper.ProtoToStatusRequest and mapper.CurrentStateToProto in the mapper
subpackage. The Status mapper is the first with a non-trivial entity-to-proto
direction (translating the CurrentState read model into pb.StatusResponse).

Add entity.StatusRequest{ID} for input consistency with the other controllers.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Test Plan


## Issues


## Stack
1. #359
1. #360
1. @ #363
1. #361
