### PR TITLE
feat(platform): add pipeline.Construct engine

### DIFF
--- a/platform/pipeline/BUILD.bazel
+++ b/platform/pipeline/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["pipeline.go"],
+    importpath = "github.com/uber/submitqueue/platform/pipeline",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//platform/consumer:go_default_library",
+        "//platform/errs:go_default_library",
+        "//platform/extension/messagequeue:go_default_library",
+        "//platform/lifecycle:go_default_library",
+        "@com_github_uber_go_tally//:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["pipeline_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//platform/consumer:go_default_library",
+        "//platform/extension/messagequeue:go_default_library",
+        "//platform/extension/messagequeue/mock:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@com_github_uber_go_tally//:go_default_library",
+        "@org_uber_go_mock//gomock:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)

--- a/platform/pipeline/BUILD.bazel
+++ b/platform/pipeline/BUILD.bazel
@@ -8,6 +8,8 @@ go_library(
     deps = [
         "//platform/consumer:go_default_library",
         "//platform/errs:go_default_library",
+        "//platform/extension/consumergate:go_default_library",
+        "//platform/extension/consumergate/noop:go_default_library",
         "//platform/extension/messagequeue:go_default_library",
         "//platform/lifecycle:go_default_library",
         "@com_github_uber_go_tally//:go_default_library",

--- a/platform/pipeline/pipeline.go
+++ b/platform/pipeline/pipeline.go
@@ -49,16 +49,33 @@ type Stage[D any] struct {
 	// (e.g. "orchestrator-start").
 	ConsumerGroup string
 
-	// New builds the stage's controller from the service's Deps. The engine
-	// calls it once, eagerly, inside Construct — so a nil/missing dependency
-	// fails at boot with the stage's name on it, never mid-delivery.
-	New func(D) (consumer.Controller, error)
+	// New builds the stage's controller from the service's Deps and engine-
+	// provided StageContext. The engine calls it once, eagerly, inside
+	// Construct — so a nil/missing dependency fails at boot with the stage's
+	// name on it, never mid-delivery.
+	New func(D, StageContext) (consumer.Controller, error)
 
 	// DLQ, when non-nil, declares "this stage dead-letters". The engine then
 	// derives the paired DLQ topic (<topic>_dlq, retry budget, DLQ-of-DLQ
 	// disabled) AND registers this reconciler on the DLQ consumer. Declaring
 	// one without getting the other is impossible — that's the invariant.
-	DLQ func(D) (consumer.Controller, error)
+	DLQ func(D, StageContext) (consumer.Controller, error)
+}
+
+// StageContext carries engine-produced values that controllers need at
+// construction time but the host does not own: the assembled topic
+// registry (for publishing to downstream stages), the stage's own topic
+// key, and its consumer group.
+type StageContext struct {
+	// Registry is the fully assembled TopicRegistry. Controllers use it to
+	// look up topic names and queue backends for publishing downstream.
+	Registry consumer.TopicRegistry
+
+	// TopicKey is this stage's logical topic key.
+	TopicKey consumer.TopicKey
+
+	// ConsumerGroup is this stage's consumer group name.
+	ConsumerGroup string
 }
 
 // PublishOnlyTopic declares a topic the service publishes to but does not
@@ -166,7 +183,13 @@ func Construct[D any](
 
 	// Eagerly construct and register all controllers.
 	for _, s := range stages {
-		ctl, err := s.New(deps)
+		sc := StageContext{
+			Registry:      registry,
+			TopicKey:      s.Key,
+			ConsumerGroup: s.ConsumerGroup,
+		}
+
+		ctl, err := s.New(deps, sc)
 		if err != nil {
 			return nil, fmt.Errorf("pipeline: stage %s: failed to create controller: %w", s.Key, err)
 		}
@@ -175,7 +198,12 @@ func Construct[D any](
 		}
 
 		if s.DLQ != nil {
-			rec, err := s.DLQ(deps)
+			dlqSC := StageContext{
+				Registry:      registry,
+				TopicKey:      dlqTopicKey(s.Key),
+				ConsumerGroup: s.ConsumerGroup + "-dlq",
+			}
+			rec, err := s.DLQ(deps, dlqSC)
 			if err != nil {
 				return nil, fmt.Errorf("pipeline: stage %s dlq: failed to create controller: %w", s.Key, err)
 			}

--- a/platform/pipeline/pipeline.go
+++ b/platform/pipeline/pipeline.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pipeline provides a typed engine for assembling queue-driven
+// service pipelines from declarative data. A service declares its topology
+// as a []Stage[D] table and its dependencies as a Deps struct; Construct
+// builds all consumers, registers controllers, pairs DLQ stages, and
+// returns a single lifecycle.Component the host drives with Start/Stop.
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/uber-go/tally"
+	"github.com/uber/submitqueue/platform/consumer"
+	"github.com/uber/submitqueue/platform/errs"
+	extqueue "github.com/uber/submitqueue/platform/extension/messagequeue"
+	"github.com/uber/submitqueue/platform/lifecycle"
+	"go.uber.org/zap"
+)
+
+// timeNow is a hook for tests to control time. Production uses time.Now.
+var timeNow = time.Now
+
+// Stage is one row of a service's topology table. D is the service's Deps type.
+type Stage[D any] struct {
+	// Key is the stage's logical topic key (e.g. topickey.TopicKeyStart).
+	// The engine maps it to a physical topic name via the TopicNames option.
+	Key consumer.TopicKey
+
+	// Name is the physical topic name for this stage (e.g. "start").
+	// Used as the default when no TopicNames override is provided.
+	Name string
+
+	// ConsumerGroup is the consumer group suffix for this stage's subscription
+	// (e.g. "orchestrator-start").
+	ConsumerGroup string
+
+	// New builds the stage's controller from the service's Deps. The engine
+	// calls it once, eagerly, inside Construct — so a nil/missing dependency
+	// fails at boot with the stage's name on it, never mid-delivery.
+	New func(D) (consumer.Controller, error)
+
+	// DLQ, when non-nil, declares "this stage dead-letters". The engine then
+	// derives the paired DLQ topic (<topic>_dlq, retry budget, DLQ-of-DLQ
+	// disabled) AND registers this reconciler on the DLQ consumer. Declaring
+	// one without getting the other is impossible — that's the invariant.
+	DLQ func(D) (consumer.Controller, error)
+}
+
+// PublishOnlyTopic declares a topic the service publishes to but does not
+// consume. The engine registers it in the TopicRegistry so controllers
+// can publish to it, but creates no subscription or controller.
+type PublishOnlyTopic struct {
+	// Key is the logical topic key.
+	Key consumer.TopicKey
+
+	// Name is the physical topic name.
+	Name string
+}
+
+// options holds the resolved configuration for a Construct call.
+type options struct {
+	topicNames      map[consumer.TopicKey]string
+	classifiers     []errs.Classifier
+	publishOnly     []PublishOnlyTopic
+	extraComponents []lifecycle.Component
+}
+
+// Option configures a Construct call.
+type Option func(*options)
+
+// TopicNames provides a mapping from logical topic keys to physical topic
+// names. Keys not present in the map fall back to the Stage.Name default.
+func TopicNames(m map[consumer.TopicKey]string) Option {
+	return func(o *options) { o.topicNames = m }
+}
+
+// Classifiers sets the error classifiers for the primary consumer's
+// ErrorProcessor. DLQ consumers always use AlwaysRetryableProcessor.
+func Classifiers(c ...errs.Classifier) Option {
+	return func(o *options) { o.classifiers = c }
+}
+
+// PublishOnly adds topics the service publishes to but does not consume.
+func PublishOnly(topics ...PublishOnlyTopic) Option {
+	return func(o *options) { o.publishOnly = append(o.publishOnly, topics...) }
+}
+
+// ExtraComponents adds lifecycle components that are started before
+// consumers and stopped after them.
+func ExtraComponents(c ...lifecycle.Component) Option {
+	return func(o *options) { o.extraComponents = append(o.extraComponents, c...) }
+}
+
+// dlqTopicKey returns the DLQ topic key for a primary stage key.
+// Matches the convention in submitqueue/orchestrator/controller/dlq.TopicKey.
+const dlqTopicSuffix = "_dlq"
+
+func dlqTopicKey(primary consumer.TopicKey) consumer.TopicKey {
+	return consumer.TopicKey(string(primary) + dlqTopicSuffix)
+}
+
+// Construct is the single assembly function for a queue-driven service.
+// It builds the topic registry, creates primary and DLQ consumers,
+// eagerly constructs all controllers, and returns a lifecycle.Component
+// that starts and stops everything in the correct order.
+//
+// The returned Component starts in this order:
+//  1. Extra components (infrastructure)
+//  2. Primary consumer (work-accepting)
+//  3. DLQ consumer (reconciliation)
+//
+// Stop reverses the order: DLQ consumer drains first, then primary, then
+// infrastructure.
+func Construct[D any](
+	logger *zap.SugaredLogger,
+	scope tally.Scope,
+	queue extqueue.Queue,
+	subscriberName string,
+	deps D,
+	stages []Stage[D],
+	opts ...Option,
+) (lifecycle.Component, error) {
+	if len(stages) == 0 {
+		return nil, fmt.Errorf("pipeline: at least one stage is required")
+	}
+
+	o := &options{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Build topic configs for the registry.
+	configs, err := buildTopicConfigs(queue, subscriberName, stages, o)
+	if err != nil {
+		return nil, err
+	}
+
+	registry, err := consumer.NewTopicRegistry(configs)
+	if err != nil {
+		return nil, fmt.Errorf("pipeline: failed to create topic registry: %w", err)
+	}
+
+	// Create the primary consumer with user-provided classifiers.
+	primaryProcessor := errs.NewClassifierProcessor(o.classifiers...)
+	primary := consumer.New(logger, scope, registry, primaryProcessor)
+
+	// Create the DLQ consumer with always-retryable processor.
+	dlq := consumer.New(logger, scope, registry, errs.AlwaysRetryableProcessor)
+
+	hasDLQ := false
+
+	// Eagerly construct and register all controllers.
+	for _, s := range stages {
+		ctl, err := s.New(deps)
+		if err != nil {
+			return nil, fmt.Errorf("pipeline: stage %s: failed to create controller: %w", s.Key, err)
+		}
+		if err := primary.Register(ctl); err != nil {
+			return nil, fmt.Errorf("pipeline: stage %s: failed to register controller: %w", s.Key, err)
+		}
+
+		if s.DLQ != nil {
+			rec, err := s.DLQ(deps)
+			if err != nil {
+				return nil, fmt.Errorf("pipeline: stage %s dlq: failed to create controller: %w", s.Key, err)
+			}
+			if err := dlq.Register(rec); err != nil {
+				return nil, fmt.Errorf("pipeline: stage %s dlq: failed to register controller: %w", s.Key, err)
+			}
+			hasDLQ = true
+		}
+	}
+
+	// Compose the lifecycle group.
+	members := make([]lifecycle.Component, 0, len(o.extraComponents)+2)
+	members = append(members, o.extraComponents...)
+	members = append(members, &consumerComponent{name: "primary", c: primary})
+	if hasDLQ {
+		members = append(members, &consumerComponent{name: "dlq", c: dlq})
+	}
+
+	return lifecycle.NewGroup(members...), nil
+}
+
+// buildTopicConfigs constructs the []consumer.TopicConfig from stages and options.
+func buildTopicConfigs[D any](
+	queue extqueue.Queue,
+	subscriberName string,
+	stages []Stage[D],
+	o *options,
+) ([]consumer.TopicConfig, error) {
+	// Pre-size: each stage gets a primary config + optional DLQ config,
+	// plus publish-only topics.
+	configs := make([]consumer.TopicConfig, 0, 2*len(stages)+len(o.publishOnly))
+
+	for _, s := range stages {
+		topicName := resolveTopicName(s.Key, s.Name, o.topicNames)
+
+		configs = append(configs, consumer.TopicConfig{
+			Key:   s.Key,
+			Name:  topicName,
+			Queue: queue,
+			Subscription: extqueue.DefaultSubscriptionConfig(
+				subscriberName, s.ConsumerGroup,
+			),
+		})
+
+		if s.DLQ != nil {
+			configs = append(configs, consumer.TopicConfig{
+				Key:   dlqTopicKey(s.Key),
+				Name:  topicName + dlqTopicSuffix,
+				Queue: queue,
+				Subscription: extqueue.DLQSubscriptionConfig(
+					subscriberName, s.ConsumerGroup+"-dlq",
+				),
+			})
+		}
+	}
+
+	for _, p := range o.publishOnly {
+		topicName := resolveTopicName(p.Key, p.Name, o.topicNames)
+		configs = append(configs, consumer.TopicConfig{
+			Key:   p.Key,
+			Name:  topicName,
+			Queue: queue,
+		})
+	}
+
+	return configs, nil
+}
+
+// resolveTopicName returns the override name if present, otherwise the default.
+func resolveTopicName(key consumer.TopicKey, defaultName string, overrides map[consumer.TopicKey]string) string {
+	if overrides != nil {
+		if name, ok := overrides[key]; ok {
+			return name
+		}
+	}
+	return defaultName
+}
+
+// consumerComponent adapts consumer.Consumer to lifecycle.Component.
+// Consumer.Stop takes a timeoutMs int64; Component.Stop takes a context.
+// We derive the timeout from the context's deadline if set, defaulting to 30s.
+type consumerComponent struct {
+	name string
+	c    consumer.Consumer
+}
+
+func (a *consumerComponent) Start(ctx context.Context) error {
+	return a.c.Start(ctx)
+}
+
+func (a *consumerComponent) Stop(ctx context.Context) error {
+	const defaultStopTimeoutMs = 30000
+	timeoutMs := int64(defaultStopTimeoutMs)
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := deadline.Sub(timeNow())
+		if remaining > 0 {
+			timeoutMs = remaining.Milliseconds()
+		} else {
+			timeoutMs = 0
+		}
+	}
+	return a.c.Stop(timeoutMs)
+}

--- a/platform/pipeline/pipeline.go
+++ b/platform/pipeline/pipeline.go
@@ -27,6 +27,8 @@ import (
 	"github.com/uber-go/tally"
 	"github.com/uber/submitqueue/platform/consumer"
 	"github.com/uber/submitqueue/platform/errs"
+	"github.com/uber/submitqueue/platform/extension/consumergate"
+	consumergatenoop "github.com/uber/submitqueue/platform/extension/consumergate/noop"
 	extqueue "github.com/uber/submitqueue/platform/extension/messagequeue"
 	"github.com/uber/submitqueue/platform/lifecycle"
 	"go.uber.org/zap"
@@ -94,6 +96,7 @@ type PublishOnlyTopic struct {
 type options struct {
 	topicNames      map[consumer.TopicKey]string
 	classifiers     []errs.Classifier
+	gate            consumergate.Gate
 	publishOnly     []PublishOnlyTopic
 	extraComponents []lifecycle.Component
 }
@@ -111,6 +114,13 @@ func TopicNames(m map[consumer.TopicKey]string) Option {
 // ErrorProcessor. DLQ consumers always use AlwaysRetryableProcessor.
 func Classifiers(c ...errs.Classifier) Option {
 	return func(o *options) { o.classifiers = c }
+}
+
+// Gate sets the consumer gate for runtime stop/start of individual
+// controllers. Both the primary and DLQ consumers share the same gate.
+// When not set, a no-op gate is used (all controllers always admitted).
+func Gate(g consumergate.Gate) Option {
+	return func(o *options) { o.gate = g }
 }
 
 // PublishOnly adds topics the service publishes to but does not consume.
@@ -162,6 +172,11 @@ func Construct[D any](
 		opt(o)
 	}
 
+	// Default to no-op gate when none is provided.
+	if o.gate == nil {
+		o.gate = consumergatenoop.New()
+	}
+
 	// Build topic configs for the registry.
 	configs, err := buildTopicConfigs(queue, subscriberName, stages, o)
 	if err != nil {
@@ -175,10 +190,10 @@ func Construct[D any](
 
 	// Create the primary consumer with user-provided classifiers.
 	primaryProcessor := errs.NewClassifierProcessor(o.classifiers...)
-	primary := consumer.New(logger, scope, registry, primaryProcessor)
+	primary := consumer.New(logger, scope, registry, primaryProcessor, o.gate)
 
 	// Create the DLQ consumer with always-retryable processor.
-	dlq := consumer.New(logger, scope, registry, errs.AlwaysRetryableProcessor)
+	dlq := consumer.New(logger, scope, registry, errs.AlwaysRetryableProcessor, o.gate)
 
 	// Eagerly construct and register all controllers.
 	for _, s := range stages {

--- a/platform/pipeline/pipeline.go
+++ b/platform/pipeline/pipeline.go
@@ -45,8 +45,8 @@ type Stage[D any] struct {
 	// Used as the default when no TopicNames override is provided.
 	Name string
 
-	// ConsumerGroup is the consumer group suffix for this stage's subscription
-	// (e.g. "orchestrator-start").
+	// ConsumerGroup is the consumer group for this stage's subscription
+	// (e.g. "orchestrator").
 	ConsumerGroup string
 
 	// New builds the stage's controller from the service's Deps and engine-
@@ -55,10 +55,11 @@ type Stage[D any] struct {
 	// name on it, never mid-delivery.
 	New func(D, StageContext) (consumer.Controller, error)
 
-	// DLQ, when non-nil, declares "this stage dead-letters". The engine then
-	// derives the paired DLQ topic (<topic>_dlq, retry budget, DLQ-of-DLQ
-	// disabled) AND registers this reconciler on the DLQ consumer. Declaring
-	// one without getting the other is impossible — that's the invariant.
+	// DLQ builds the stage's dead-letter reconciler. Every stage must declare
+	// one: the queue infrastructure always creates a DLQ topic, so not
+	// processing it silently accumulates messages. The engine derives the
+	// paired DLQ topic (<topic>_dlq, retry budget, DLQ-of-DLQ disabled) and
+	// registers this reconciler on the DLQ consumer automatically.
 	DLQ func(D, StageContext) (consumer.Controller, error)
 }
 
@@ -179,10 +180,12 @@ func Construct[D any](
 	// Create the DLQ consumer with always-retryable processor.
 	dlq := consumer.New(logger, scope, registry, errs.AlwaysRetryableProcessor)
 
-	hasDLQ := false
-
 	// Eagerly construct and register all controllers.
 	for _, s := range stages {
+		if s.DLQ == nil {
+			return nil, fmt.Errorf("pipeline: stage %s: DLQ handler is required (every topic gets a DLQ)", s.Key)
+		}
+
 		sc := StageContext{
 			Registry:      registry,
 			TopicKey:      s.Key,
@@ -197,20 +200,17 @@ func Construct[D any](
 			return nil, fmt.Errorf("pipeline: stage %s: failed to register controller: %w", s.Key, err)
 		}
 
-		if s.DLQ != nil {
-			dlqSC := StageContext{
-				Registry:      registry,
-				TopicKey:      dlqTopicKey(s.Key),
-				ConsumerGroup: s.ConsumerGroup + "-dlq",
-			}
-			rec, err := s.DLQ(deps, dlqSC)
-			if err != nil {
-				return nil, fmt.Errorf("pipeline: stage %s dlq: failed to create controller: %w", s.Key, err)
-			}
-			if err := dlq.Register(rec); err != nil {
-				return nil, fmt.Errorf("pipeline: stage %s dlq: failed to register controller: %w", s.Key, err)
-			}
-			hasDLQ = true
+		dlqSC := StageContext{
+			Registry:      registry,
+			TopicKey:      dlqTopicKey(s.Key),
+			ConsumerGroup: s.ConsumerGroup + "-dlq",
+		}
+		rec, err := s.DLQ(deps, dlqSC)
+		if err != nil {
+			return nil, fmt.Errorf("pipeline: stage %s dlq: failed to create controller: %w", s.Key, err)
+		}
+		if err := dlq.Register(rec); err != nil {
+			return nil, fmt.Errorf("pipeline: stage %s dlq: failed to register controller: %w", s.Key, err)
 		}
 	}
 
@@ -218,9 +218,7 @@ func Construct[D any](
 	members := make([]lifecycle.Component, 0, len(o.extraComponents)+2)
 	members = append(members, o.extraComponents...)
 	members = append(members, &consumerComponent{name: "primary", c: primary})
-	if hasDLQ {
-		members = append(members, &consumerComponent{name: "dlq", c: dlq})
-	}
+	members = append(members, &consumerComponent{name: "dlq", c: dlq})
 
 	return lifecycle.NewGroup(members...), nil
 }
@@ -232,7 +230,7 @@ func buildTopicConfigs[D any](
 	stages []Stage[D],
 	o *options,
 ) ([]consumer.TopicConfig, error) {
-	// Pre-size: each stage gets a primary config + optional DLQ config,
+	// Pre-size: each stage gets a primary config + DLQ config,
 	// plus publish-only topics.
 	configs := make([]consumer.TopicConfig, 0, 2*len(stages)+len(o.publishOnly))
 
@@ -248,16 +246,14 @@ func buildTopicConfigs[D any](
 			),
 		})
 
-		if s.DLQ != nil {
-			configs = append(configs, consumer.TopicConfig{
-				Key:   dlqTopicKey(s.Key),
-				Name:  topicName + dlqTopicSuffix,
-				Queue: queue,
-				Subscription: extqueue.DLQSubscriptionConfig(
-					subscriberName, s.ConsumerGroup+"-dlq",
-				),
-			})
-		}
+		configs = append(configs, consumer.TopicConfig{
+			Key:   dlqTopicKey(s.Key),
+			Name:  topicName + dlqTopicSuffix,
+			Queue: queue,
+			Subscription: extqueue.DLQSubscriptionConfig(
+				subscriberName, s.ConsumerGroup+"-dlq",
+			),
+		})
 	}
 
 	for _, p := range o.publishOnly {

--- a/platform/pipeline/pipeline_test.go
+++ b/platform/pipeline/pipeline_test.go
@@ -62,8 +62,8 @@ func TestConstruct_SingleStage_NoDLQ(t *testing.T) {
 			Key:           "start",
 			Name:          "start",
 			ConsumerGroup: "orchestrator-start",
-			New: func(d testDeps) (consumer.Controller, error) {
-				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
 	}
@@ -85,11 +85,11 @@ func TestConstruct_WithDLQ(t *testing.T) {
 			Key:           "start",
 			Name:          "start",
 			ConsumerGroup: "orchestrator-start",
-			New: func(d testDeps) (consumer.Controller, error) {
-				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
-			DLQ: func(d testDeps) (consumer.Controller, error) {
-				return &fakeController{key: "start_dlq", group: "orchestrator-start-dlq"}, nil
+			DLQ: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
 	}
@@ -111,19 +111,19 @@ func TestConstruct_MultipleStages(t *testing.T) {
 			Key:           "start",
 			Name:          "start",
 			ConsumerGroup: "orchestrator-start",
-			New: func(d testDeps) (consumer.Controller, error) {
-				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
 		{
 			Key:           "validate",
 			Name:          "validate",
 			ConsumerGroup: "orchestrator-validate",
-			New: func(d testDeps) (consumer.Controller, error) {
-				return &fakeController{key: "validate", group: "orchestrator-validate"}, nil
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
-			DLQ: func(d testDeps) (consumer.Controller, error) {
-				return &fakeController{key: "validate_dlq", group: "orchestrator-validate-dlq"}, nil
+			DLQ: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
 	}
@@ -155,7 +155,7 @@ func TestConstruct_ControllerCreationFailure(t *testing.T) {
 			Key:           "start",
 			Name:          "start",
 			ConsumerGroup: "orchestrator-start",
-			New: func(d testDeps) (consumer.Controller, error) {
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return nil, fmt.Errorf("missing dependency")
 			},
 		},
@@ -179,10 +179,10 @@ func TestConstruct_DLQControllerCreationFailure(t *testing.T) {
 			Key:           "start",
 			Name:          "start",
 			ConsumerGroup: "orchestrator-start",
-			New: func(d testDeps) (consumer.Controller, error) {
-				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
-			DLQ: func(d testDeps) (consumer.Controller, error) {
+			DLQ: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return nil, fmt.Errorf("dlq dependency missing")
 			},
 		},
@@ -206,8 +206,8 @@ func TestConstruct_WithPublishOnly(t *testing.T) {
 			Key:           "start",
 			Name:          "start",
 			ConsumerGroup: "orchestrator-start",
-			New: func(d testDeps) (consumer.Controller, error) {
-				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
 	}
@@ -234,8 +234,8 @@ func TestConstruct_WithTopicNameOverrides(t *testing.T) {
 			Key:           "start",
 			Name:          "start",
 			ConsumerGroup: "orchestrator-start",
-			New: func(d testDeps) (consumer.Controller, error) {
-				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
 	}
@@ -247,6 +247,46 @@ func TestConstruct_WithTopicNameOverrides(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.NotNil(t, comp)
+}
+
+func TestConstruct_StageContext_Populated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
+	q.EXPECT().Publisher().Return(mqmock.NewMockPublisher(ctrl)).AnyTimes()
+
+	deps := testDeps{logger: newTestLogger()}
+
+	var primarySC, dlqSC StageContext
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator-start",
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				primarySC = sc
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
+			},
+			DLQ: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				dlqSC = sc
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
+			},
+		},
+	}
+
+	_, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, stages)
+	require.NoError(t, err)
+
+	// Primary StageContext should have the stage's own key and group.
+	assert.Equal(t, consumer.TopicKey("start"), primarySC.TopicKey)
+	assert.Equal(t, "orchestrator-start", primarySC.ConsumerGroup)
+
+	// DLQ StageContext should have the derived DLQ key and group.
+	assert.Equal(t, consumer.TopicKey("start_dlq"), dlqSC.TopicKey)
+	assert.Equal(t, "orchestrator-start-dlq", dlqSC.ConsumerGroup)
+
+	// Both should share the same registry.
+	assert.Equal(t, primarySC.Registry, dlqSC.Registry)
 }
 
 func TestResolveTopicName(t *testing.T) {
@@ -308,14 +348,14 @@ func TestBuildTopicConfigs(t *testing.T) {
 			Key:           "start",
 			Name:          "start",
 			ConsumerGroup: "orchestrator-start",
-			New:           func(d testDeps) (consumer.Controller, error) { return nil, nil },
-			DLQ:           func(d testDeps) (consumer.Controller, error) { return nil, nil },
+			New:           func(d testDeps, sc StageContext) (consumer.Controller, error) { return nil, nil },
+			DLQ:           func(d testDeps, sc StageContext) (consumer.Controller, error) { return nil, nil },
 		},
 		{
 			Key:           "validate",
 			Name:          "validate",
 			ConsumerGroup: "orchestrator-validate",
-			New:           func(d testDeps) (consumer.Controller, error) { return nil, nil },
+			New:           func(d testDeps, sc StageContext) (consumer.Controller, error) { return nil, nil },
 			// No DLQ for this stage.
 		},
 	}

--- a/platform/pipeline/pipeline_test.go
+++ b/platform/pipeline/pipeline_test.go
@@ -1,0 +1,357 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"github.com/uber/submitqueue/platform/consumer"
+	extqueue "github.com/uber/submitqueue/platform/extension/messagequeue"
+	mqmock "github.com/uber/submitqueue/platform/extension/messagequeue/mock"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+)
+
+// testDeps is a minimal Deps type for testing.
+type testDeps struct {
+	logger *zap.SugaredLogger
+}
+
+// fakeController satisfies consumer.Controller for testing.
+type fakeController struct {
+	key   consumer.TopicKey
+	group string
+}
+
+func (f *fakeController) Process(_ context.Context, _ consumer.Delivery) error { return nil }
+func (f *fakeController) Name() string                                         { return string(f.key) }
+func (f *fakeController) TopicKey() consumer.TopicKey                          { return f.key }
+func (f *fakeController) ConsumerGroup() string                                { return f.group }
+
+func newTestLogger() *zap.SugaredLogger {
+	l, _ := zap.NewDevelopment()
+	return l.Sugar()
+}
+
+func TestConstruct_SingleStage_NoDLQ(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
+	q.EXPECT().Publisher().Return(mqmock.NewMockPublisher(ctrl)).AnyTimes()
+
+	deps := testDeps{logger: newTestLogger()}
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator-start",
+			New: func(d testDeps) (consumer.Controller, error) {
+				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			},
+		},
+	}
+
+	comp, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, stages)
+	require.NoError(t, err)
+	assert.NotNil(t, comp)
+}
+
+func TestConstruct_WithDLQ(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
+	q.EXPECT().Publisher().Return(mqmock.NewMockPublisher(ctrl)).AnyTimes()
+
+	deps := testDeps{logger: newTestLogger()}
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator-start",
+			New: func(d testDeps) (consumer.Controller, error) {
+				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			},
+			DLQ: func(d testDeps) (consumer.Controller, error) {
+				return &fakeController{key: "start_dlq", group: "orchestrator-start-dlq"}, nil
+			},
+		},
+	}
+
+	comp, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, stages)
+	require.NoError(t, err)
+	assert.NotNil(t, comp)
+}
+
+func TestConstruct_MultipleStages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
+	q.EXPECT().Publisher().Return(mqmock.NewMockPublisher(ctrl)).AnyTimes()
+
+	deps := testDeps{logger: newTestLogger()}
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator-start",
+			New: func(d testDeps) (consumer.Controller, error) {
+				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			},
+		},
+		{
+			Key:           "validate",
+			Name:          "validate",
+			ConsumerGroup: "orchestrator-validate",
+			New: func(d testDeps) (consumer.Controller, error) {
+				return &fakeController{key: "validate", group: "orchestrator-validate"}, nil
+			},
+			DLQ: func(d testDeps) (consumer.Controller, error) {
+				return &fakeController{key: "validate_dlq", group: "orchestrator-validate-dlq"}, nil
+			},
+		},
+	}
+
+	comp, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, stages)
+	require.NoError(t, err)
+	assert.NotNil(t, comp)
+}
+
+func TestConstruct_EmptyStages_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+
+	deps := testDeps{logger: newTestLogger()}
+	_, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one stage is required")
+}
+
+func TestConstruct_ControllerCreationFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
+	q.EXPECT().Publisher().Return(mqmock.NewMockPublisher(ctrl)).AnyTimes()
+
+	deps := testDeps{logger: newTestLogger()}
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator-start",
+			New: func(d testDeps) (consumer.Controller, error) {
+				return nil, fmt.Errorf("missing dependency")
+			},
+		},
+	}
+
+	_, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, stages)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stage start")
+	assert.Contains(t, err.Error(), "missing dependency")
+}
+
+func TestConstruct_DLQControllerCreationFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
+	q.EXPECT().Publisher().Return(mqmock.NewMockPublisher(ctrl)).AnyTimes()
+
+	deps := testDeps{logger: newTestLogger()}
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator-start",
+			New: func(d testDeps) (consumer.Controller, error) {
+				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			},
+			DLQ: func(d testDeps) (consumer.Controller, error) {
+				return nil, fmt.Errorf("dlq dependency missing")
+			},
+		},
+	}
+
+	_, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, stages)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stage start dlq")
+	assert.Contains(t, err.Error(), "dlq dependency missing")
+}
+
+func TestConstruct_WithPublishOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
+	q.EXPECT().Publisher().Return(mqmock.NewMockPublisher(ctrl)).AnyTimes()
+
+	deps := testDeps{logger: newTestLogger()}
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator-start",
+			New: func(d testDeps) (consumer.Controller, error) {
+				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			},
+		},
+	}
+
+	comp, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, stages,
+		PublishOnly(
+			PublishOnlyTopic{Key: "log", Name: "log"},
+			PublishOnlyTopic{Key: "merge-request", Name: "merge-request"},
+		),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, comp)
+}
+
+func TestConstruct_WithTopicNameOverrides(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
+	q.EXPECT().Publisher().Return(mqmock.NewMockPublisher(ctrl)).AnyTimes()
+
+	deps := testDeps{logger: newTestLogger()}
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator-start",
+			New: func(d testDeps) (consumer.Controller, error) {
+				return &fakeController{key: "start", group: "orchestrator-start"}, nil
+			},
+		},
+	}
+
+	comp, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, stages,
+		TopicNames(map[consumer.TopicKey]string{
+			"start": "custom-start-topic",
+		}),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, comp)
+}
+
+func TestResolveTopicName(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       consumer.TopicKey
+		defaultN  string
+		overrides map[consumer.TopicKey]string
+		want      string
+	}{
+		{
+			name:     "no overrides",
+			key:      "start",
+			defaultN: "start",
+			want:     "start",
+		},
+		{
+			name:      "nil overrides",
+			key:       "start",
+			defaultN:  "start",
+			overrides: nil,
+			want:      "start",
+		},
+		{
+			name:      "key not in overrides",
+			key:       "start",
+			defaultN:  "start",
+			overrides: map[consumer.TopicKey]string{"other": "other-name"},
+			want:      "start",
+		},
+		{
+			name:      "key in overrides",
+			key:       "start",
+			defaultN:  "start",
+			overrides: map[consumer.TopicKey]string{"start": "custom-start"},
+			want:      "custom-start",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveTopicName(tt.key, tt.defaultN, tt.overrides)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDLQTopicKey(t *testing.T) {
+	assert.Equal(t, consumer.TopicKey("start_dlq"), dlqTopicKey("start"))
+	assert.Equal(t, consumer.TopicKey("validate_dlq"), dlqTopicKey("validate"))
+}
+
+func TestBuildTopicConfigs(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator-start",
+			New:           func(d testDeps) (consumer.Controller, error) { return nil, nil },
+			DLQ:           func(d testDeps) (consumer.Controller, error) { return nil, nil },
+		},
+		{
+			Key:           "validate",
+			Name:          "validate",
+			ConsumerGroup: "orchestrator-validate",
+			New:           func(d testDeps) (consumer.Controller, error) { return nil, nil },
+			// No DLQ for this stage.
+		},
+	}
+
+	o := &options{
+		publishOnly: []PublishOnlyTopic{
+			{Key: "log", Name: "log"},
+		},
+	}
+
+	configs, err := buildTopicConfigs(q, "test-sub", stages, o)
+	require.NoError(t, err)
+
+	// Expected: start (primary + DLQ) + validate (primary only) + log (publish-only) = 4
+	assert.Len(t, configs, 4)
+
+	// Verify primary stage config.
+	assert.Equal(t, consumer.TopicKey("start"), configs[0].Key)
+	assert.Equal(t, "start", configs[0].Name)
+	assert.Equal(t, "orchestrator-start", configs[0].Subscription.ConsumerGroup)
+
+	// Verify DLQ config derived from primary.
+	assert.Equal(t, consumer.TopicKey("start_dlq"), configs[1].Key)
+	assert.Equal(t, "start_dlq", configs[1].Name)
+	assert.Equal(t, "orchestrator-start-dlq", configs[1].Subscription.ConsumerGroup)
+
+	// Verify DLQ subscription has DLQ disabled (no cascade).
+	expected := extqueue.DLQSubscriptionConfig("test-sub", "orchestrator-start-dlq")
+	assert.Equal(t, expected.DLQ.Enabled, configs[1].Subscription.DLQ.Enabled)
+	assert.Equal(t, expected.Retry.MaxAttempts, configs[1].Subscription.Retry.MaxAttempts)
+
+	// Verify validate stage (no DLQ).
+	assert.Equal(t, consumer.TopicKey("validate"), configs[2].Key)
+
+	// Verify publish-only topic.
+	assert.Equal(t, consumer.TopicKey("log"), configs[3].Key)
+	assert.Equal(t, "log", configs[3].Name)
+	assert.Equal(t, "", configs[3].Subscription.ConsumerGroup)
+}

--- a/platform/pipeline/pipeline_test.go
+++ b/platform/pipeline/pipeline_test.go
@@ -50,7 +50,7 @@ func newTestLogger() *zap.SugaredLogger {
 	return l.Sugar()
 }
 
-func TestConstruct_SingleStage_NoDLQ(t *testing.T) {
+func TestConstruct_SingleStage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	q := mqmock.NewMockQueue(ctrl)
 	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
@@ -61,8 +61,11 @@ func TestConstruct_SingleStage_NoDLQ(t *testing.T) {
 		{
 			Key:           "start",
 			Name:          "start",
-			ConsumerGroup: "orchestrator-start",
+			ConsumerGroup: "orchestrator",
 			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
+			},
+			DLQ: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
@@ -84,7 +87,7 @@ func TestConstruct_WithDLQ(t *testing.T) {
 		{
 			Key:           "start",
 			Name:          "start",
-			ConsumerGroup: "orchestrator-start",
+			ConsumerGroup: "orchestrator",
 			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
@@ -99,6 +102,30 @@ func TestConstruct_WithDLQ(t *testing.T) {
 	assert.NotNil(t, comp)
 }
 
+func TestConstruct_NilDLQ_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := mqmock.NewMockQueue(ctrl)
+	q.EXPECT().Subscriber().Return(mqmock.NewMockSubscriber(ctrl)).AnyTimes()
+	q.EXPECT().Publisher().Return(mqmock.NewMockPublisher(ctrl)).AnyTimes()
+
+	deps := testDeps{logger: newTestLogger()}
+	stages := []Stage[testDeps]{
+		{
+			Key:           "start",
+			Name:          "start",
+			ConsumerGroup: "orchestrator",
+			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
+			},
+			// DLQ intentionally omitted.
+		},
+	}
+
+	_, err := Construct(deps.logger, tally.NoopScope, q, "test-sub", deps, stages)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DLQ handler is required")
+}
+
 func TestConstruct_MultipleStages(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	q := mqmock.NewMockQueue(ctrl)
@@ -110,15 +137,18 @@ func TestConstruct_MultipleStages(t *testing.T) {
 		{
 			Key:           "start",
 			Name:          "start",
-			ConsumerGroup: "orchestrator-start",
+			ConsumerGroup: "orchestrator",
 			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
+			},
+			DLQ: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
 		{
 			Key:           "validate",
 			Name:          "validate",
-			ConsumerGroup: "orchestrator-validate",
+			ConsumerGroup: "orchestrator",
 			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
@@ -154,9 +184,12 @@ func TestConstruct_ControllerCreationFailure(t *testing.T) {
 		{
 			Key:           "start",
 			Name:          "start",
-			ConsumerGroup: "orchestrator-start",
+			ConsumerGroup: "orchestrator",
 			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return nil, fmt.Errorf("missing dependency")
+			},
+			DLQ: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
 	}
@@ -178,7 +211,7 @@ func TestConstruct_DLQControllerCreationFailure(t *testing.T) {
 		{
 			Key:           "start",
 			Name:          "start",
-			ConsumerGroup: "orchestrator-start",
+			ConsumerGroup: "orchestrator",
 			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
@@ -205,8 +238,11 @@ func TestConstruct_WithPublishOnly(t *testing.T) {
 		{
 			Key:           "start",
 			Name:          "start",
-			ConsumerGroup: "orchestrator-start",
+			ConsumerGroup: "orchestrator",
 			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
+			},
+			DLQ: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
@@ -233,8 +269,11 @@ func TestConstruct_WithTopicNameOverrides(t *testing.T) {
 		{
 			Key:           "start",
 			Name:          "start",
-			ConsumerGroup: "orchestrator-start",
+			ConsumerGroup: "orchestrator",
 			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
+				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
+			},
+			DLQ: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
 			},
 		},
@@ -262,7 +301,7 @@ func TestConstruct_StageContext_Populated(t *testing.T) {
 		{
 			Key:           "start",
 			Name:          "start",
-			ConsumerGroup: "orchestrator-start",
+			ConsumerGroup: "orchestrator",
 			New: func(d testDeps, sc StageContext) (consumer.Controller, error) {
 				primarySC = sc
 				return &fakeController{key: sc.TopicKey, group: sc.ConsumerGroup}, nil
@@ -279,11 +318,11 @@ func TestConstruct_StageContext_Populated(t *testing.T) {
 
 	// Primary StageContext should have the stage's own key and group.
 	assert.Equal(t, consumer.TopicKey("start"), primarySC.TopicKey)
-	assert.Equal(t, "orchestrator-start", primarySC.ConsumerGroup)
+	assert.Equal(t, "orchestrator", primarySC.ConsumerGroup)
 
 	// DLQ StageContext should have the derived DLQ key and group.
 	assert.Equal(t, consumer.TopicKey("start_dlq"), dlqSC.TopicKey)
-	assert.Equal(t, "orchestrator-start-dlq", dlqSC.ConsumerGroup)
+	assert.Equal(t, "orchestrator-dlq", dlqSC.ConsumerGroup)
 
 	// Both should share the same registry.
 	assert.Equal(t, primarySC.Registry, dlqSC.Registry)
@@ -347,16 +386,16 @@ func TestBuildTopicConfigs(t *testing.T) {
 		{
 			Key:           "start",
 			Name:          "start",
-			ConsumerGroup: "orchestrator-start",
+			ConsumerGroup: "orchestrator",
 			New:           func(d testDeps, sc StageContext) (consumer.Controller, error) { return nil, nil },
 			DLQ:           func(d testDeps, sc StageContext) (consumer.Controller, error) { return nil, nil },
 		},
 		{
 			Key:           "validate",
 			Name:          "validate",
-			ConsumerGroup: "orchestrator-validate",
+			ConsumerGroup: "orchestrator",
 			New:           func(d testDeps, sc StageContext) (consumer.Controller, error) { return nil, nil },
-			// No DLQ for this stage.
+			DLQ:           func(d testDeps, sc StageContext) (consumer.Controller, error) { return nil, nil },
 		},
 	}
 
@@ -369,29 +408,30 @@ func TestBuildTopicConfigs(t *testing.T) {
 	configs, err := buildTopicConfigs(q, "test-sub", stages, o)
 	require.NoError(t, err)
 
-	// Expected: start (primary + DLQ) + validate (primary only) + log (publish-only) = 4
-	assert.Len(t, configs, 4)
+	// Expected: start (primary + DLQ) + validate (primary + DLQ) + log (publish-only) = 5
+	assert.Len(t, configs, 5)
 
 	// Verify primary stage config.
 	assert.Equal(t, consumer.TopicKey("start"), configs[0].Key)
 	assert.Equal(t, "start", configs[0].Name)
-	assert.Equal(t, "orchestrator-start", configs[0].Subscription.ConsumerGroup)
+	assert.Equal(t, "orchestrator", configs[0].Subscription.ConsumerGroup)
 
 	// Verify DLQ config derived from primary.
 	assert.Equal(t, consumer.TopicKey("start_dlq"), configs[1].Key)
 	assert.Equal(t, "start_dlq", configs[1].Name)
-	assert.Equal(t, "orchestrator-start-dlq", configs[1].Subscription.ConsumerGroup)
+	assert.Equal(t, "orchestrator-dlq", configs[1].Subscription.ConsumerGroup)
 
 	// Verify DLQ subscription has DLQ disabled (no cascade).
-	expected := extqueue.DLQSubscriptionConfig("test-sub", "orchestrator-start-dlq")
+	expected := extqueue.DLQSubscriptionConfig("test-sub", "orchestrator-dlq")
 	assert.Equal(t, expected.DLQ.Enabled, configs[1].Subscription.DLQ.Enabled)
 	assert.Equal(t, expected.Retry.MaxAttempts, configs[1].Subscription.Retry.MaxAttempts)
 
-	// Verify validate stage (no DLQ).
+	// Verify validate stage (primary + DLQ).
 	assert.Equal(t, consumer.TopicKey("validate"), configs[2].Key)
+	assert.Equal(t, consumer.TopicKey("validate_dlq"), configs[3].Key)
 
 	// Verify publish-only topic.
-	assert.Equal(t, consumer.TopicKey("log"), configs[3].Key)
-	assert.Equal(t, "log", configs[3].Name)
-	assert.Equal(t, "", configs[3].Subscription.ConsumerGroup)
+	assert.Equal(t, consumer.TopicKey("log"), configs[4].Key)
+	assert.Equal(t, "log", configs[4].Name)
+	assert.Equal(t, "", configs[4].Subscription.ConsumerGroup)
 }


### PR DESCRIPTION
## Summary

- Introduces `platform/pipeline` with the typed `Construct[D]` engine
- `Stage[D]` struct declares pipeline topology as a typed table (key, name, consumer group, controller constructor, optional DLQ)
- Engine builds topic registry, creates primary + DLQ consumers, eagerly constructs all controllers, pairs DLQ stages automatically
- Returns a `lifecycle.Component` for ordered start/stop
- Options: `TopicNames`, `Classifiers`, `PublishOnly`, `ExtraComponents`
- Pure addition — no existing code changes

Step 2 of the [Modular Queue Wiring RFC](https://github.com/uber/submitqueue/blob/main/doc/rfc/submitqueue/modular-queue-wiring.md). Stacked on https://github.com/uber/submitqueue/pull/402.

## Test plan

- [x] 10 unit tests: single stage, DLQ pairing, multiple stages, empty stages error, controller creation failure, DLQ creation failure, publish-only topics, topic name overrides, resolveTopicName table test, dlqTopicKey, buildTopicConfigs
- [x] `bazel test //platform/pipeline:go_default_test` passes
- [x] `make gazelle` — BUILD.bazel in sync
- [x] `make fmt` — code formatted

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Issues

https://linear.app/uber/issue/CODEM-209/example-figure-out-a-better-structure-for-wiring-up

## Stack

- #402 
- @#403 
- #404
- #440