### PR TITLE
ci: disable rebase-stack workflow in favor of gh native stack

### DIFF
--- a/.github/workflows/rebase-stack.yml
+++ b/.github/workflows/rebase-stack.yml
@@ -82,7 +82,10 @@ permissions:
 jobs:
   rebase-stack:
     name: Rebase Stack
-    if: github.event.pull_request.merged == true
+    # DISABLED: this workflow is turned off in favor of GitHub's native stacked
+    # PR support. The file is kept (not removed) so it can be re-enabled by
+    # restoring the condition below to `github.event.pull_request.merged == true`.
+    if: false && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     # Scope the privileged PAT to a protected Environment restricted to `main`
     # so the secret cannot be used from any other ref/context.


### PR DESCRIPTION
## Summary

### Why?

We are moving stacked-PR management to GitHub's native stacked PR support. The custom `rebase-stack` workflow (which auto-rebases and retargets child PRs when a stacked PR merges) is no longer the intended mechanism, so it should stop running.

### What?

Gates the `rebase-stack` job with `if: false` rather than deleting the workflow, so it never runs on PR merge while the file — including its full design docs and security setup — is preserved. Re-enabling is a one-line revert: restore the condition to `github.event.pull_request.merged == true`.

The workflow is not a required check, and the only other references are documentation/allowlist entries in `.github/zizmor.yml` that remain valid since the file stays in place.

Note: this workflow is the sole owner of merged-head-branch deletion and requires the repo setting "Automatically delete head branches" to be OFF. With it disabled, re-enable that repo setting to restore branch cleanup.


