### PR TITLE
refactor(stovepipe): retire entity JSON queue serializers (CODEM-306)

### DIFF
--- a/stovepipe/entity/build.go
+++ b/stovepipe/entity/build.go
@@ -14,8 +14,6 @@
 
 package entity
 
-import "encoding/json"
-
 // BuildStatus defines the possible states of a build. Shaped the same as
 // SubmitQueue's own BuildStatus (submitqueue/entity/build.go), but defined
 // locally rather than shared — see build.md's "Alternatives considered for
@@ -74,36 +72,11 @@ type Build struct {
 	Version int32 `json:"version"`
 }
 
-// ToBytes serializes the Build to JSON bytes for queue message payload.
-func (b Build) ToBytes() ([]byte, error) {
-	return json.Marshal(b)
-}
-
-// BuildFromBytes deserializes a Build from JSON bytes.
-func BuildFromBytes(data []byte) (Build, error) {
-	var build Build
-	err := json.Unmarshal(data, &build)
-	return build, err
-}
-
-// BuildID is a lightweight entity for publishing and consuming just the
-// build identifier via the queue, and for the BuildRunner Status/Cancel
-// parameter. It wraps the one runner-assigned id everywhere it appears.
+// BuildID wraps the runner-assigned build identifier for BuildRunner
+// Status/Cancel/Trigger parameters.
 type BuildID struct {
 	// ID is the runner-assigned identifier for the build.
 	ID string `json:"id"`
-}
-
-// ToBytes serializes the BuildID to JSON bytes for queue message payload.
-func (b BuildID) ToBytes() ([]byte, error) {
-	return json.Marshal(b)
-}
-
-// BuildIDFromBytes deserializes a BuildID from JSON bytes.
-func BuildIDFromBytes(data []byte) (BuildID, error) {
-	var bid BuildID
-	err := json.Unmarshal(data, &bid)
-	return bid, err
 }
 
 // BuildMetadata carries caller-supplied, provider-echoed free-form metadata

--- a/stovepipe/entity/build_test.go
+++ b/stovepipe/entity/build_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBuildStatus_IsTerminal(t *testing.T) {
@@ -40,83 +39,4 @@ func TestBuildStatus_IsTerminal(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.status.IsTerminal())
 		})
 	}
-}
-
-func TestBuild_SerializationRoundTrip(t *testing.T) {
-	tests := []struct {
-		name  string
-		build Build
-	}{
-		{
-			name: "accepted incremental build",
-			build: Build{
-				ID:        "bk-1001",
-				RequestID: "request/monorepo/main/42",
-				Status:    BuildStatusAccepted,
-				Version:   1,
-			},
-		},
-		{
-			name: "succeeded full build with no baseline",
-			build: Build{
-				ID:        "bk-1002",
-				RequestID: "request/monorepo/main/43",
-				Status:    BuildStatusSucceeded,
-				Version:   3,
-			},
-		},
-		{
-			name: "failed build",
-			build: Build{
-				ID:        "bk-1003",
-				RequestID: "request/monorepo/main/44",
-				Status:    BuildStatusFailed,
-				Version:   2,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			data, err := tt.build.ToBytes()
-			require.NoError(t, err)
-
-			deserialized, err := BuildFromBytes(data)
-			require.NoError(t, err)
-
-			assert.Equal(t, tt.build, deserialized)
-		})
-	}
-}
-
-func TestBuildFromBytes_InvalidJSON(t *testing.T) {
-	_, err := BuildFromBytes([]byte(`{"invalid": json"}`))
-	assert.Error(t, err)
-}
-
-func TestBuildFromBytes_EmptyData(t *testing.T) {
-	build, err := BuildFromBytes([]byte(`{}`))
-	require.NoError(t, err)
-
-	assert.Empty(t, build.ID)
-	assert.Empty(t, build.RequestID)
-	assert.Equal(t, BuildStatusUnknown, build.Status)
-	assert.Equal(t, int32(0), build.Version)
-}
-
-func TestBuildID_SerializationRoundTrip(t *testing.T) {
-	original := BuildID{ID: "bk-1001"}
-
-	data, err := original.ToBytes()
-	require.NoError(t, err)
-
-	deserialized, err := BuildIDFromBytes(data)
-	require.NoError(t, err)
-
-	assert.Equal(t, original, deserialized)
-}
-
-func TestBuildIDFromBytes_InvalidJSON(t *testing.T) {
-	_, err := BuildIDFromBytes([]byte(`{"invalid": json"}`))
-	assert.Error(t, err)
 }

--- a/stovepipe/entity/request.go
+++ b/stovepipe/entity/request.go
@@ -14,10 +14,6 @@
 
 package entity
 
-import (
-	"encoding/json"
-)
-
 // RequestState defines the internal state of a Stovepipe validation request as it moves
 // through the pipeline. States are internal and used to implement a state machine; a
 // customer-facing status type may be layered on top later, as in SubmitQueue.
@@ -123,34 +119,4 @@ type Request struct {
 	// Version is the version of the object. It is used for optimistic locking.
 	// Versioning starts at 1 and is incremented for each change to the object.
 	Version int32 `json:"version"`
-}
-
-// ToBytes serializes the Request to JSON bytes for queue message payload.
-func (r Request) ToBytes() ([]byte, error) {
-	return json.Marshal(r)
-}
-
-// RequestFromBytes deserializes a Request from JSON bytes.
-func RequestFromBytes(data []byte) (Request, error) {
-	var req Request
-	err := json.Unmarshal(data, &req)
-	return req, err
-}
-
-// RequestID is a lightweight entity for publishing and consuming just the request identifier via the queue.
-type RequestID struct {
-	// ID is the globally unique identifier for the request.
-	ID string `json:"id"`
-}
-
-// ToBytes serializes the RequestID to JSON bytes for queue message payload.
-func (r RequestID) ToBytes() ([]byte, error) {
-	return json.Marshal(r)
-}
-
-// RequestIDFromBytes deserializes a RequestID from JSON bytes.
-func RequestIDFromBytes(data []byte) (RequestID, error) {
-	var rid RequestID
-	err := json.Unmarshal(data, &rid)
-	return rid, err
 }

--- a/stovepipe/entity/request_test.go
+++ b/stovepipe/entity/request_test.go
@@ -18,66 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestRequest_SerializationRoundTrip(t *testing.T) {
-	tests := []struct {
-		name string
-		req  Request
-	}{
-		{
-			name: "accepted with resolved uri",
-			req: Request{
-				ID:      "request/monorepo/main/100",
-				Queue:   "monorepo/main",
-				URI:     "git://remote/monorepo/main/abcdef0123456789",
-				State:   RequestStateAccepted,
-				Version: 1,
-			},
-		},
-		{
-			name: "processing with strategy and baseline",
-			req: Request{
-				ID:            "request/monorepo/main/101",
-				Queue:         "monorepo/main",
-				URI:           "git://remote/monorepo/main/bbbb2222",
-				State:         RequestStateProcessing,
-				BuildStrategy: BuildStrategyIncrementalSinceGreen,
-				BaseURI:       "git://remote/monorepo/main/green-aaaa",
-				Version:       2,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			data, err := tt.req.ToBytes()
-			require.NoError(t, err)
-
-			deserialized, err := RequestFromBytes(data)
-			require.NoError(t, err)
-
-			assert.Equal(t, tt.req, deserialized)
-		})
-	}
-}
-
-func TestRequestFromBytes_InvalidJSON(t *testing.T) {
-	_, err := RequestFromBytes([]byte(`{"invalid": json"}`))
-	assert.Error(t, err)
-}
-
-func TestRequestFromBytes_EmptyData(t *testing.T) {
-	req, err := RequestFromBytes([]byte(`{}`))
-	require.NoError(t, err)
-
-	assert.Empty(t, req.ID)
-	assert.Empty(t, req.Queue)
-	assert.Empty(t, req.URI)
-	assert.Equal(t, RequestStateUnknown, req.State)
-	assert.Equal(t, int32(0), req.Version)
-}
 
 func TestRequestState_IsTerminal(t *testing.T) {
 	tests := []struct {
@@ -121,16 +62,4 @@ func TestRequestState_HasBuildOutcome(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.state.HasBuildOutcome())
 		})
 	}
-}
-
-func TestRequestID_SerializationRoundTrip(t *testing.T) {
-	original := RequestID{ID: "request/monorepo/main/100"}
-
-	data, err := original.ToBytes()
-	require.NoError(t, err)
-
-	deserialized, err := RequestIDFromBytes(data)
-	require.NoError(t, err)
-
-	assert.Equal(t, original, deserialized)
 }


### PR DESCRIPTION
## Summary

- Remove unused `ToBytes`/`FromBytes` helpers from `stovepipe/entity/request.go` and `stovepipe/entity/build.go`, including the dead `RequestID` wrapper type
- Update `BuildID` docs to describe its BuildRunner role only (no queue serialization)
- Drop the entity serialization unit tests; queue wire format is already covered by `stovepipe/core/messagequeue` proto contract tests

Closes #357 

All stovepipe queue topics already use proto contracts (`ProcessRequest`, `BuildRequest`, `BuildSignal`, `Record`); this removes the misleading entity JSON helpers that could steer new stages toward the wrong pattern.

## Test plan

- [x] `bazel test //stovepipe/entity/... //stovepipe/core/messagequeue/...`
- [x] CI green