### PR TITLE
Adding WORKSPACE to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ MODULE.bazel.lock
 .mcp.json.bak
 .ijwb/
 
+WORKSPACE
 
 # Built binaries
 bin/


### PR DESCRIPTION
## Summary
A `WORKSPACE` file is needed for the Uber bazel plugin for GoLand to work properly. Adding it to `.gitignore`.
