### PR TITLE
fix(controller): drop redundant ControllerName prefix from wrapped error messages

### DIFF
--- a/stovepipe/controller/build/build.go
+++ b/stovepipe/controller/build/build.go
@@ -107,7 +107,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	buildRunner, err := c.buildRunners.For(buildrunner.Config{QueueName: request.Queue})
 	if err != nil {
 		// A queue with no registered builder is a config error.
-		return fmt.Errorf("BuildController failed to resolve build runner for queue %s: %w", request.Queue, err)
+		return fmt.Errorf("failed to resolve build runner for queue %s: %w", request.Queue, err)
 	}
 
 	// process decided the scope; build never re-derives incremental-vs-full.
@@ -122,7 +122,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 
 	buildID, err := buildRunner.Trigger(ctx, baseURI, request.URI, nil)
 	if err != nil {
-		return fmt.Errorf("BuildController failed to trigger build for request %s: %w", request.ID, err)
+		return fmt.Errorf("failed to trigger build for request %s: %w", request.ID, err)
 	}
 
 	build := entity.Build{
@@ -132,11 +132,11 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 		Version:   1,
 	}
 	if err := c.store.GetBuildStore().Create(ctx, build); err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
-		return fmt.Errorf("BuildController failed to persist build %s: %w", build.ID, err)
+		return fmt.Errorf("failed to persist build %s: %w", build.ID, err)
 	}
 
 	if err := c.publishBuildSignal(ctx, build.ID); err != nil {
-		return fmt.Errorf("BuildController failed to publish build signal for %s: %w", build.ID, err)
+		return fmt.Errorf("failed to publish build signal for %s: %w", build.ID, err)
 	}
 
 	c.logger.Debugw("triggered build",
@@ -150,7 +150,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 
 // loadRequest returns the request for id.
 func (c *Controller) loadRequest(ctx context.Context, id string) (entity.Request, error) {
-	return loader.ByID(ctx, id, c.store.GetRequestStore().Get, "BuildController", "request")
+	return loader.ByID(ctx, id, c.store.GetRequestStore().Get, "request")
 }
 
 // publishBuildSignal publishes buildID to the buildsignal stage, partitioned by

--- a/stovepipe/controller/buildsignal/buildsignal.go
+++ b/stovepipe/controller/buildsignal/buildsignal.go
@@ -129,12 +129,12 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	buildRunner, err := c.buildRunners.For(buildrunner.Config{QueueName: request.Queue})
 	if err != nil {
 		// A queue with no registered builder is a config error.
-		return fmt.Errorf("BuildSignalController failed to resolve build runner for queue %s: %w", request.Queue, err)
+		return fmt.Errorf("failed to resolve build runner for queue %s: %w", request.Queue, err)
 	}
 
 	status, _, err := buildRunner.Status(ctx, entity.BuildID{ID: build.ID})
 	if err != nil {
-		return fmt.Errorf("BuildSignalController failed to poll status for build %s: %w", build.ID, err)
+		return fmt.Errorf("failed to poll status for build %s: %w", build.ID, err)
 	}
 
 	effective, err := c.reconcile(ctx, build, status)
@@ -144,7 +144,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 
 	if effective.IsTerminal() {
 		if err := c.publishRecord(ctx, build.ID, request.ID); err != nil {
-			return fmt.Errorf("BuildSignalController failed to publish record for build %s: %w", build.ID, err)
+			return fmt.Errorf("failed to publish record for build %s: %w", build.ID, err)
 		}
 		c.logger.Infow("build reached terminal status",
 			"build_id", build.ID,
@@ -156,7 +156,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 
 	delayMs := pollDelay(effective)
 	if err := c.publishBuildSignal(ctx, build.ID, delayMs); err != nil {
-		return errs.NewRetryableError(fmt.Errorf("BuildSignalController failed to reschedule poll for build %s: %w", build.ID, err))
+		return errs.NewRetryableError(fmt.Errorf("failed to reschedule poll for build %s: %w", build.ID, err))
 	}
 	c.logger.Debugw("rescheduled build status poll",
 		"build_id", build.ID,
@@ -188,19 +188,19 @@ func (c *Controller) reconcile(ctx context.Context, build entity.Build, status e
 		if errors.Is(err, storage.ErrVersionMismatch) {
 			return "", errs.NewRetryableError(fmt.Errorf("build %s version conflict: %w", build.ID, err))
 		}
-		return "", fmt.Errorf("BuildSignalController failed to persist status for build %s: %w", build.ID, err)
+		return "", fmt.Errorf("failed to persist status for build %s: %w", build.ID, err)
 	}
 	return status, nil
 }
 
 // loadBuild returns the build for id.
 func (c *Controller) loadBuild(ctx context.Context, id string) (entity.Build, error) {
-	return loader.ByID(ctx, id, c.store.GetBuildStore().Get, "BuildSignalController", "build")
+	return loader.ByID(ctx, id, c.store.GetBuildStore().Get, "build")
 }
 
 // loadRequest returns the request for id.
 func (c *Controller) loadRequest(ctx context.Context, id string) (entity.Request, error) {
-	return loader.ByID(ctx, id, c.store.GetRequestStore().Get, "BuildSignalController", "request")
+	return loader.ByID(ctx, id, c.store.GetRequestStore().Get, "request")
 }
 
 // pollDelay returns the delay before the next Status call for a non-terminal status.

--- a/stovepipe/controller/ingest.go
+++ b/stovepipe/controller/ingest.go
@@ -93,7 +93,7 @@ func (c *IngestController) Ingest(ctx context.Context, req entity.IngestRequest)
 	defer func() { op.Complete(retErr) }()
 
 	if req.Queue == "" {
-		return entity.IngestResult{}, fmt.Errorf("IngestController requires the request to have a queue name specified: %w", ErrInvalidRequest)
+		return entity.IngestResult{}, fmt.Errorf("requires the request to have a queue name specified: %w", ErrInvalidRequest)
 	}
 	queue := req.Queue
 
@@ -101,14 +101,14 @@ func (c *IngestController) Ingest(ctx context.Context, req entity.IngestRequest)
 	// An unresolvable queue/ref is a caller error (unknown queue), not infrastructure.
 	sc, err := c.sourceControl.For(sourcecontrol.Config{QueueName: queue})
 	if err != nil {
-		return entity.IngestResult{}, fmt.Errorf("IngestController failed to resolve source control for queue=%s: %w", queue, err)
+		return entity.IngestResult{}, fmt.Errorf("failed to resolve source control for queue=%s: %w", queue, err)
 	}
 	uri, err := sc.Latest(ctx)
 	if err != nil {
 		if sourcecontrol.IsNotFound(err) {
-			return entity.IngestResult{}, fmt.Errorf("IngestController could not resolve head for queue=%s: %w: %w", queue, err, ErrInvalidRequest)
+			return entity.IngestResult{}, fmt.Errorf("could not resolve head for queue=%s: %w: %w", queue, err, ErrInvalidRequest)
 		}
-		return entity.IngestResult{}, fmt.Errorf("IngestController failed to resolve head for queue=%s: %w", queue, err)
+		return entity.IngestResult{}, fmt.Errorf("failed to resolve head for queue=%s: %w", queue, err)
 	}
 
 	// The (queue, URI) mapping is the dedup gate and the source of truth for "does this head
@@ -135,7 +135,7 @@ func (c *IngestController) Ingest(ctx context.Context, req entity.IngestRequest)
 	// process advances the request past Accepted, ingest stops re-publishing.
 	if request.State == entity.RequestStateAccepted {
 		if err := c.publishProcess(ctx, id, queue); err != nil {
-			return entity.IngestResult{}, fmt.Errorf("IngestController failed to publish request %s to process: %w", id, err)
+			return entity.IngestResult{}, fmt.Errorf("failed to publish request %s to process: %w", id, err)
 		}
 	}
 
@@ -159,7 +159,7 @@ func (c *IngestController) resolveID(ctx context.Context, queue, uri string) (st
 	if id, err := uriStore.GetIDByURI(ctx, queue, uri); err == nil {
 		return id, nil
 	} else if !errors.Is(err, storage.ErrNotFound) {
-		return "", fmt.Errorf("IngestController failed to look up existing request for queue=%s: %w", queue, err)
+		return "", fmt.Errorf("failed to look up existing request for queue=%s: %w", queue, err)
 	}
 
 	// Mint a globally unique request ID namespaced by the queue. The counter domain
@@ -167,7 +167,7 @@ func (c *IngestController) resolveID(ctx context.Context, queue, uri string) (st
 	domain := "request/" + queue
 	seq, err := c.counter.Next(ctx, domain)
 	if err != nil {
-		return "", fmt.Errorf("IngestController failed to generate request ID for queue=%s: %w", queue, err)
+		return "", fmt.Errorf("failed to generate request ID for queue=%s: %w", queue, err)
 	}
 	id := fmt.Sprintf("%s/%d", domain, seq)
 
@@ -175,11 +175,11 @@ func (c *IngestController) resolveID(ctx context.Context, queue, uri string) (st
 		if errors.Is(err, storage.ErrAlreadyExists) {
 			existing, getErr := uriStore.GetIDByURI(ctx, queue, uri)
 			if getErr != nil {
-				return "", fmt.Errorf("IngestController failed to resolve raced request for queue=%s: %w", queue, getErr)
+				return "", fmt.Errorf("failed to resolve raced request for queue=%s: %w", queue, getErr)
 			}
 			return existing, nil
 		}
-		return "", fmt.Errorf("IngestController failed to map URI for queue=%s: %w", queue, err)
+		return "", fmt.Errorf("failed to map URI for queue=%s: %w", queue, err)
 	}
 	return id, nil
 }
@@ -194,7 +194,7 @@ func (c *IngestController) ensureRequest(ctx context.Context, id, queue, uri str
 		return got, nil
 	}
 	if !errors.Is(err, storage.ErrNotFound) {
-		return entity.Request{}, fmt.Errorf("IngestController failed to load request %s: %w", id, err)
+		return entity.Request{}, fmt.Errorf("failed to load request %s: %w", id, err)
 	}
 
 	request := entity.Request{
@@ -206,7 +206,7 @@ func (c *IngestController) ensureRequest(ctx context.Context, id, queue, uri str
 	}
 	if err := reqStore.Create(ctx, request); err != nil {
 		if !errors.Is(err, storage.ErrAlreadyExists) {
-			return entity.Request{}, fmt.Errorf("IngestController failed to persist request %s: %w", id, err)
+			return entity.Request{}, fmt.Errorf("failed to persist request %s: %w", id, err)
 		}
 		// Raced with a concurrent creator; read the canonical row.
 		return reqStore.Get(ctx, id)
@@ -224,7 +224,7 @@ func (c *IngestController) ensureQueue(ctx context.Context, name string) (entity
 		return got, nil
 	}
 	if !errors.Is(err, storage.ErrNotFound) {
-		return entity.Queue{}, fmt.Errorf("IngestController failed to load queue %s: %w", name, err)
+		return entity.Queue{}, fmt.Errorf("failed to load queue %s: %w", name, err)
 	}
 
 	queue := entity.Queue{
@@ -233,7 +233,7 @@ func (c *IngestController) ensureQueue(ctx context.Context, name string) (entity
 	}
 	if err := queueStore.Create(ctx, queue); err != nil {
 		if !errors.Is(err, storage.ErrAlreadyExists) {
-			return entity.Queue{}, fmt.Errorf("IngestController failed to persist queue %s: %w", name, err)
+			return entity.Queue{}, fmt.Errorf("failed to persist queue %s: %w", name, err)
 		}
 		// Raced with a concurrent creator; read the canonical row.
 		return queueStore.Get(ctx, name)
@@ -254,7 +254,7 @@ func (c *IngestController) advanceQueueLatestRequestID(ctx context.Context, queu
 		if queueRow.LatestRequestID != "" {
 			cmp, err := entity.CompareRequestID(queue, id, queueRow.LatestRequestID)
 			if err != nil {
-				return fmt.Errorf("IngestController failed to compare request ids for queue %s: %w", queue, err)
+				return fmt.Errorf("failed to compare request ids for queue %s: %w", queue, err)
 			}
 			if cmp <= 0 {
 				return nil
@@ -268,7 +268,7 @@ func (c *IngestController) advanceQueueLatestRequestID(ctx context.Context, queu
 			if errors.Is(err, storage.ErrVersionMismatch) {
 				continue
 			}
-			return fmt.Errorf("IngestController failed to update queue %s latest_request_id: %w", queue, err)
+			return fmt.Errorf("failed to update queue %s latest_request_id: %w", queue, err)
 		}
 		return nil
 	}

--- a/stovepipe/controller/process/process.go
+++ b/stovepipe/controller/process/process.go
@@ -106,7 +106,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) (r
 	case entity.RequestStateProcessing:
 		if err := c.publishBuild(ctx, request.ID); err != nil {
 			metrics.NamedCounter(c.metricsScope, _opName, "publish_errors", 1)
-			return fmt.Errorf("ProcessController failed to publish request %s to build: %w", request.ID, err)
+			return fmt.Errorf("failed to publish request %s to build: %w", request.ID, err)
 		}
 		return nil
 	case entity.RequestStateSuperseded:
@@ -152,7 +152,7 @@ func (c *Controller) processAccepted(ctx context.Context, request entity.Request
 	if err != nil {
 		// TODO(queueconfig): decide retryability when a real config store lands — is a
 		// missing queue "drop" (non-retryable) or "retry until configured"?
-		return fmt.Errorf("ProcessController failed to load queue config for %s: %w", request.Queue, err)
+		return fmt.Errorf("failed to load queue config for %s: %w", request.Queue, err)
 	}
 
 	return c.admitLatestHead(ctx, request, queueRow, cfg)
@@ -164,7 +164,7 @@ func (c *Controller) processAccepted(ctx context.Context, request entity.Request
 func (c *Controller) coalesce(ctx context.Context, request entity.Request, latestRequestID string) (bool, error) {
 	cmp, err := entity.CompareRequestID(request.Queue, request.ID, latestRequestID)
 	if err != nil {
-		return false, fmt.Errorf("ProcessController failed to compare request ids for queue %s: %w", request.Queue, err)
+		return false, fmt.Errorf("failed to compare request ids for queue %s: %w", request.Queue, err)
 	}
 	if cmp >= 0 {
 		return false, nil
@@ -203,7 +203,7 @@ func (c *Controller) admitLatestHead(ctx context.Context, request entity.Request
 				metrics.NamedCounter(c.metricsScope, _opName, "source_control_errors", 1,
 					metrics.NewTag("stage", "resolve"),
 				)
-				return fmt.Errorf("ProcessController failed to resolve source control for queue %s: %w", request.Queue, err)
+				return fmt.Errorf("failed to resolve source control for queue %s: %w", request.Queue, err)
 			}
 		}
 
@@ -242,7 +242,7 @@ func (c *Controller) admitLatestHead(ctx context.Context, request entity.Request
 
 	if err := c.publishBuild(ctx, request.ID); err != nil {
 		metrics.NamedCounter(c.metricsScope, _opName, "publish_errors", 1)
-		return fmt.Errorf("ProcessController failed to publish request %s to build: %w", request.ID, err)
+		return fmt.Errorf("failed to publish request %s to build: %w", request.ID, err)
 	}
 
 	metrics.NamedCounter(c.metricsScope, _opName, "admitted", 1,
@@ -281,7 +281,7 @@ func (c *Controller) deriveBuildStrategy(ctx context.Context, sc sourcecontrol.S
 		metrics.NamedCounter(c.metricsScope, _opName, "source_control_errors", 1,
 			metrics.NewTag("stage", "ancestry"),
 		)
-		return entity.BuildStrategyUnknown, "", fmt.Errorf("ProcessController failed to check ancestry for queue %s: %w", request.Queue, err)
+		return entity.BuildStrategyUnknown, "", fmt.Errorf("failed to check ancestry for queue %s: %w", request.Queue, err)
 	}
 
 	if isAncestor {
@@ -302,12 +302,12 @@ func (c *Controller) claimBuildSlot(ctx context.Context, queueRow *entity.Queue)
 		if errors.Is(err, storage.ErrVersionMismatch) {
 			got, getErr := queueStore.Get(ctx, queueRow.Name)
 			if getErr != nil {
-				return fmt.Errorf("ProcessController failed to reload queue %s after version mismatch: %w", queueRow.Name, getErr)
+				return fmt.Errorf("failed to reload queue %s after version mismatch: %w", queueRow.Name, getErr)
 			}
 			*queueRow = got
 			return storage.ErrVersionMismatch
 		}
-		return fmt.Errorf("ProcessController failed to claim build slot for queue %s: %w", queueRow.Name, err)
+		return fmt.Errorf("failed to claim build slot for queue %s: %w", queueRow.Name, err)
 	}
 	updated.Version = newVersion
 	*queueRow = updated
@@ -336,12 +336,12 @@ func (c *Controller) markProcessing(ctx context.Context, request *entity.Request
 			if errors.Is(err, storage.ErrVersionMismatch) {
 				got, getErr := reqStore.Get(ctx, request.ID)
 				if getErr != nil {
-					return false, fmt.Errorf("ProcessController failed to reload request %s after version mismatch: %w", request.ID, getErr)
+					return false, fmt.Errorf("failed to reload request %s after version mismatch: %w", request.ID, getErr)
 				}
 				*request = got
 				continue
 			}
-			return false, fmt.Errorf("ProcessController failed to mark request %s processing: %w", request.ID, err)
+			return false, fmt.Errorf("failed to mark request %s processing: %w", request.ID, err)
 		}
 		updated.Version = newVersion
 		*request = updated
@@ -402,12 +402,12 @@ func (c *Controller) supersedeRequest(ctx context.Context, request entity.Reques
 			if errors.Is(err, storage.ErrVersionMismatch) {
 				got, getErr := reqStore.Get(ctx, request.ID)
 				if getErr != nil {
-					return fmt.Errorf("ProcessController failed to reload request %s after version mismatch: %w", request.ID, getErr)
+					return fmt.Errorf("failed to reload request %s after version mismatch: %w", request.ID, getErr)
 				}
 				request = got
 				continue
 			}
-			return fmt.Errorf("ProcessController failed to supersede request %s: %w", request.ID, err)
+			return fmt.Errorf("failed to supersede request %s: %w", request.ID, err)
 		}
 		return nil
 	}
@@ -418,12 +418,12 @@ func (c *Controller) supersedeRequest(ctx context.Context, request entity.Reques
 func (c *Controller) rescheduleProcess(ctx context.Context, request entity.Request, inFlightCount int32, delayMs int64) error {
 	if delayMs <= 0 {
 		metrics.NamedCounter(c.metricsScope, _opName, "config_errors", 1)
-		return fmt.Errorf("ProcessController requires a positive gate wait delay for queue %s, got %dms", request.Queue, delayMs)
+		return fmt.Errorf("requires a positive gate wait delay for queue %s, got %dms", request.Queue, delayMs)
 	}
 
 	payload, err := stovepipemq.Marshal(&stovepipemq.ProcessRequest{Id: request.ID})
 	if err != nil {
-		return fmt.Errorf("ProcessController failed to serialize process request %s: %w", request.ID, err)
+		return fmt.Errorf("failed to serialize process request %s: %w", request.ID, err)
 	}
 
 	// Suffix the message id with the publish time so the reschedule can't collide with
@@ -442,7 +442,7 @@ func (c *Controller) rescheduleProcess(ctx context.Context, request entity.Reque
 
 	if err := q.Publisher().PublishAfter(ctx, topicName, msg, delayMs); err != nil {
 		metrics.NamedCounter(c.metricsScope, _opName, "publish_errors", 1)
-		return fmt.Errorf("ProcessController failed to reschedule process request %s: %w", request.ID, err)
+		return fmt.Errorf("failed to reschedule process request %s: %w", request.ID, err)
 	}
 	c.logger.Infow("rescheduled latest head awaiting build slot",
 		"request_id", request.ID,
@@ -456,12 +456,12 @@ func (c *Controller) rescheduleProcess(ctx context.Context, request entity.Reque
 
 // loadRequest returns the request for id.
 func (c *Controller) loadRequest(ctx context.Context, id string) (entity.Request, error) {
-	return loader.ByID(ctx, id, c.store.GetRequestStore().Get, "ProcessController", "request")
+	return loader.ByID(ctx, id, c.store.GetRequestStore().Get, "request")
 }
 
 // loadQueue returns the queue row for name.
 func (c *Controller) loadQueue(ctx context.Context, name string) (entity.Queue, error) {
-	return loader.ByID(ctx, name, c.store.GetQueueStore().Get, "ProcessController", "queue")
+	return loader.ByID(ctx, name, c.store.GetQueueStore().Get, "queue")
 }
 
 // publishBuild publishes the admitted request ID to the build stage. The build

--- a/stovepipe/core/loader/loader.go
+++ b/stovepipe/core/loader/loader.go
@@ -22,9 +22,8 @@ import (
 )
 
 // ByID loads one entity by id via get, returning it unwrapped on success. On
-// failure it wraps the error as "<controllerName> failed to load <entityName>
-// <id>: <cause>" so every stovepipe controller reports load failures in the
-// same shape.
+// failure it wraps the error as "failed to load <entityName> <id>: <cause>"
+// so every stovepipe controller reports load failures in the same shape.
 //
 // get is typically a store's Get method value passed directly (e.g.
 // c.store.GetRequestStore().Get), which fixes T through inference so callers
@@ -36,11 +35,11 @@ import (
 // causally-prior write should already have produced is a storage
 // implementation defect, not a lag condition worth retrying through. It
 // surfaces as a plain error, non-retryable by platform/errs's default.
-func ByID[T any](ctx context.Context, id string, get func(context.Context, string) (T, error), controllerName, entityName string) (T, error) {
+func ByID[T any](ctx context.Context, id string, get func(context.Context, string) (T, error), entityName string) (T, error) {
 	got, err := get(ctx, id)
 	if err != nil {
 		var zero T
-		return zero, fmt.Errorf("%s failed to load %s %s: %w", controllerName, entityName, id, err)
+		return zero, fmt.Errorf("failed to load %s %s: %w", entityName, id, err)
 	}
 	return got, nil
 }

--- a/stovepipe/core/loader/loader_test.go
+++ b/stovepipe/core/loader/loader_test.go
@@ -33,7 +33,7 @@ func TestByID(t *testing.T) {
 			return widget{Name: id}, nil
 		}
 
-		got, err := ByID(context.Background(), "abc", get, "TestController", "widget")
+		got, err := ByID(context.Background(), "abc", get, "widget")
 
 		require.NoError(t, err)
 		assert.Equal(t, widget{Name: "abc"}, got)
@@ -45,7 +45,7 @@ func TestByID(t *testing.T) {
 			return widget{}, sentinel
 		}
 
-		got, err := ByID(context.Background(), "abc", get, "TestController", "widget")
+		got, err := ByID(context.Background(), "abc", get, "widget")
 
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, sentinel))

--- a/submitqueue/gateway/controller/cancel.go
+++ b/submitqueue/gateway/controller/cancel.go
@@ -73,7 +73,7 @@ func (c *CancelController) Cancel(ctx context.Context, req entity.CancelRequest)
 	c.metricsScope.Counter("cancel_request_count").Inc(1)
 
 	if req.ID == "" {
-		return fmt.Errorf("CancelController requires the request to have a sqid specified: %w", ErrInvalidRequest)
+		return fmt.Errorf("requires the request to have a sqid specified: %w", ErrInvalidRequest)
 	}
 
 	c.logger.Debugw("cancel request received",
@@ -87,7 +87,7 @@ func (c *CancelController) Cancel(ctx context.Context, req entity.CancelRequest)
 			c.metricsScope.Counter("cancel_request_not_found").Inc(1)
 			return errs.NewUserError(&RequestNotFoundError{Sqid: req.ID})
 		}
-		return fmt.Errorf("CancelController failed to look up request summary for sqid=%s: %w", req.ID, err)
+		return fmt.Errorf("failed to look up request summary for sqid=%s: %w", req.ID, err)
 	}
 
 	// Record the user's intent in the request log before publishing. Writing direct to the
@@ -99,11 +99,11 @@ func (c *CancelController) Cancel(ctx context.Context, req entity.CancelRequest)
 	}
 	logEntry := entity.NewRequestLog(req.ID, entity.RequestStatusCancelling, 0, "", metadata)
 	if err := c.materializer.PersistLog(ctx, logEntry); err != nil {
-		return fmt.Errorf("CancelController failed to insert cancelling log for sqid=%s: %w", req.ID, err)
+		return fmt.Errorf("failed to insert cancelling log for sqid=%s: %w", req.ID, err)
 	}
 
 	if err := c.publishToQueue(ctx, req); err != nil {
-		return fmt.Errorf("CancelController failed to publish cancel request to queue: %w", err)
+		return fmt.Errorf("failed to publish cancel request to queue: %w", err)
 	}
 
 	c.logger.Infow("cancel request published to queue",

--- a/submitqueue/gateway/controller/land.go
+++ b/submitqueue/gateway/controller/land.go
@@ -96,10 +96,10 @@ func (c *LandController) Land(ctx context.Context, req entity.LandRequest) (resu
 
 	// Validate provider-agnostic request constraints before allocating an sqid.
 	if err := validateQueueIdentifier(req.Queue); err != nil {
-		return entity.LandResult{}, fmt.Errorf("LandController invalid queue: %w", err)
+		return entity.LandResult{}, fmt.Errorf("invalid queue: %w", err)
 	}
 	if err := validateChangeURIs(req.Change.URIs); err != nil {
-		return entity.LandResult{}, fmt.Errorf("LandController invalid change URIs: %w", err)
+		return entity.LandResult{}, fmt.Errorf("invalid change URIs: %w", err)
 	}
 
 	queue := req.Queue
@@ -107,18 +107,18 @@ func (c *LandController) Land(ctx context.Context, req entity.LandRequest) (resu
 		if errors.Is(err, queueconfig.ErrNotFound) {
 			return entity.LandResult{}, errs.NewUserError(&UnrecognizedQueueError{Queue: queue})
 		}
-		return entity.LandResult{}, fmt.Errorf("LandController failed to look up queue %q: %w", queue, err)
+		return entity.LandResult{}, fmt.Errorf("failed to look up queue %q: %w", queue, err)
 	}
 
 	// Generate a globally unique request ID for the land request.
 	// The inbound entity arrives with an empty ID; the controller owns minting it.
 	seq, err := c.counter.Next(ctx, "request/"+queue)
 	if err != nil {
-		return entity.LandResult{}, fmt.Errorf("LandController failed to generate request ID for queue=%s: %w", queue, err)
+		return entity.LandResult{}, fmt.Errorf("failed to generate request ID for queue=%s: %w", queue, err)
 	}
 	req.ID = fmt.Sprintf("%s/%d", queue, seq)
 	if err := validateStoredIdentifier("generated sqid", req.ID); err != nil {
-		return entity.LandResult{}, fmt.Errorf("LandController generated invalid request ID for queue=%s: %w", queue, err)
+		return entity.LandResult{}, fmt.Errorf("generated invalid request ID for queue=%s: %w", queue, err)
 	}
 
 	receivedAtMs := time.Now().UnixMilli()
@@ -133,13 +133,13 @@ func (c *LandController) Land(ctx context.Context, req entity.LandRequest) (resu
 		Metadata:          map[string]string{},
 	}
 	if err := c.store.GetRequestSummaryStore().Create(ctx, summary); err != nil {
-		return entity.LandResult{}, fmt.Errorf("LandController failed to create request receipt sqid=%s: %w", req.ID, err)
+		return entity.LandResult{}, fmt.Errorf("failed to create request receipt sqid=%s: %w", req.ID, err)
 	}
 
 	// Publish before exposing the request as accepted. A failed publish leaves an
 	// internal accepting receipt that public read APIs do not expose.
 	if err := c.publishToQueue(ctx, req); err != nil {
-		return entity.LandResult{}, fmt.Errorf("LandController failed to publish request to queue: %w", err)
+		return entity.LandResult{}, fmt.Errorf("failed to publish request to queue: %w", err)
 	}
 
 	logEntry := entity.RequestLog{

--- a/submitqueue/gateway/controller/list.go
+++ b/submitqueue/gateway/controller/list.go
@@ -68,23 +68,23 @@ func (c *ListController) List(ctx context.Context, req entity.ListRequest) (resu
 	defer func() { op.Complete(retErr) }()
 
 	if err := validateStoredIdentifier("queue", req.Queue); err != nil {
-		return entity.ListResult{}, fmt.Errorf("ListController invalid queue: %w", err)
+		return entity.ListResult{}, fmt.Errorf("invalid queue: %w", err)
 	}
 	if _, err := c.queueConfigs.Get(ctx, req.Queue); err != nil {
 		if errors.Is(err, queueconfig.ErrNotFound) {
 			return entity.ListResult{}, errs.NewUserError(&UnrecognizedQueueError{Queue: req.Queue})
 		}
-		return entity.ListResult{}, fmt.Errorf("ListController failed to look up queue %q: %w", req.Queue, err)
+		return entity.ListResult{}, fmt.Errorf("failed to look up queue %q: %w", req.Queue, err)
 	}
 	if req.ReceivedAtOrAfterMs >= req.ReceivedBeforeMs {
-		return entity.ListResult{}, fmt.Errorf("ListController requires received_at_or_after_ms < received_before_ms: %w", ErrInvalidRequest)
+		return entity.ListResult{}, fmt.Errorf("requires received_at_or_after_ms < received_before_ms: %w", ErrInvalidRequest)
 	}
 	pageSize := int(req.PageSize)
 	if pageSize == 0 {
 		pageSize = defaultListPageSize
 	}
 	if pageSize < 0 || pageSize > maxListPageSize {
-		return entity.ListResult{}, fmt.Errorf("ListController page_size must be between 0 and %d: %w", maxListPageSize, ErrInvalidRequest)
+		return entity.ListResult{}, fmt.Errorf("page_size must be between 0 and %d: %w", maxListPageSize, ErrInvalidRequest)
 	}
 
 	query := storage.RequestQueueSummaryQuery{
@@ -96,10 +96,10 @@ func (c *ListController) List(ctx context.Context, req entity.ListRequest) (resu
 	if req.PageToken != "" {
 		token, err := decodeListPageToken(req.PageToken)
 		if err != nil {
-			return entity.ListResult{}, fmt.Errorf("ListController invalid page token: %w", ErrInvalidRequest)
+			return entity.ListResult{}, fmt.Errorf("invalid page token: %w", ErrInvalidRequest)
 		}
 		if token.Queue != req.Queue || token.ReceivedAtOrAfterMs != req.ReceivedAtOrAfterMs || token.ReceivedBeforeMs != req.ReceivedBeforeMs {
-			return entity.ListResult{}, fmt.Errorf("ListController page token does not match query: %w", ErrInvalidRequest)
+			return entity.ListResult{}, fmt.Errorf("page token does not match query: %w", ErrInvalidRequest)
 		}
 		query.HasCursor = true
 		query.Cursor = storage.RequestQueueSummaryCursor{ReceivedAtMs: token.LastReceivedAtMs, RequestID: token.LastRequestID}
@@ -107,7 +107,7 @@ func (c *ListController) List(ctx context.Context, req entity.ListRequest) (resu
 
 	summaries, err := c.requestQueueSummaryStore.List(ctx, query)
 	if err != nil {
-		return entity.ListResult{}, fmt.Errorf("ListController failed to list queue=%s: %w", req.Queue, err)
+		return entity.ListResult{}, fmt.Errorf("failed to list queue=%s: %w", req.Queue, err)
 	}
 
 	visible := summaries


### PR DESCRIPTION
Remove redundant controllerName prefix in error msg body
