### PR TITLE
Add StatusResult type alias for consistent naming

### DIFF
--- a/submitqueue/gateway/controller/status.go
+++ b/submitqueue/gateway/controller/status.go
@@ -63,8 +63,13 @@ func NewStatusController(logger *zap.SugaredLogger, scope tally.Scope, requestLo
 	}
 }
 
+// StatusResult is the outcome of a status query. It is a type alias for
+// request.CurrentState so that the controller's return type follows the
+// same Result naming convention as LandResult and other controller outputs.
+type StatusResult = request.CurrentState
+
 // Status returns the current reconciled status of a request identified by its sqid.
-func (c *StatusController) Status(ctx context.Context, req entity.StatusRequest) (request.CurrentState, error) {
+func (c *StatusController) Status(ctx context.Context, req entity.StatusRequest) (StatusResult, error) {
 	start := time.Now()
 	defer func() {
 		c.metricsScope.Timer("status_latency").Record(time.Since(start))
@@ -73,15 +78,15 @@ func (c *StatusController) Status(ctx context.Context, req entity.StatusRequest)
 	c.metricsScope.Counter("status_count").Inc(1)
 
 	if req.ID == "" {
-		return request.CurrentState{}, fmt.Errorf("StatusController requires the request to have a sqid specified: %w", ErrInvalidRequest)
+		return StatusResult{}, fmt.Errorf("StatusController requires the request to have a sqid specified: %w", ErrInvalidRequest)
 	}
 
 	state, err := request.GetCurrentStateFromRequestLog(ctx, c.requestLogStore, req.ID)
 	if err != nil {
 		if storage.IsNotFound(err) {
-			return request.CurrentState{}, errs.NewUserError(&RequestNotFoundError{Sqid: req.ID})
+			return StatusResult{}, errs.NewUserError(&RequestNotFoundError{Sqid: req.ID})
 		}
-		return request.CurrentState{}, fmt.Errorf("StatusController failed to get current state for sqid=%s: %w", req.ID, err)
+		return StatusResult{}, fmt.Errorf("StatusController failed to get current state for sqid=%s: %w", req.ID, err)
 	}
 
 	c.logger.Debugw("request status retrieved",


### PR DESCRIPTION
## Summary
Currently, the Land and Cancel controllers return a LandResult and CancelResult, respectively. The StatusResult is returning a request.CurrentState struct, which causes inconsistency in the naming convention. I'm adding a StatusResult type alias for request.CurrentState in the status controller, matching the naming convention used by other controllers.

I'm choosing to do this, rather than creating a separate entity.StatusResult struct with the same fields as request.CurrentState to avoid the duplication and boilerplate mapping code that would be required. If the desired fields in the request.CurrentState struct and Status() response diverge in the future, we can create a separate entity.StatusResult, like the other endpoints/controllers have.

## Test Plan
Unit tests
