### PR TITLE
feat(orchestrator): poll builds and stop the ones nothing wants

### DIFF
--- a/submitqueue/orchestrator/controller/buildsignal/BUILD.bazel
+++ b/submitqueue/orchestrator/controller/buildsignal/BUILD.bazel
@@ -6,9 +6,9 @@ go_library(
     importpath = "github.com/uber/submitqueue/submitqueue/orchestrator/controller/buildsignal",
     visibility = ["//visibility:public"],
     deps = [
-        "//platform/base/messagequeue:go_default_library",
         "//platform/consumer:go_default_library",
         "//platform/metrics:go_default_library",
+        "//submitqueue/core/publish:go_default_library",
         "//submitqueue/core/topickey:go_default_library",
         "//submitqueue/entity:go_default_library",
         "//submitqueue/extension/buildrunner:go_default_library",
@@ -26,7 +26,6 @@ go_test(
         "//platform/base/messagequeue:go_default_library",
         "//platform/consumer:go_default_library",
         "//platform/consumer/mock:go_default_library",
-        "//platform/errs:go_default_library",
         "//platform/extension/messagequeue/mock:go_default_library",
         "//submitqueue/core/topickey:go_default_library",
         "//submitqueue/entity:go_default_library",

--- a/submitqueue/orchestrator/controller/buildsignal/buildsignal.go
+++ b/submitqueue/orchestrator/controller/buildsignal/buildsignal.go
@@ -12,24 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package buildsignal implements the build poll loop. Each message carries
-// a Build; the controller calls BuildRunner.Status, writes the latest
-// status to the BuildStore, publishes the batch ID to TopicKeySpeculate
-// so the state machine re-evaluates, and holds the delivery for the next
-// poll when the build has not yet reached a terminal state. Each message
-// partitions by batch ID, so slow polls on one batch's build do not block
-// others. A webhook-capable backend can publish into this same topic — the
-// controller cannot tell a poll-driven message from a push.
+// Package buildsignal implements the build poll loop. Each message names one
+// build by the runner's own ID; the controller calls BuildRunner.Status, writes
+// the latest status to that build's record, and wakes the speculate run for its
+// batch, holding its delivery between polls while the build is still in
+// flight.
+//
+// The poll loop is also where builds are stopped. It follows every build to a
+// terminal state anyway, so on each poll it checks whether anything still
+// wants the build running — the batch not halted, the path's current attempt,
+// with a status that is not a stop, linked to this very build — and asks the
+// runner to cancel when nothing does. That makes cancellation level-triggered:
+// the speculate run records intent in the path set and nothing more, no cancel
+// message exists to go stale, and a check that misses one poll is remade on
+// the next.
+//
+// The path set is read here as that kill list, and never written — the
+// speculate run stays its only writer, which is what lets a run hold one
+// version of a head's paths across its whole decision without a poll
+// invalidating it. The read must come from the primary: a stale replica read
+// could report a wanted build unwanted, and a cancel is irreversible.
+//
+// Each build partitions independently, so slow polls on one build do not block
+// another, and successive polls of one build stay ordered. A webhook-capable
+// backend can publish into this same topic — the controller cannot tell a
+// poll-driven message from a push.
 package buildsignal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/uber-go/tally"
-	entityqueue "github.com/uber/submitqueue/platform/base/messagequeue"
 	"github.com/uber/submitqueue/platform/consumer"
 	"github.com/uber/submitqueue/platform/metrics"
+	"github.com/uber/submitqueue/submitqueue/core/publish"
 	"github.com/uber/submitqueue/submitqueue/core/topickey"
 	"github.com/uber/submitqueue/submitqueue/entity"
 	"github.com/uber/submitqueue/submitqueue/extension/buildrunner"
@@ -51,6 +69,9 @@ var (
 	// is executing.
 	PollDelayRunningMs int64 = 2000
 )
+
+// opName is the metric operation name shared by every emit in this file.
+const opName = "process"
 
 // Controller consumes build signal messages, polls BuildRunner.Status,
 // persists the result, and drives the polling loop.
@@ -88,20 +109,30 @@ func NewController(
 	}
 }
 
-// Process polls the build's current status, persists it, publishes the
-// batch ID to speculate so the state machine re-evaluates, and holds the
-// delivery for the next poll when the build is still in flight.
+// Process polls one attempt's build status, stops the build if nothing wants
+// it running any more, persists the status, wakes the speculate run, and
+// holds the delivery for the next poll while the build is still in flight.
 // Returns nil to ack (success), or error to nack/reject.
 //
-// Error classification: deserialize, Status, Update, and the speculate
-// publish stay non-retryable — they reject straight to DLQ on the first
-// failure, where the operational republish path is the recovery mechanism.
-// The poll loop's continuation is a hold, not a publish: the framework
-// postpones the delivery, and a failed postpone write lapses into a normal
-// visibility-timeout redelivery, so the loop cannot stall on an enqueue.
+// There is deliberately no short-circuit for halted batches. A cancelling batch
+// reaches its terminal state only once its paths stop, and this loop is the
+// only thing watching them stop — and, now, the thing stopping them: speculate
+// marks a path cancelling, the next poll here asks the runner to cancel, and a
+// later poll observes CI actually stop and records it. Skipping the work —
+// including the hold — for a halted batch would leave every cancelled
+// batch stranded in Cancelling forever.
+//
+// Error classification: deserialize, Status, the kill-list reads, the
+// persistence writes, and the speculate publish stay non-retryable — they
+// reject straight to DLQ on the first failure, where the operational republish
+// path is the recovery mechanism. The Cancel call is best-effort instead:
+// failing the message for it would kill the poll chain that is the only thing
+// that will retry the cancel, so a failure is logged and the next poll remakes
+// the whole check. The poll loop's continuation is a hold, not a publish: the
+// framework postpones the delivery, and a failed postpone write lapses into a
+// normal visibility-timeout redelivery, so the loop cannot stall on an
+// enqueue.
 func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) error {
-	const opName = "process"
-
 	msg := delivery.Message()
 
 	buildID, err := entity.BuildIDFromBytes(msg.Payload)
@@ -161,39 +192,47 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 		return fmt.Errorf("failed to get status for build %s: %w", buildID.ID, err)
 	}
 
-	// Short-circuit if the batch is already halted (terminal OR cancelling).
-	// Speculate is already idempotent on terminal, but skipping the publish
-	// avoids noise. For Cancelling batches the cancel controller owns the
-	// terminal write and the downstream fan-out, so further pipeline work
-	// would race against it; silent ack is the only safe action.
-	if entity.IsBatchStateHalted(batch.State) {
-		metrics.NamedCounter(c.metricsScope, opName, "skipped_halted", 1)
-		c.logger.Infow("skipping buildsignal publish for halted batch",
-			"batch_id", batch.ID,
-			"state", string(batch.State),
-		)
-		return nil
+	// Reconcile before recording: a build still running that nothing wants any
+	// more is asked to stop. Best-effort by design — the reschedule below is
+	// what guarantees the request is remade, so a failed Cancel must not fail
+	// the message and take that reschedule with it.
+	if !status.IsTerminal() {
+		stop, err := c.unwanted(ctx, store, batch, build)
+		if err != nil {
+			return err
+		}
+		if stop {
+			if err := buildRunner.Cancel(ctx, buildID); err != nil {
+				metrics.NamedCounter(c.metricsScope, opName, "cancel_errors", 1)
+				c.logger.Warnw("failed to cancel an unwanted build; the next poll retries",
+					"build_id", build.ID,
+					"batch_id", build.BatchID,
+					"error", err,
+				)
+			} else {
+				metrics.NamedCounter(c.metricsScope, opName, "build_cancelled", 1)
+				c.logger.Infow("requested cancellation of a build nothing wants running",
+					"build_id", build.ID,
+					"batch_id", build.BatchID,
+					"path_id", build.PathID,
+					"attempt", build.Attempt,
+				)
+			}
+		}
 	}
 
-	updatedBuild := build
-	updatedBuild.Status = status
-
-	if err := store.GetBuildStore().Update(ctx, updatedBuild); err != nil {
-		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
-		return fmt.Errorf("failed to update status for build %s: %w", build.ID, err)
+	if status != build.Status {
+		build.Status = status
+		if err := store.GetBuildStore().Update(ctx, build); err != nil {
+			metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
+			return fmt.Errorf("failed to update status for build %s: %w", build.ID, err)
+		}
 	}
 
-	// Re-evaluate the batch state machine with the latest build status. The
-	// speculate topic is partitioned by queue like every other speculate
-	// publisher, so a queue's batches keep their serial processing guarantee.
-	// The message ID is scoped to (batch, build): the queue backend dedupes a
-	// publish on (topic, partition, id) against rows not yet garbage-collected,
-	// so reusing the bare batch ID — the ID the batch controller's original
-	// speculate publish used on this same partition — would silently drop this
-	// nudge. A redelivered poll re-mints the same (batch, build) ID, which
-	// dedupes to the first publish, exactly as intended.
-	signalID := fmt.Sprintf("%s/build-signal/%s", updatedBuild.BatchID, updatedBuild.ID)
-	if err := c.publishBatchID(ctx, topickey.TopicKeySpeculate, signalID, updatedBuild.BatchID, batch.Queue); err != nil {
+	// Wake the speculate run so it re-plans the queue with this result. It
+	// reads the status from the record above rather than being told it, so a
+	// duplicated or reordered signal costs nothing.
+	if err := c.publishBatchID(ctx, topickey.TopicKeySpeculate, batch.ID, batch.Queue); err != nil {
 		metrics.NamedCounter(c.metricsScope, opName, "publish_errors", 1)
 		return fmt.Errorf("failed to publish to speculate: %w", err)
 	}
@@ -201,8 +240,8 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	if status.IsTerminal() {
 		metrics.NamedCounter(c.metricsScope, opName, "terminal", 1, metrics.NewTag("status", string(status)))
 		c.logger.Infow("build reached terminal status",
-			"build_id", updatedBuild.ID,
-			"batch_id", updatedBuild.BatchID,
+			"build_id", build.ID,
+			"batch_id", build.BatchID,
 			"status", string(status),
 		)
 		return nil
@@ -215,7 +254,7 @@ func (c *Controller) Process(ctx context.Context, delivery consumer.Delivery) er
 	delivery.Hold(delayMs)
 
 	c.logger.Debugw("holding for next build status poll",
-		"build_id", updatedBuild.ID,
+		"build_id", build.ID,
 		"status", string(status),
 		"delay_ms", delayMs,
 	)
@@ -233,34 +272,106 @@ func pollDelay(status entity.BuildStatus) int64 {
 	}
 }
 
+// unwanted reports whether nothing wants this build running any more: its
+// batch has halted, its path was called off or has moved to another attempt,
+// or the attempt's link names a different build (this one lost a dispatch
+// race). Every one of those conditions is permanent once true, so a stale read
+// can only err toward keeping a build — never toward cancelling a wanted one.
+//
+// The two anomaly cases run the other way on purpose. A missing set or entry
+// cannot legitimately happen — the dispatch read the entry out of the set to
+// start this build, and entries are not removed — and a missing link cannot
+// either, because the signal that led here is published after the link. Both
+// therefore indicate store corruption, and since a cancel is irreversible, a
+// corrupt kill list keeps the build rather than killing it; a halted batch is
+// still caught by the first check, which needs none of those records.
+func (c *Controller) unwanted(ctx context.Context, store storage.Storage, batch entity.Batch, build entity.Build) (bool, error) {
+	if entity.IsBatchStateHalted(batch.State) {
+		return true, nil
+	}
+
+	// A build without path coordinates predates per-path dispatch; the batch
+	// state above is the only kill list it has.
+	if build.PathID == "" {
+		return false, nil
+	}
+
+	set, err := store.GetSpeculationPathSetStore().Get(ctx, batch.ID)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			metrics.NamedCounter(c.metricsScope, opName, "kill_list_anomalies", 1)
+			c.logger.Warnw("build exists but its head has no path set; keeping the build",
+				"build_id", build.ID,
+				"batch_id", batch.ID,
+			)
+			return false, nil
+		}
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
+		return false, fmt.Errorf("failed to get path set for batch %s: %w", batch.ID, err)
+	}
+
+	entry, found := findEntry(set, build.PathID)
+	if !found {
+		metrics.NamedCounter(c.metricsScope, opName, "kill_list_anomalies", 1)
+		c.logger.Warnw("build exists but its path is gone from the set; keeping the build",
+			"build_id", build.ID,
+			"batch_id", batch.ID,
+			"path_id", build.PathID,
+		)
+		return false, nil
+	}
+
+	switch entry.Status {
+	case entity.SpeculationPathStatusCancelling, entity.SpeculationPathStatusCancelled:
+		return true, nil
+	}
+
+	// The path has moved on to a newer attempt; this build belongs to a
+	// superseded one.
+	if entry.Attempt != build.Attempt {
+		return true, nil
+	}
+
+	link, err := store.GetPathBuildStore().Get(ctx, build.PathID, build.Attempt)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			metrics.NamedCounter(c.metricsScope, opName, "kill_list_anomalies", 1)
+			c.logger.Warnw("build exists but its attempt has no link; keeping the build",
+				"build_id", build.ID,
+				"path_id", build.PathID,
+				"attempt", build.Attempt,
+			)
+			return false, nil
+		}
+		metrics.NamedCounter(c.metricsScope, opName, "storage_errors", 1)
+		return false, fmt.Errorf("failed to look up build for path %s attempt %d: %w", build.PathID, build.Attempt, err)
+	}
+
+	// The attempt's build is a different one: this build lost the dispatch
+	// race, and nothing downstream will ever look at it.
+	return link.BuildID != build.ID, nil
+}
+
+// findEntry returns the set's entry for a path ID.
+func findEntry(set entity.SpeculationPathSet, pathID string) (entity.SpeculationPathEntry, bool) {
+	for _, entry := range set.Paths {
+		if entry.ID == pathID {
+			return entry, true
+		}
+	}
+	return entity.SpeculationPathEntry{}, false
+}
+
 // publishBatchID publishes a batch ID to the topic identified by key, stamped
-// with and partitioned by the batch's queue. msgID is the caller-owned message
-// identity the queue backend dedupes on; it must be distinct from other
-// publishes of the same batch ID on the same partition.
-func (c *Controller) publishBatchID(ctx context.Context, key consumer.TopicKey, msgID string, batchID string, queue string) error {
-	bid := entity.BatchID{ID: batchID, Queue: queue}
-	payload, err := bid.ToBytes()
+// with and partitioned by the batch's queue, with a distinct message ID per
+// publish (publish.UniqueID) so a later wake-up for the same batch is never
+// deduplicated away.
+func (c *Controller) publishBatchID(ctx context.Context, key consumer.TopicKey, batchID string, queue string) error {
+	payload, err := entity.BatchID{ID: batchID, Queue: queue}.ToBytes()
 	if err != nil {
 		return fmt.Errorf("failed to serialize batch ID: %w", err)
 	}
-
-	msg := entityqueue.NewMessage(msgID, payload, queue, nil)
-
-	q, ok := c.registry.Queue(key)
-	if !ok {
-		return fmt.Errorf("no queue registered for topic key %s", key)
-	}
-
-	topicName, ok := c.registry.TopicName(key)
-	if !ok {
-		return fmt.Errorf("no topic name registered for topic key %s", key)
-	}
-
-	if err := q.Publisher().Publish(ctx, topicName, msg); err != nil {
-		return fmt.Errorf("failed to publish message: %w", err)
-	}
-
-	return nil
+	return publish.Message(ctx, c.registry, key, publish.UniqueID(batchID), payload, queue)
 }
 
 // Name returns the controller name for logging and metrics.

--- a/submitqueue/orchestrator/controller/buildsignal/buildsignal_test.go
+++ b/submitqueue/orchestrator/controller/buildsignal/buildsignal_test.go
@@ -25,7 +25,6 @@ import (
 	entityqueue "github.com/uber/submitqueue/platform/base/messagequeue"
 	"github.com/uber/submitqueue/platform/consumer"
 	consumermock "github.com/uber/submitqueue/platform/consumer/mock"
-	"github.com/uber/submitqueue/platform/errs"
 	queuemock "github.com/uber/submitqueue/platform/extension/messagequeue/mock"
 	"github.com/uber/submitqueue/submitqueue/core/topickey"
 	"github.com/uber/submitqueue/submitqueue/entity"
@@ -36,14 +35,25 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+const (
+	testPathID  = "path-abc"
+	testAttempt = 2
+	testBuildID = "build-7"
+	testBatchID = "test-queue/batch/head"
+)
+
 // testHarness wires a Controller against mock queues for two topic keys
-// (buildsignal and speculate) so individual tests can assert which publish
-// or hold happens.
+// (buildsignal and speculate) so individual tests can assert which Publish
+// happens. Nothing may publish to buildsignal — the poll continuation is a
+// hold on the delivery — so the signal publisher carries no expectations and
+// any publish to it fails the test.
 type testHarness struct {
 	controller   *Controller
 	br           *buildrunnermock.MockBuildRunner
-	buildStore   *storagemock.MockBuildStore
+	builds       *storagemock.MockBuildStore
 	batchStore   *storagemock.MockBatchStore
+	pathSets     *storagemock.MockSpeculationPathSetStore
+	pathBuilds   *storagemock.MockPathBuildStore
 	signalPub    *queuemock.MockPublisher
 	speculatePub *queuemock.MockPublisher
 }
@@ -54,7 +64,7 @@ type staticStorageFactory struct{ store storage.Storage }
 // For returns the fixed store aggregate for any queue.
 func (f staticStorageFactory) For(storage.Config) (storage.Storage, error) { return f.store, nil }
 
-func newTestHarness(t *testing.T, ctrl *gomock.Controller) *testHarness {
+func newTestHarness(t *testing.T, ctrl *gomock.Controller, batchState entity.BatchState) *testHarness {
 	br := buildrunnermock.NewMockBuildRunner(ctrl)
 	brFactory := buildrunnermock.NewMockFactory(ctrl)
 	brFactory.EXPECT().For(gomock.Any()).Return(br, nil).AnyTimes()
@@ -73,11 +83,23 @@ func newTestHarness(t *testing.T, ctrl *gomock.Controller) *testHarness {
 	})
 	require.NoError(t, err)
 
-	buildStore := storagemock.NewMockBuildStore(ctrl)
+	builds := storagemock.NewMockBuildStore(ctrl)
 	batchStore := storagemock.NewMockBatchStore(ctrl)
+	batchStore.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.Batch{
+		ID: testBatchID, Queue: "test-queue", State: batchState, Version: 1,
+	}, nil).AnyTimes()
+
+	// The path set and link stores are wired read-only: their getters answer,
+	// but no write expectation exists, so any Create/Update from this
+	// controller fails the test.
+	pathSets := storagemock.NewMockSpeculationPathSetStore(ctrl)
+	pathBuilds := storagemock.NewMockPathBuildStore(ctrl)
+
 	store := storagemock.NewMockStorage(ctrl)
-	store.EXPECT().GetBuildStore().Return(buildStore).AnyTimes()
+	store.EXPECT().GetBuildStore().Return(builds).AnyTimes()
 	store.EXPECT().GetBatchStore().Return(batchStore).AnyTimes()
+	store.EXPECT().GetSpeculationPathSetStore().Return(pathSets).AnyTimes()
+	store.EXPECT().GetPathBuildStore().Return(pathBuilds).AnyTimes()
 
 	c := NewController(
 		zaptest.NewLogger(t).Sugar(),
@@ -91,31 +113,58 @@ func newTestHarness(t *testing.T, ctrl *gomock.Controller) *testHarness {
 	return &testHarness{
 		controller:   c,
 		br:           br,
-		buildStore:   buildStore,
+		builds:       builds,
 		batchStore:   batchStore,
+		pathSets:     pathSets,
+		pathBuilds:   pathBuilds,
 		signalPub:    signalPub,
 		speculatePub: speculatePub,
 	}
 }
 
-// buildDelivery builds a delivery whose payload is the build's ID, matching
-// the on-queue contract: only the identifier travels, the consumer loads the
-// full Build from storage. Tests that expect a hold add the expectation on
-// the returned mock.
-func buildDelivery(t *testing.T, ctrl *gomock.Controller, b entity.Build) *consumermock.MockDelivery {
+// wanted wires the kill-list reads to say the build is still wanted: its entry
+// is live on the build's own attempt, and the attempt's link names this build.
+func (h *testHarness) wanted() {
+	h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.SpeculationPathSet{
+		Head: testBatchID,
+		Paths: []entity.SpeculationPathEntry{
+			{ID: testPathID, Status: entity.SpeculationPathStatusBuilding, Attempt: testAttempt},
+		},
+	}, nil).AnyTimes()
+	h.pathBuilds.EXPECT().Get(gomock.Any(), testPathID, testAttempt).Return(entity.PathBuild{
+		PathID: testPathID, Attempt: testAttempt, BuildID: testBuildID,
+	}, nil).AnyTimes()
+}
+
+// delivery builds a delivery whose payload is the attempt's key, matching the
+// on-queue contract: only the identifier travels, and the consumer loads the
+// execution record — including the build ID — from storage. The concrete mock
+// is returned so tests can expect a Hold for the next poll.
+func delivery(t *testing.T, ctrl *gomock.Controller) *consumermock.MockDelivery {
 	t.Helper()
-	payload, err := entity.BuildID{ID: b.ID}.ToBytes()
+	payload, err := entity.BuildID{ID: testBuildID}.ToBytes()
 	require.NoError(t, err)
-	msg := entityqueue.NewMessage(b.ID, payload, b.BatchID, nil)
+	msg := entityqueue.NewMessage(testBuildID, payload, testBuildID, nil)
 	d := consumermock.NewMockDelivery(ctrl)
 	d.EXPECT().Message().Return(msg).AnyTimes()
 	d.EXPECT().Attempt().Return(1).AnyTimes()
 	return d
 }
 
+// testBuild returns the build under test, in the given status.
+func testBuild(status entity.BuildStatus) entity.Build {
+	return entity.Build{
+		ID:      testBuildID,
+		BatchID: testBatchID,
+		PathID:  testPathID,
+		Attempt: testAttempt,
+		Status:  status,
+	}
+}
+
 func TestController_Identity(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	h := newTestHarness(t, ctrl)
+	h := newTestHarness(t, ctrl, entity.BatchStateSpeculating)
 
 	assert.Equal(t, "buildsignal", h.controller.Name())
 	assert.Equal(t, topickey.TopicKeyBuildSignal, h.controller.TopicKey())
@@ -124,10 +173,10 @@ func TestController_Identity(t *testing.T) {
 	var _ consumer.Controller = h.controller
 }
 
-// TestController_Process_Terminal verifies a terminal poll persists the
-// status, publishes the batch ID to speculate, and does NOT hold the
-// delivery for another poll.
-func TestController_Process_Terminal(t *testing.T) {
+// The poll loop records status on the build and wakes the run. It must never
+// write the path set — that is the speculate run's state, and it is read here
+// only as the kill list.
+func TestProcess_RecordsStatusAndNeverWritesThePathSet(t *testing.T) {
 	tests := []struct {
 		name   string
 		status entity.BuildStatus
@@ -140,164 +189,384 @@ func TestController_Process_Terminal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			h := newTestHarness(t, ctrl)
+			h := newTestHarness(t, ctrl, entity.BatchStateSpeculating)
 
-			build := entity.Build{ID: "b-1", BatchID: "batch-1", Status: entity.BuildStatusAccepted}
-			updatedBuild := build
-			updatedBuild.Status = tt.status
+			h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+			h.br.EXPECT().Status(gomock.Any(), entity.BuildID{ID: testBuildID}).Return(tt.status, nil, nil)
+			h.builds.EXPECT().Update(gomock.Any(), testBuild(tt.status)).Return(nil)
 
-			h.buildStore.EXPECT().Get(gomock.Any(), build.ID).Return(build, nil)
-			h.br.EXPECT().Status(gomock.Any(), entity.BuildID{ID: build.ID}).Return(tt.status, entity.BuildMetadata{}, nil)
-			h.batchStore.EXPECT().Get(gomock.Any(), build.BatchID).Return(entity.Batch{ID: build.BatchID, State: entity.BatchStateSpeculating}, nil)
-			h.buildStore.EXPECT().Update(gomock.Any(), updatedBuild).Return(nil)
-			h.speculatePub.EXPECT().
-				Publish(gomock.Any(), "speculate", gomock.AssignableToTypeOf(entityqueue.Message{})).
-				DoAndReturn(func(_ context.Context, _ string, msg entityqueue.Message) error {
-					bid, err := entity.BatchIDFromBytes(msg.Payload)
-					require.NoError(t, err)
-					assert.Equal(t, build.BatchID, bid.ID)
-					return nil
-				}).Times(1)
-			// No Hold expected on terminal — any Hold call fails the test.
+			h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+			// Terminal: no reschedule, no Cancel, and not even a kill-list read
+			// — a finished build has nothing left to stop. Any path-set write
+			// fails the test (none is expected on the mock).
 
-			err := h.controller.Process(context.Background(), buildDelivery(t, ctrl, build))
-			require.NoError(t, err)
+			require.NoError(t, h.controller.Process(context.Background(), delivery(t, ctrl)))
 		})
 	}
 }
 
-// TestController_Process_NonTerminal verifies a non-terminal poll persists
-// the status, publishes to speculate, AND holds the delivery for the next
-// poll with the per-status delay.
-func TestController_Process_NonTerminal(t *testing.T) {
+// While a build is in flight the loop holds the delivery for the poll delay,
+// so the same message — and the same build partition — carries every poll.
+func TestProcess_NonTerminalHoldsForNextPoll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := newTestHarness(t, ctrl, entity.BatchStateSpeculating)
+	h.wanted()
+
+	h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusAccepted), nil)
+	h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+	h.builds.EXPECT().Update(gomock.Any(), testBuild(entity.BuildStatusRunning)).Return(nil)
+
+	h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+	d := delivery(t, ctrl)
+	d.EXPECT().Hold(PollDelayRunningMs)
+
+	require.NoError(t, h.controller.Process(context.Background(), d))
+}
+
+// An unchanged status is not rewritten on every poll of a long build.
+func TestProcess_UnchangedStatusSkipsWrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := newTestHarness(t, ctrl, entity.BatchStateSpeculating)
+	h.wanted()
+
+	h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+	h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+	// No Update expected.
+	h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+	d := delivery(t, ctrl)
+	d.EXPECT().Hold(PollDelayRunningMs)
+
+	require.NoError(t, h.controller.Process(context.Background(), d))
+}
+
+// TestProcess_StopsUnwantedBuilds covers the kill list: a running build is
+// cancelled the moment nothing wants it — its path called off, its attempt
+// superseded, its link naming a different build, or its whole batch halted —
+// and the poll keeps running so a later poll records the stop.
+func TestProcess_StopsUnwantedBuilds(t *testing.T) {
 	tests := []struct {
-		name        string
-		status      entity.BuildStatus
-		wantDelayMs int64
+		name       string
+		batchState entity.BatchState
+		setup      func(h *testHarness)
 	}{
-		{"accepted uses accepted delay", entity.BuildStatusAccepted, PollDelayAcceptedMs},
-		{"running uses running delay", entity.BuildStatusRunning, PollDelayRunningMs},
+		{
+			name:       "path cancelling",
+			batchState: entity.BatchStateSpeculating,
+			setup: func(h *testHarness) {
+				h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.SpeculationPathSet{
+					Head: testBatchID,
+					Paths: []entity.SpeculationPathEntry{
+						{ID: testPathID, Status: entity.SpeculationPathStatusCancelling, Attempt: testAttempt},
+					},
+				}, nil)
+			},
+		},
+		{
+			name:       "path cancelled",
+			batchState: entity.BatchStateSpeculating,
+			setup: func(h *testHarness) {
+				h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.SpeculationPathSet{
+					Head: testBatchID,
+					Paths: []entity.SpeculationPathEntry{
+						{ID: testPathID, Status: entity.SpeculationPathStatusCancelled, Attempt: testAttempt},
+					},
+				}, nil)
+			},
+		},
+		{
+			name:       "attempt superseded",
+			batchState: entity.BatchStateSpeculating,
+			setup: func(h *testHarness) {
+				h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.SpeculationPathSet{
+					Head: testBatchID,
+					Paths: []entity.SpeculationPathEntry{
+						{ID: testPathID, Status: entity.SpeculationPathStatusPending, Attempt: testAttempt + 1},
+					},
+				}, nil)
+			},
+		},
+		{
+			name:       "link names another build",
+			batchState: entity.BatchStateSpeculating,
+			setup: func(h *testHarness) {
+				h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.SpeculationPathSet{
+					Head: testBatchID,
+					Paths: []entity.SpeculationPathEntry{
+						{ID: testPathID, Status: entity.SpeculationPathStatusBuilding, Attempt: testAttempt},
+					},
+				}, nil)
+				h.pathBuilds.EXPECT().Get(gomock.Any(), testPathID, testAttempt).Return(entity.PathBuild{
+					PathID: testPathID, Attempt: testAttempt, BuildID: "build-winner",
+				}, nil)
+			},
+		},
+		{
+			name:       "batch halted",
+			batchState: entity.BatchStateCancelling,
+			setup: func(h *testHarness) {
+				// No kill-list reads: the batch state alone decides, so no
+				// set/link expectations exist and any read fails the test.
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			h := newTestHarness(t, ctrl)
+			h := newTestHarness(t, ctrl, tt.batchState)
+			tt.setup(h)
 
-			build := entity.Build{ID: "b-2", BatchID: "batch-2", Status: entity.BuildStatusAccepted}
-			updatedBuild := build
-			updatedBuild.Status = tt.status
+			h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+			h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+			h.br.EXPECT().Cancel(gomock.Any(), entity.BuildID{ID: testBuildID}).Return(nil)
 
-			h.buildStore.EXPECT().Get(gomock.Any(), build.ID).Return(build, nil)
-			h.br.EXPECT().Status(gomock.Any(), entity.BuildID{ID: build.ID}).Return(tt.status, entity.BuildMetadata{}, nil)
-			h.batchStore.EXPECT().Get(gomock.Any(), build.BatchID).Return(entity.Batch{ID: build.BatchID, State: entity.BatchStateSpeculating}, nil)
-			h.buildStore.EXPECT().Update(gomock.Any(), updatedBuild).Return(nil)
-			h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil).Times(1)
+			h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+			d := delivery(t, ctrl)
+			d.EXPECT().Hold(PollDelayRunningMs)
 
-			d := buildDelivery(t, ctrl, build)
-			d.EXPECT().Hold(tt.wantDelayMs)
-
-			err := h.controller.Process(context.Background(), d)
-			require.NoError(t, err)
+			require.NoError(t, h.controller.Process(context.Background(), d))
 		})
 	}
 }
 
-func TestController_Process_StatusError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	h := newTestHarness(t, ctrl)
-
-	build := entity.Build{ID: "b-3", BatchID: "batch-3", Status: entity.BuildStatusAccepted}
-
-	h.buildStore.EXPECT().Get(gomock.Any(), build.ID).Return(build, nil)
-	h.batchStore.EXPECT().Get(gomock.Any(), build.BatchID).Return(entity.Batch{ID: build.BatchID, State: entity.BatchStateSpeculating}, nil)
-	h.br.EXPECT().Status(gomock.Any(), entity.BuildID{ID: build.ID}).Return(entity.BuildStatusUnknown, nil, errors.New("provider down"))
-	// No Update, no Publish, no Hold expected.
-
-	err := h.controller.Process(context.Background(), buildDelivery(t, ctrl, build))
-	require.Error(t, err)
-	// Non-retryable: rejects to DLQ on first failure; republish is the recovery path.
-	assert.False(t, errs.IsRetryable(err))
-}
-
-func TestController_Process_UpdateError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	h := newTestHarness(t, ctrl)
-
-	build := entity.Build{ID: "b-4", BatchID: "batch-4", Status: entity.BuildStatusAccepted}
-	updatedBuild := build
-	updatedBuild.Status = entity.BuildStatusRunning
-
-	h.buildStore.EXPECT().Get(gomock.Any(), build.ID).Return(build, nil)
-	h.br.EXPECT().Status(gomock.Any(), entity.BuildID{ID: build.ID}).Return(entity.BuildStatusRunning, nil, nil)
-	h.batchStore.EXPECT().Get(gomock.Any(), build.BatchID).Return(entity.Batch{ID: build.BatchID, State: entity.BatchStateSpeculating}, nil)
-	h.buildStore.EXPECT().Update(gomock.Any(), updatedBuild).
-		Return(errors.New("db unreachable"))
-	// No Publish / Hold expected after the store failure.
-
-	err := h.controller.Process(context.Background(), buildDelivery(t, ctrl, build))
-	require.Error(t, err)
-	// Non-retryable: rejects to DLQ on first failure; republish is the recovery path.
-	assert.False(t, errs.IsRetryable(err))
-}
-
-// TestController_Process_GetError verifies that a failure to load the Build
-// from storage (only the ID is on the queue) surfaces an error. Non-retryable:
-// it rejects to DLQ on first failure, consistent with other storage reads.
-func TestController_Process_GetError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	h := newTestHarness(t, ctrl)
-
-	build := entity.Build{ID: "b-6", BatchID: "batch-6", Status: entity.BuildStatusAccepted}
-
-	h.buildStore.EXPECT().Get(gomock.Any(), build.ID).Return(entity.Build{}, errors.New("db unreachable"))
-	// No Status / Update / Publish expected once the load fails.
-
-	err := h.controller.Process(context.Background(), buildDelivery(t, ctrl, build))
-	require.Error(t, err)
-	assert.False(t, errs.IsRetryable(err))
-}
-
-func TestController_Process_MalformedPayload(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	h := newTestHarness(t, ctrl)
-
-	msg := entityqueue.NewMessage("bad", []byte(`{"invalid"`), "batch-bad", nil)
-	d := consumermock.NewMockDelivery(ctrl)
-	d.EXPECT().Message().Return(msg).AnyTimes()
-	d.EXPECT().Attempt().Return(1).AnyTimes()
-
-	err := h.controller.Process(context.Background(), d)
-	require.Error(t, err)
-}
-
-// A halted batch (terminal OR cancelling) must short-circuit: just ack, no
-// status persist and no publish to speculate. For terminal: speculate is
-// already idempotent on terminal, but skipping the publish keeps the system
-// from re-emitting noise. For Cancelling: the cancel controller owns the
-// terminal write and downstream fan-out, so any further pipeline work would
-// race against it.
-func TestController_Process_HaltedShortCircuit(t *testing.T) {
-	for _, state := range []entity.BatchState{
-		entity.BatchStateCancelled,
-		entity.BatchStateCancelling,
-		entity.BatchStateSucceeded,
-		entity.BatchStateFailed,
+// TestProcess_KeepsWantedBuilds is the inverse: a live entry on the build's own
+// attempt, linked to this very build, must never be cancelled.
+func TestProcess_KeepsWantedBuilds(t *testing.T) {
+	for _, status := range []entity.SpeculationPathStatus{
+		entity.SpeculationPathStatusPending,
+		entity.SpeculationPathStatusBuilding,
+		entity.SpeculationPathStatusPassed,
 	} {
-		t.Run(string(state), func(t *testing.T) {
+		t.Run(string(status), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			h := newTestHarness(t, ctrl)
+			h := newTestHarness(t, ctrl, entity.BatchStateSpeculating)
 
-			build := entity.Build{ID: "b-halt", BatchID: "batch-halt", Status: entity.BuildStatusAccepted}
+			h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.SpeculationPathSet{
+				Head: testBatchID,
+				Paths: []entity.SpeculationPathEntry{
+					{ID: testPathID, Status: status, Attempt: testAttempt},
+				},
+			}, nil)
+			h.pathBuilds.EXPECT().Get(gomock.Any(), testPathID, testAttempt).Return(entity.PathBuild{
+				PathID: testPathID, Attempt: testAttempt, BuildID: testBuildID,
+			}, nil)
 
-			h.buildStore.EXPECT().Get(gomock.Any(), build.ID).Return(build, nil)
-			h.br.EXPECT().Status(gomock.Any(), entity.BuildID{ID: build.ID}).Return(entity.BuildStatusRunning, entity.BuildMetadata{}, nil)
-			h.batchStore.EXPECT().Get(gomock.Any(), build.BatchID).Return(entity.Batch{ID: build.BatchID, State: state}, nil)
-			// Halted: no Update, no speculate Publish, no Hold. The
-			// harness publishers have no expectations, so any publish fails
-			// the test.
+			h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+			h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+			h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+			d := delivery(t, ctrl)
+			d.EXPECT().Hold(PollDelayRunningMs)
 
-			require.NoError(t, h.controller.Process(context.Background(), buildDelivery(t, ctrl, build)))
+			// No Cancel: gomock fails the test if one happens.
+			require.NoError(t, h.controller.Process(context.Background(), d))
+		})
+	}
+}
+
+// A kill list that cannot legitimately be missing keeps the build when it is:
+// a cancel is irreversible, so store anomalies err toward keeping. The halted
+// check still covers every real stop that matters for such a batch.
+func TestProcess_AnomalousKillListKeepsTheBuild(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(h *testHarness)
+	}{
+		{
+			name: "path set missing",
+			setup: func(h *testHarness) {
+				h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).
+					Return(entity.SpeculationPathSet{}, storage.ErrNotFound)
+			},
+		},
+		{
+			name: "entry missing from the set",
+			setup: func(h *testHarness) {
+				h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.SpeculationPathSet{
+					Head: testBatchID,
+					Paths: []entity.SpeculationPathEntry{
+						{ID: "some-other-path", Status: entity.SpeculationPathStatusBuilding, Attempt: 1},
+					},
+				}, nil)
+			},
+		},
+		{
+			name: "link missing",
+			setup: func(h *testHarness) {
+				h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.SpeculationPathSet{
+					Head: testBatchID,
+					Paths: []entity.SpeculationPathEntry{
+						{ID: testPathID, Status: entity.SpeculationPathStatusBuilding, Attempt: testAttempt},
+					},
+				}, nil)
+				h.pathBuilds.EXPECT().Get(gomock.Any(), testPathID, testAttempt).
+					Return(entity.PathBuild{}, storage.ErrNotFound)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			h := newTestHarness(t, ctrl, entity.BatchStateSpeculating)
+			tt.setup(h)
+
+			h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+			h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+			h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+			d := delivery(t, ctrl)
+			d.EXPECT().Hold(PollDelayRunningMs)
+
+			// No Cancel: gomock fails the test if one happens.
+			require.NoError(t, h.controller.Process(context.Background(), d))
+		})
+	}
+}
+
+// A failed Cancel must not fail the message: the held delivery is the only
+// thing that will retry the cancel, so the poll survives and remakes the
+// check.
+func TestProcess_CancelFailureDoesNotFailThePoll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := newTestHarness(t, ctrl, entity.BatchStateCancelling)
+
+	h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+	h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+	h.br.EXPECT().Cancel(gomock.Any(), entity.BuildID{ID: testBuildID}).
+		Return(errors.New("runner unavailable"))
+
+	h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+	d := delivery(t, ctrl)
+	d.EXPECT().Hold(PollDelayRunningMs)
+
+	require.NoError(t, h.controller.Process(context.Background(), d))
+}
+
+// A build without path coordinates predates per-path dispatch. The batch state
+// is the only kill list it has: no set or link is read for it.
+func TestProcess_BuildWithoutPathChecksOnlyTheBatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := newTestHarness(t, ctrl, entity.BatchStateSpeculating)
+
+	legacy := testBuild(entity.BuildStatusRunning)
+	legacy.PathID = ""
+	legacy.Attempt = 0
+
+	h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(legacy, nil)
+	h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+	h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+	d := delivery(t, ctrl)
+	d.EXPECT().Hold(PollDelayRunningMs)
+
+	// No set/link reads and no Cancel: gomock fails the test on any of them.
+	require.NoError(t, h.controller.Process(context.Background(), d))
+}
+
+// TestProcess_HaltedBatchStillRuns is the cancellation-correctness case. A
+// cancelling batch reaches terminal only once its builds stop, and this loop is
+// what stops them and watches them stop, so a halted batch must still be
+// polled, cancelled, recorded and rescheduled. Short-circuiting strands it in
+// Cancelling forever.
+func TestProcess_HaltedBatchStillRuns(t *testing.T) {
+	t.Run("cancels and holds for the next poll while the build runs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		h := newTestHarness(t, ctrl, entity.BatchStateCancelling)
+
+		h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+		h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+		h.br.EXPECT().Cancel(gomock.Any(), entity.BuildID{ID: testBuildID}).Return(nil)
+		h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+		d := delivery(t, ctrl)
+		d.EXPECT().Hold(PollDelayRunningMs)
+
+		require.NoError(t, h.controller.Process(context.Background(), d))
+	})
+
+	t.Run("still records the terminal status", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		h := newTestHarness(t, ctrl, entity.BatchStateCancelling)
+
+		h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+		h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusCancelled, nil, nil)
+		h.builds.EXPECT().Update(gomock.Any(), testBuild(entity.BuildStatusCancelled)).Return(nil)
+		h.speculatePub.EXPECT().Publish(gomock.Any(), "speculate", gomock.Any()).Return(nil)
+
+		// Terminal: no Cancel and no reschedule.
+		require.NoError(t, h.controller.Process(context.Background(), delivery(t, ctrl)))
+	})
+}
+
+func TestProcess_Errors(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(h *testHarness)
+	}{
+		{
+			name: "build read failure",
+			setup: func(h *testHarness) {
+				h.builds.EXPECT().Get(gomock.Any(), testBuildID).
+					Return(entity.Build{}, errors.New("connection reset"))
+			},
+		},
+		{
+			name: "status failure",
+			setup: func(h *testHarness) {
+				h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+				h.br.EXPECT().Status(gomock.Any(), gomock.Any()).
+					Return(entity.BuildStatusUnknown, nil, errors.New("runner unavailable"))
+			},
+		},
+		{
+			name: "kill list set read failure",
+			setup: func(h *testHarness) {
+				h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+				h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+				h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).
+					Return(entity.SpeculationPathSet{}, errors.New("connection reset"))
+			},
+		},
+		{
+			name: "kill list link read failure",
+			setup: func(h *testHarness) {
+				h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+				h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+				h.pathSets.EXPECT().Get(gomock.Any(), testBatchID).Return(entity.SpeculationPathSet{
+					Head: testBatchID,
+					Paths: []entity.SpeculationPathEntry{
+						{ID: testPathID, Status: entity.SpeculationPathStatusBuilding, Attempt: testAttempt},
+					},
+				}, nil)
+				h.pathBuilds.EXPECT().Get(gomock.Any(), testPathID, testAttempt).
+					Return(entity.PathBuild{}, errors.New("connection reset"))
+			},
+		},
+		{
+			name: "status write failure",
+			setup: func(h *testHarness) {
+				h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+				h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusSucceeded, nil, nil)
+				h.builds.EXPECT().Update(gomock.Any(), gomock.Any()).
+					Return(errors.New("connection reset"))
+			},
+		},
+		{
+			name: "speculate publish failure",
+			setup: func(h *testHarness) {
+				h.wanted()
+				h.builds.EXPECT().Get(gomock.Any(), testBuildID).Return(testBuild(entity.BuildStatusRunning), nil)
+				h.br.EXPECT().Status(gomock.Any(), gomock.Any()).Return(entity.BuildStatusRunning, nil, nil)
+				h.speculatePub.EXPECT().Publish(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(errors.New("queue down"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			h := newTestHarness(t, ctrl, entity.BatchStateSpeculating)
+			tt.setup(h)
+
+			require.Error(t, h.controller.Process(context.Background(), delivery(t, ctrl)))
 		})
 	}
 }

--- a/submitqueue/orchestrator/controller/dlq/buildsignal.go
+++ b/submitqueue/orchestrator/controller/dlq/buildsignal.go
@@ -28,13 +28,13 @@ import (
 )
 
 // buildSignalController is the DLQ reconciler for the buildsignal topic. Its
-// payload carries a BuildID, so reconciliation needs an extra hop: look up
-// the Build to recover its BatchID, then fan out via failBatch.
+// payload names a build, so reconciliation needs one hop: read the build to
+// recover its batch, then fan out via failBatch.
 //
-// The build itself is left in whatever non-terminal state the build runner
-// last reported. Fixing the build entity is not useful here — the
-// pipeline's source of truth for "did this batch finish" is the batch state,
-// and that is what gates the gateway response and conclude.
+// The build is left in whatever non-terminal state the runner last reported.
+// Fixing it is not useful here — the pipeline's source of truth for "did this
+// batch finish" is the batch state, and that is what gates the gateway response
+// and conclude.
 type buildSignalController struct {
 	logger        *zap.SugaredLogger
 	metricsScope  tally.Scope
@@ -73,54 +73,50 @@ func (c *buildSignalController) Process(ctx context.Context, delivery consumer.D
 
 	msg := delivery.Message()
 
-	bid, err := entity.BuildIDFromBytes(msg.Payload)
+	buildID, err := entity.BuildIDFromBytes(msg.Payload)
 	if err != nil {
 		metrics.NamedCounter(c.metricsScope, opName, "deserialize_errors", 1)
 		return fmt.Errorf("failed to decode build id from dlq payload: %w", err)
 	}
-	if bid.ID == "" {
+	if buildID.ID == "" {
 		metrics.NamedCounter(c.metricsScope, opName, "empty_id_errors", 1)
 		return fmt.Errorf("dlq payload decoded to empty build id")
 	}
 
-	store, err := c.stores.For(storage.Config{QueueName: bid.Queue})
+	store, err := c.stores.For(storage.Config{QueueName: buildID.Queue})
 	if err != nil {
 		metrics.NamedCounter(c.metricsScope, opName, "storage_resolve_errors", 1)
 		// Non-retryable: a missing or unresolvable queue is a malformed message.
-		return fmt.Errorf("failed to resolve storage for queue %q: %w", bid.Queue, err)
+		return fmt.Errorf("failed to resolve storage for queue %q: %w", buildID.Queue, err)
 	}
 
 	dmeta := delivery.Metadata()
 	c.logger.Warnw("dlq message received",
-		"build_id", bid.ID,
+		"build_id", buildID.ID,
 		"attempt", delivery.Attempt(),
 		"dlq_original_topic", dmeta["dlq.original_topic"],
 		"dlq_failure_count", dmeta["dlq.failure_count"],
 		"dlq_last_error", dmeta["dlq.last_error"],
 	)
 
-	build, err := store.GetBuildStore().Get(ctx, bid.ID)
+	build, err := store.GetBuildStore().Get(ctx, buildID.ID)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			// The build was never persisted (e.g. the build controller crashed
-			// before Create). There is no batch to reconcile from this signal —
-			// any associated batch should be reconciled from its own DLQ.
-			c.logger.Warnw("dlq reconcile: build not found, skipping",
-				"build_id", bid.ID,
-			)
+			// The build was never recorded (e.g. a crash between triggering and
+			// writing it down). There is no batch to reconcile from this
+			// signal; any associated batch reconciles from its own DLQ.
+			c.logger.Warnw("dlq reconcile: build not found, skipping", "build_id", buildID.ID)
 			metrics.NamedCounter(c.metricsScope, opName, "build_not_found", 1)
 			return nil
 		}
 		metrics.NamedCounter(c.metricsScope, opName, "build_store_errors", 1)
-		return fmt.Errorf("failed to get build %s: %w", bid.ID, err)
+		return fmt.Errorf("failed to get build %s: %w", buildID.ID, err)
 	}
 
 	if build.BatchID == "" {
 		// Defensive: a build without a batch is malformed and there is nothing
 		// to fan out to. Log and ack so the DLQ does not grow unbounded.
-		c.logger.Errorw("dlq reconcile: build has empty batch id, skipping",
-			"build_id", bid.ID,
-		)
+		c.logger.Errorw("dlq reconcile: build has empty batch id, skipping", "build_id", buildID.ID)
 		metrics.NamedCounter(c.metricsScope, opName, "build_missing_batch", 1)
 		return nil
 	}

--- a/submitqueue/orchestrator/controller/dlq/buildsignal_test.go
+++ b/submitqueue/orchestrator/controller/dlq/buildsignal_test.go
@@ -46,7 +46,8 @@ func TestDLQBuildSignalController_Process_FansOutToBatch(t *testing.T) {
 
 	buildStore := storagemock.NewMockBuildStore(ctrl)
 	buildStore.EXPECT().Get(gomock.Any(), "build-1").Return(entity.Build{
-		ID: "build-1", BatchID: "q/batch/2", Status: entity.BuildStatusRunning,
+		ID: "build-1", BatchID: "q/batch/2", PathID: "path-1", Attempt: 1,
+		Status: entity.BuildStatusRunning,
 	}, nil)
 
 	batchStore := storagemock.NewMockBatchStore(ctrl)


### PR DESCRIPTION
## Summary
### Why?

The poll loop was writing the path set on every terminal build — the third concurrent writer on a row where the speculate run, which holds a version across its whole Speculator call, was structurally the one to lose. And with the build stage now start-only, something has to enact cancellation.

### What?

The poll loop becomes speculation's kill mechanism. On every poll of a non-terminal build it checks whether anything still wants the build running — batch not halted, the path's entry live and on this build's attempt, the attempt's link naming this very build — and asks the runner to cancel when nothing does. That one level-triggered check subsumes path cancels, batch halts, superseded attempts, and lost dispatch races: no cancel message exists to go stale, and a check that misses one poll is remade on the next.

It cannot cancel a wanted build: every "unwanted" condition is permanent once true, so a stale read only errs toward keeping, and store anomalies (a set, entry, or link that cannot legitimately be missing) also keep the build — a cancel is irreversible. The Cancel call is best-effort so a failure never kills the poll chain that would retry it. The path set is read as that kill list and never written.

Polls now partition on the build ID rather than the batch, and each re-poll mints a distinct message ID so the queue never dedups it away. The halted short-circuit stays removed: a cancelling batch reaches terminal only once its builds stop, and this loop is both what stops them and what watches them stop.

## Test Plan
✅ `bazel test //submitqueue/orchestrator/...` — every unwanted condition cancels; a wanted build never sees a Cancel; anomalies keep the build; a failed Cancel does not fail the poll; statuses recorded per terminal state; and no path-set write happens at all (the set store is wired read-only on the mock).

✅ `make fmt`, `make gazelle`

## Issues

