### PR TITLE
feat(runway): resolve merge targets per queue and provision their checkouts

### DIFF
--- a/service/runway/README.md
+++ b/service/runway/README.md
@@ -15,7 +15,38 @@ These topic keys and their wire contracts are owned by the queue's producer side
 
 ### Merger backend
 
-The merge work is done by the [`merger`](../../runway/extension/merger) extension. By default the server wires the **noop** merger (always succeeds — for local dev and compose). Set `MERGE_CHECKOUT_PATH` to wire the real **git** merger, built from the `MERGE_*` / `GIT_*` environment (see Configuration); the git merger owns the checkout at that path and pushes to the configured remote/target.
+The merge work is done by the [`merger`](../../runway/extension/merger) extension, resolved **per queue** — so one Runway can serve several repositories by giving each queue its own merge target. By default every queue gets the **noop** merger (always succeeds — for local dev and compose). Point `MERGE_CONFIG_PATH` at a merge configuration file to wire real **git** merge targets, or set `MERGE_CHECKOUT_PATH` to configure a single one from the environment (see Configuration).
+
+Two queues naming the same checkout resolve to the *same* merger instance, which is what serializes them against each other: a git merger locks the working tree it owns, and two instances over one tree would reset it out from under each other mid-merge. Naming one checkout for two *different* targets is rejected at startup.
+
+### Merge configuration file
+
+`MERGE_CONFIG_PATH` names a YAML file with a `defaults` block and per-queue overrides. A queue's `merger` block replaces the default wholesale rather than merging field by field.
+
+```yaml
+defaults:
+  merger: {type: noop}            # noop | git
+queues:
+  - name: demo-queue
+    merger:
+      type: git
+      remoteUrl: https://github.com/uber/sq-sandbox.git
+      target: main
+      checkoutPath: /var/runway/checkouts/sq-sandbox
+      defaultStrategy: SQUASH_REBASE
+      updateHeadBranch: true
+      tokenEnv: GITHUB_TOKEN
+```
+
+The file holds **no secret**: `tokenEnv` names the environment variable carrying the credential, so the file stays committable and rotating the token needs no edit. Omitting `remoteUrl` means the checkout is provisioned by something else and is used as it stands.
+
+### Checkout provisioning
+
+A git merge target's checkout is created at startup if it is not already there: the repository is initialised, the remote configured, the credential written, and the target branch checked out. It is idempotent, so restarting against a persisted volume costs nothing and a rotated token takes effect.
+
+The credential never goes into the remote URL. The merger folds git's stderr into the errors it returns, so a URL-embedded token would be reprinted into logs and dead-letter payloads by any failed fetch. Instead it is written as an HTTP `Authorization` header into a `0600` config fragment inside `.git/`, which the repository config includes — keeping it out of the command line too.
+
+For SSH, leave `tokenEnv` unset and use an `ssh://` remote: the merger already passes `SSH_AUTH_SOCK` and `GIT_SSH_COMMAND` through to git, so an agent or a mounted deploy key works with no further configuration.
 
 Because Runway only consumes queues and serves `Ping`, it needs a **queue** database but no application/storage database.
 
@@ -40,14 +71,16 @@ The Runway controllers themselves live under [`runway/controller/`](../../runway
 | `QUEUE_MYSQL_DSN` | yes      | Queue database DSN                            | —                        |
 | `PORT`            | no       | gRPC listen address                           | `:8086`                  |
 | `HOSTNAME`        | no       | Subscriber name for the queue consumer        | `runway-<unix_ts>`       |
-| `MERGE_CHECKOUT_PATH` | no   | Absolute path to the git checkout the merger owns. When unset, the noop merger is used. | — (noop) |
+| `MERGE_CONFIG_PATH` | no | Path to the per-queue merge configuration file (see above). Takes precedence over the `MERGE_*` variables below, which configure a single target. | — |
+| `MERGE_CHECKOUT_PATH` | no   | Absolute path to the git checkout the merger owns. When unset (and no config file), the noop merger is used. | — (noop) |
 | `MERGE_REMOTE`    | no       | Git remote to fetch/push                       | `origin`                 |
 | `MERGE_TARGET`    | no       | Destination branch on the remote               | `main`                   |
 | `MERGE_DEFAULT_STRATEGY` | no | Strategy a `DEFAULT` step resolves to: `REBASE`, `SQUASH_REBASE`, `MERGE`, or `PROMOTE` | `REBASE` |
 | `MERGE_COMMITTER_NAME` | no  | Committer name for service-created commits      | `SubmitQueue Runway`     |
 | `MERGE_COMMITTER_EMAIL` | no | Committer email for service-created commits     | `runway@submitqueue.invalid` |
-| `GIT_EXECUTABLE` / `GIT_EXEC_PATH` / `GIT_TEMPLATE_DIR` | when `MERGE_CHECKOUT_PATH` set | Absolute paths to the pinned git runtime | — |
+| `GIT_EXECUTABLE` / `GIT_EXEC_PATH` / `GIT_TEMPLATE_DIR` | no | Absolute paths pinning the git runtime. Each is derived from the installed git when unset — the executable from `PATH`, the exec path from `git --exec-path`, the templates from the matching install prefix. | derived |
 | `MERGE_CHECK_STALENESS` | no | Verify each change's provider ref still points at the commit its URI names before applying | `true` |
+| `MERGE_UPDATE_HEAD_BRANCH` | no | Before pushing the target, move each change's head branch to the commit it landed as, so the provider marks the change merged rather than closed. Only affects `REBASE`/`SQUASH_REBASE`. | `false` |
 | `MERGE_ALLOW_UNRELATED_HISTORIES` | no | Let a `MERGE` step integrate a change sharing no ancestry with the target (repository imports). Leave off unless the queue exists to perform imports. | `false` |
 | `MERGE_FETCH_REFSPECS` | no | Comma-separated extra refspecs fetched each cycle. Only needed for a remote that refuses to serve an unadvertised commit by SHA. | — |
 

--- a/service/runway/server/BUILD.bazel
+++ b/service/runway/server/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library", "go_test")
 
 exports_files(
     ["docker-compose.yml"],
@@ -7,7 +7,12 @@ exports_files(
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "checkout.go",
+        "config.go",
+        "gitruntime.go",
+        "main.go",
+    ],
     importpath = "github.com/uber/submitqueue/service/runway/server",
     visibility = ["//visibility:private"],
     deps = [
@@ -33,6 +38,7 @@ go_library(
         "//runway/extension/merger/noop:go_default_library",
         "@com_github_go_sql_driver_mysql//:go_default_library",
         "@com_github_uber_go_tally//:go_default_library",
+        "@in_gopkg_yaml_v3//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//reflection:go_default_library",
         "@org_uber_go_zap//:go_default_library",
@@ -65,4 +71,34 @@ filegroup(
         ":runway_linux",
     ],
     visibility = ["//test:__subpackages__"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "checkout_test.go",
+        "config_test.go",
+    ],
+    # Checkout provisioning runs real git, so the test uses the same pinned
+    # runtime the merger does rather than whatever git the host happens to have.
+    data = [
+        "@git",
+        "@git//:git_receive_pack",
+        "@git//:git_upload_archive",
+        "@git//:git_upload_pack",
+        "@git//:templates",
+        "@git//:templates/description",
+    ],
+    embed = [":go_default_library"],
+    env = {
+        "SUBMITQUEUE_TEST_GIT": "$(location @git//:git)",
+        "SUBMITQUEUE_TEST_GIT_TEMPLATE_DESCRIPTION": "$(location @git//:templates/description)",
+    },
+    deps = [
+        "//api/base/mergestrategy/protopb:go_default_library",
+        "//runway/extension/merger/git:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@org_uber_go_zap//zaptest:go_default_library",
+    ],
 )

--- a/service/runway/server/Dockerfile
+++ b/service/runway/server/Dockerfile
@@ -1,6 +1,9 @@
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/* \
+# git is a runtime dependency, not a build one: the git merger shells out to it
+# to fetch, apply, and push. Without it the service still starts, but only the
+# noop merger works — a git merge target fails at startup instead.
+RUN apt-get update && apt-get install -y ca-certificates git && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /app && chmod 0755 /app
 WORKDIR /app
 

--- a/service/runway/server/checkout.go
+++ b/service/runway/server/checkout.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/zap"
+
+	gitmerger "github.com/uber/submitqueue/runway/extension/merger/git"
+)
+
+// credentialFile is the name, inside the checkout's .git directory, of the
+// config fragment holding the remote's credential. It is included from the
+// repository config rather than written into it, so the secret lives in one
+// file this service owns and can chmod, and `git config --list` on the
+// repository does not print it back out.
+const credentialFile = "submitqueue-credentials.config"
+
+// provisionCheckout makes the working tree the git merger requires: a
+// repository at CheckoutPath with the configured remote, its credential in
+// place, and the target branch checked out.
+//
+// The merger deliberately does none of this — it declares that the checkout
+// must already exist, so that it never has to decide whether a surprising
+// working tree is one it should repair or one it should refuse. Creating it is
+// the wiring layer's job, and doing it here keeps the decision out of the merge
+// path.
+//
+// It is idempotent: an existing checkout has its remote URL and credential
+// brought back in line rather than being recreated, so a restart against a
+// persisted volume costs nothing and a rotated token takes effect.
+func provisionCheckout(ctx context.Context, logger *zap.SugaredLogger, runtime gitmerger.GitRuntime, cfg mergerConfig) error {
+	if err := os.MkdirAll(cfg.CheckoutPath, 0o755); err != nil {
+		return fmt.Errorf("create checkout dir %q: %w", cfg.CheckoutPath, err)
+	}
+
+	fresh, err := initRepository(ctx, runtime, cfg)
+	if err != nil {
+		return err
+	}
+
+	// Written before the first fetch, because a private remote cannot be read
+	// without it.
+	if err := writeCredential(cfg); err != nil {
+		return err
+	}
+	if err := configureRemote(ctx, runtime, cfg); err != nil {
+		return err
+	}
+
+	if _, err := runGit(ctx, runtime, cfg.CheckoutPath, "fetch", cfg.Remote); err != nil {
+		return fmt.Errorf("fetch %s from %s: %w", cfg.Remote, cfg.RemoteURL, err)
+	}
+	remoteRef := cfg.Remote + "/" + cfg.Target
+	if _, err := runGit(ctx, runtime, cfg.CheckoutPath, "checkout", "-B", cfg.Target, remoteRef); err != nil {
+		return fmt.Errorf("check out %s: %w", remoteRef, err)
+	}
+
+	// The merger points HOME here. Its own `git clean -fdx` may remove it
+	// again, which is harmless — nothing is stored there, and the scrubbed
+	// environment means git reads no configuration from it either way.
+	if err := os.MkdirAll(filepath.Join(cfg.CheckoutPath, ".submitqueue-git-home", "xdg"), 0o700); err != nil {
+		return fmt.Errorf("create git home in %q: %w", cfg.CheckoutPath, err)
+	}
+
+	logger.Infow("provisioned merge checkout",
+		"checkout", cfg.CheckoutPath,
+		"remote", cfg.Remote,
+		"remote_url", cfg.RemoteURL,
+		"target", cfg.Target,
+		"cloned", fresh,
+		"credential", cfg.needsHTTPCredential(),
+	)
+	return nil
+}
+
+// initRepository creates the repository if the path does not already hold one,
+// reporting whether it had to. An existing repository is left in place: it may
+// carry fetched objects worth keeping, and re-creating it would discard them.
+func initRepository(ctx context.Context, runtime gitmerger.GitRuntime, cfg mergerConfig) (bool, error) {
+	if info, err := os.Stat(filepath.Join(cfg.CheckoutPath, ".git")); err == nil && info.IsDir() {
+		return false, nil
+	}
+	if _, err := runGit(ctx, runtime, cfg.CheckoutPath, "init", "-b", cfg.Target); err != nil {
+		return false, fmt.Errorf("init repository at %q: %w", cfg.CheckoutPath, err)
+	}
+	return true, nil
+}
+
+// configureRemote points the configured remote name at the configured URL,
+// adding it when absent and correcting it when it has drifted.
+func configureRemote(ctx context.Context, runtime gitmerger.GitRuntime, cfg mergerConfig) error {
+	out, err := runGit(ctx, runtime, cfg.CheckoutPath, "remote")
+	if err != nil {
+		return fmt.Errorf("list remotes in %q: %w", cfg.CheckoutPath, err)
+	}
+	for _, name := range strings.Fields(string(out)) {
+		if name != cfg.Remote {
+			continue
+		}
+		if _, err := runGit(ctx, runtime, cfg.CheckoutPath, "remote", "set-url", cfg.Remote, cfg.RemoteURL); err != nil {
+			return fmt.Errorf("set url of remote %q: %w", cfg.Remote, err)
+		}
+		return nil
+	}
+	if _, err := runGit(ctx, runtime, cfg.CheckoutPath, "remote", "add", cfg.Remote, cfg.RemoteURL); err != nil {
+		return fmt.Errorf("add remote %q: %w", cfg.Remote, err)
+	}
+	return nil
+}
+
+// writeCredential stores the remote's token as an HTTP Authorization header in
+// a config fragment the repository includes.
+//
+// The token deliberately never enters the remote URL. The merger folds git's
+// stderr into the errors it returns, so a URL-embedded credential would be
+// reprinted into logs and dead-letter payloads by any failed fetch. It is kept
+// out of the command line for the same reason — a header written by this
+// process into a file it owns is visible to neither.
+func writeCredential(cfg mergerConfig) error {
+	path := filepath.Join(cfg.CheckoutPath, ".git", credentialFile)
+
+	if !cfg.needsHTTPCredential() {
+		// A local path or SSH remote authenticates by other means. Remove any
+		// fragment a previous configuration left, so a target that stops using
+		// a token stops carrying one.
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove stale credential %q: %w", path, err)
+		}
+		return nil
+	}
+
+	token, ok := cfg.token()
+	if !ok {
+		return fmt.Errorf("environment variable %q named by tokenEnv is not set", cfg.TokenEnv)
+	}
+	if token == "" {
+		return fmt.Errorf("environment variable %q named by tokenEnv is empty", cfg.TokenEnv)
+	}
+
+	basic := base64.StdEncoding.EncodeToString([]byte(cfg.TokenUser + ":" + token))
+	fragment := fmt.Sprintf("[http %q]\n\textraheader = Authorization: Basic %s\n", cfg.RemoteURL, basic)
+	if err := os.WriteFile(path, []byte(fragment), 0o600); err != nil {
+		return fmt.Errorf("write credential %q: %w", path, err)
+	}
+
+	// include.path resolves relative to the config file holding it, which is
+	// .git/config — so the bare filename lands beside it.
+	if err := setLocalConfig(cfg.CheckoutPath, "include.path", credentialFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+// setLocalConfig sets a repository-local config key, replacing any previous
+// value for it. It edits .git/config through git itself rather than by hand so
+// the file stays git's to format.
+func setLocalConfig(checkoutPath, key, value string) error {
+	// Uses the ambient git rather than the pinned runtime: this touches only
+	// the repository's own config file, never the remote, and the pinned
+	// runtime exists to make *merge results* reproducible.
+	cmd := exec.Command("git", "config", "--local", "--replace-all", key, value)
+	cmd.Dir = checkoutPath
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git config --local %s: %w: %s", key, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// runGit invokes the pinned git in dir with an environment scrubbed of ambient
+// configuration but retaining what is needed to reach a remote — the same split
+// the merger draws, so provisioning and merging authenticate identically.
+func runGit(ctx context.Context, runtime gitmerger.GitRuntime, dir string, args ...string) ([]byte, error) {
+	full := append([]string{
+		"--exec-path=" + runtime.ExecPath,
+		"-c", "init.templateDir=" + runtime.TemplateDir,
+	}, args...)
+
+	cmd := exec.CommandContext(ctx, runtime.Executable, full...)
+	cmd.Dir = dir
+	cmd.Env = []string{
+		"HOME=" + filepath.Join(dir, ".submitqueue-git-home"),
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_EXEC_PATH=" + runtime.ExecPath,
+		"GIT_TEMPLATE_DIR=" + runtime.TemplateDir,
+		"LC_ALL=C",
+		"LANG=C",
+	}
+	for _, name := range []string{
+		"PATH", "SSH_AUTH_SOCK", "SSH_AGENT_PID",
+		"GIT_SSH", "GIT_SSH_COMMAND", "GIT_SSH_VARIANT",
+		"GIT_SSL_CAINFO", "GIT_SSL_CAPATH", "SSL_CERT_DIR", "SSL_CERT_FILE",
+		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+		"http_proxy", "https_proxy", "no_proxy",
+	} {
+		if v, ok := os.LookupEnv(name); ok {
+			cmd.Env = append(cmd.Env, name+"="+v)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}

--- a/service/runway/server/checkout_test.go
+++ b/service/runway/server/checkout_test.go
@@ -1,0 +1,304 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	gitmerger "github.com/uber/submitqueue/runway/extension/merger/git"
+)
+
+// testRuntime resolves the pinned git the Bazel target supplies. Provisioning
+// runs real git, so these tests use the same runtime the merger will.
+func testRuntime(t *testing.T) gitmerger.GitRuntime {
+	t.Helper()
+	executable := runfilePath(t, "SUBMITQUEUE_TEST_GIT")
+	templateDescription := runfilePath(t, "SUBMITQUEUE_TEST_GIT_TEMPLATE_DESCRIPTION")
+	return gitmerger.GitRuntime{
+		Executable:  executable,
+		ExecPath:    filepath.Dir(executable),
+		TemplateDir: filepath.Dir(templateDescription),
+	}
+}
+
+// runfilePath resolves a $(location)-expanded path from the test environment.
+// rules_go emits an execroot-relative path, which for an external output has to
+// be re-rooted under the runfiles directory the test actually runs from.
+func runfilePath(t *testing.T, name string) string {
+	t.Helper()
+	path := os.Getenv(name)
+	require.NotEmpty(t, path, "%s must be set by the test target", name)
+	if absolute, err := filepath.Abs(path); err == nil {
+		if _, err := os.Stat(absolute); err == nil {
+			return absolute
+		}
+	}
+
+	slashed := filepath.ToSlash(path)
+	external := ""
+	if strings.HasPrefix(slashed, "external/") {
+		external = strings.TrimPrefix(slashed, "external/")
+	} else if i := strings.Index(slashed, "/external/"); i >= 0 {
+		external = slashed[i+len("/external/"):]
+	}
+	require.NotEmpty(t, external, "%s=%q is not a runfile", name, path)
+
+	root := os.Getenv("TEST_SRCDIR")
+	require.NotEmpty(t, root)
+	candidate := filepath.Join(root, filepath.FromSlash(external))
+	_, err := os.Stat(candidate)
+	require.NoError(t, err)
+	return candidate
+}
+
+// seedBareRepo creates a bare repository holding one commit on branch and
+// returns its path — the shape of the remote a merge target points at.
+func seedBareRepo(t *testing.T, branch string) string {
+	t.Helper()
+	runtime := testRuntime(t)
+	root := t.TempDir()
+	bare := filepath.Join(root, "remote.git")
+	work := filepath.Join(root, "seed")
+
+	ctx := context.Background()
+	require.NoError(t, os.MkdirAll(work, 0o755))
+	mustRunGit(t, ctx, runtime, root, "init", "--bare", "-b", branch, bare)
+	mustRunGit(t, ctx, runtime, work, "init", "-b", branch)
+	mustRunGit(t, ctx, runtime, work, "config", "user.name", "Seed")
+	mustRunGit(t, ctx, runtime, work, "config", "user.email", "seed@example.com")
+	mustRunGit(t, ctx, runtime, work, "config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(work, "seed.txt"), []byte("seed\n"), 0o644))
+	mustRunGit(t, ctx, runtime, work, "add", ".")
+	mustRunGit(t, ctx, runtime, work, "commit", "-m", "seed")
+	mustRunGit(t, ctx, runtime, work, "remote", "add", "origin", bare)
+	mustRunGit(t, ctx, runtime, work, "push", "origin", branch)
+
+	return bare
+}
+
+func mustRunGit(t *testing.T, ctx context.Context, runtime gitmerger.GitRuntime, dir string, args ...string) string {
+	t.Helper()
+	out, err := runGit(ctx, runtime, dir, args...)
+	require.NoError(t, err, "git %s", strings.Join(args, " "))
+	return strings.TrimSpace(string(out))
+}
+
+// localCheckout builds a config pointing at a freshly seeded bare repo.
+func localCheckout(t *testing.T, bare string) mergerConfig {
+	t.Helper()
+	cfg := mergerConfig{
+		Type:         mergerTypeGit,
+		RemoteURL:    "file://" + bare,
+		CheckoutPath: filepath.Join(t.TempDir(), "checkout"),
+	}
+	require.NoError(t, cfg.normalizeAndValidate("test"))
+	return cfg
+}
+
+func TestProvisionCheckout_CreatesUsableWorkingTree(t *testing.T) {
+	ctx := context.Background()
+	runtime := testRuntime(t)
+	cfg := localCheckout(t, seedBareRepo(t, "main"))
+
+	require.NoError(t, provisionCheckout(ctx, zaptest.NewLogger(t).Sugar(), runtime, cfg))
+
+	// The merger resets to refs/remotes/<remote>/<target> on every cycle, so
+	// that ref existing is what makes the checkout usable at all.
+	assert.NotEmpty(t, mustRunGit(t, ctx, runtime, cfg.CheckoutPath, "rev-parse", "origin/main"))
+	assert.Equal(t, "main", mustRunGit(t, ctx, runtime, cfg.CheckoutPath, "rev-parse", "--abbrev-ref", "HEAD"))
+
+	content, err := os.ReadFile(filepath.Join(cfg.CheckoutPath, "seed.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "seed\n", string(content))
+}
+
+func TestProvisionCheckout_NonDefaultTargetBranch(t *testing.T) {
+	ctx := context.Background()
+	runtime := testRuntime(t)
+	cfg := localCheckout(t, seedBareRepo(t, "trunk"))
+	cfg.Target = "trunk"
+
+	require.NoError(t, provisionCheckout(ctx, zaptest.NewLogger(t).Sugar(), runtime, cfg))
+	assert.Equal(t, "trunk", mustRunGit(t, ctx, runtime, cfg.CheckoutPath, "rev-parse", "--abbrev-ref", "HEAD"))
+}
+
+func TestProvisionCheckout_IsIdempotent(t *testing.T) {
+	// A restart against a persisted volume must cost nothing and must not
+	// discard the objects the previous run fetched.
+	ctx := context.Background()
+	runtime := testRuntime(t)
+	logger := zaptest.NewLogger(t).Sugar()
+	cfg := localCheckout(t, seedBareRepo(t, "main"))
+
+	require.NoError(t, provisionCheckout(ctx, logger, runtime, cfg))
+	first := mustRunGit(t, ctx, runtime, cfg.CheckoutPath, "rev-parse", "HEAD")
+
+	require.NoError(t, provisionCheckout(ctx, logger, runtime, cfg))
+	assert.Equal(t, first, mustRunGit(t, ctx, runtime, cfg.CheckoutPath, "rev-parse", "HEAD"))
+}
+
+func TestProvisionCheckout_CorrectsDriftedRemoteURL(t *testing.T) {
+	ctx := context.Background()
+	runtime := testRuntime(t)
+	logger := zaptest.NewLogger(t).Sugar()
+
+	cfg := localCheckout(t, seedBareRepo(t, "main"))
+	require.NoError(t, provisionCheckout(ctx, logger, runtime, cfg))
+
+	moved := cfg
+	moved.RemoteURL = "file://" + seedBareRepo(t, "main")
+	require.NoError(t, provisionCheckout(ctx, logger, runtime, moved))
+
+	got := mustRunGit(t, ctx, runtime, cfg.CheckoutPath, "remote", "get-url", "origin")
+	assert.Equal(t, moved.RemoteURL, got)
+}
+
+func TestProvisionCheckout_LocalRemoteCarriesNoCredential(t *testing.T) {
+	ctx := context.Background()
+	cfg := localCheckout(t, seedBareRepo(t, "main"))
+	cfg.TokenEnv = "" // a local path authenticates by nothing at all
+
+	require.NoError(t, provisionCheckout(ctx, zaptest.NewLogger(t).Sugar(), testRuntime(t), cfg))
+
+	_, err := os.Stat(filepath.Join(cfg.CheckoutPath, ".git", credentialFile))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestWriteCredential_KeepsTokenOutOfTheRemoteURL(t *testing.T) {
+	// The merger folds git's stderr into the errors it returns, so a token in
+	// the remote URL would be reprinted by any failed fetch. This is the
+	// property that keeps it out of logs and dead-letter payloads.
+	const token = "s3cret-token-value"
+	t.Setenv("TEST_FORGE_TOKEN", token)
+
+	ctx := context.Background()
+	runtime := testRuntime(t)
+	logger := zaptest.NewLogger(t).Sugar()
+
+	// Provision from a local remote first so there is a repository to write
+	// into, then point it at an HTTPS URL carrying a credential.
+	cfg := localCheckout(t, seedBareRepo(t, "main"))
+	require.NoError(t, provisionCheckout(ctx, logger, runtime, cfg))
+
+	authed := cfg
+	authed.RemoteURL = "https://example.com/o/r.git"
+	authed.TokenEnv = "TEST_FORGE_TOKEN"
+	require.NoError(t, configureRemote(ctx, runtime, authed))
+	require.NoError(t, writeCredential(authed))
+
+	url := mustRunGit(t, ctx, runtime, authed.CheckoutPath, "remote", "get-url", "origin")
+	assert.NotContains(t, url, token)
+	assert.Equal(t, "https://example.com/o/r.git", url)
+
+	path := filepath.Join(authed.CheckoutPath, ".git", credentialFile)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "credential must not be world-readable")
+
+	// git resolves the fragment through the include, which is what makes the
+	// header reach the remote without the repository config holding it.
+	header := mustRunGit(t, ctx, runtime, authed.CheckoutPath,
+		"config", "--get", "http.https://example.com/o/r.git.extraheader")
+	assert.Contains(t, header, "Authorization: Basic ")
+	assert.NotContains(t, header, token, "the token is base64-encoded, never literal")
+}
+
+func TestWriteCredential_RemovesFragmentWhenNoLongerNeeded(t *testing.T) {
+	t.Setenv("TEST_FORGE_TOKEN", "value")
+	ctx := context.Background()
+	runtime := testRuntime(t)
+
+	cfg := localCheckout(t, seedBareRepo(t, "main"))
+	require.NoError(t, provisionCheckout(ctx, zaptest.NewLogger(t).Sugar(), runtime, cfg))
+
+	authed := cfg
+	authed.RemoteURL = "https://example.com/o/r.git"
+	authed.TokenEnv = "TEST_FORGE_TOKEN"
+	require.NoError(t, writeCredential(authed))
+	require.FileExists(t, filepath.Join(cfg.CheckoutPath, ".git", credentialFile))
+
+	// Switching the target back to one needing no credential must not leave the
+	// old secret lying in the checkout.
+	require.NoError(t, writeCredential(cfg))
+	_, err := os.Stat(filepath.Join(cfg.CheckoutPath, ".git", credentialFile))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestWriteCredential_RejectsUnsetToken(t *testing.T) {
+	// Failing here beats cloning anonymously and reporting a confusing 404 on a
+	// private repository later.
+	cfg := mergerConfig{
+		Type:         mergerTypeGit,
+		RemoteURL:    "https://example.com/o/r.git",
+		CheckoutPath: t.TempDir(),
+		TokenEnv:     "TEST_TOKEN_DEFINITELY_NOT_SET",
+		TokenUser:    "x-access-token",
+	}
+	require.Error(t, writeCredential(cfg))
+
+	t.Setenv("TEST_TOKEN_DEFINITELY_NOT_SET", "")
+	require.Error(t, writeCredential(cfg), "an empty value is a deployment mistake, not a valid credential")
+}
+
+func TestResolveGitRuntime_HonorsEnvironmentOverrides(t *testing.T) {
+	pinned := testRuntime(t)
+	t.Setenv("GIT_EXECUTABLE", pinned.Executable)
+	t.Setenv("GIT_EXEC_PATH", pinned.ExecPath)
+	t.Setenv("GIT_TEMPLATE_DIR", pinned.TemplateDir)
+
+	got, err := resolveGitRuntime(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, pinned, got)
+}
+
+func TestResolveGitRuntime_DerivesExecPathFromTheBinary(t *testing.T) {
+	// The trap this removes: the merger requires all three paths, so a
+	// deployment that sets only MERGE_CHECKOUT_PATH used to fail at startup.
+	pinned := testRuntime(t)
+	t.Setenv("GIT_EXECUTABLE", pinned.Executable)
+	t.Setenv("GIT_EXEC_PATH", "")
+	t.Setenv("GIT_TEMPLATE_DIR", pinned.TemplateDir)
+
+	got, err := resolveGitRuntime(context.Background())
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(got.ExecPath))
+	assert.NotEmpty(t, got.ExecPath)
+}
+
+func TestResolveGitRuntime_ReportsMissingGit(t *testing.T) {
+	t.Setenv("GIT_EXECUTABLE", "")
+	t.Setenv("GIT_EXEC_PATH", "")
+	t.Setenv("GIT_TEMPLATE_DIR", "")
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := resolveGitRuntime(context.Background())
+	require.Error(t, err)
+}
+
+// Verify the pinned git is what the tests actually exercised.
+func TestTestRuntimeIsUsable(t *testing.T) {
+	out, err := exec.Command(testRuntime(t).Executable, "--version").Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "git version")
+}

--- a/service/runway/server/config.go
+++ b/service/runway/server/config.go
@@ -1,0 +1,314 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	yamlv3 "gopkg.in/yaml.v3"
+
+	mergestrategypb "github.com/uber/submitqueue/api/base/mergestrategy/protopb"
+)
+
+// Merger types selectable from configuration.
+const (
+	mergerTypeNoop = "noop"
+	mergerTypeGit  = "git"
+)
+
+// mergeConfig is the runway merge configuration file: which merger each queue
+// gets, and how its merge target is reached.
+//
+// It carries no secret. A git target names the *environment variable* holding
+// its credential (tokenEnv), so the file stays committable and a deployment
+// swaps the credential without editing it.
+type mergeConfig struct {
+	// Defaults applies to any queue without its own entry.
+	Defaults queueMergeConfig `yaml:"defaults"`
+	// Queues holds per-queue overrides, keyed by queue name.
+	Queues []namedQueueMergeConfig `yaml:"queues"`
+}
+
+// namedQueueMergeConfig is one queue's entry.
+type namedQueueMergeConfig struct {
+	// Name is the queue this entry configures.
+	Name string `yaml:"name"`
+	// Merger replaces the default merger wholesale when present. Overriding is
+	// per-block rather than per-field: a half-inherited git target, where the
+	// remote comes from one place and the branch from another, is harder to
+	// read than one stated outright.
+	Merger *mergerConfig `yaml:"merger"`
+}
+
+// queueMergeConfig is the set of extensions a queue resolves to.
+type queueMergeConfig struct {
+	// Merger performs the mergeability check and the committing merge.
+	Merger mergerConfig `yaml:"merger"`
+}
+
+// mergerConfig selects a merger implementation and configures it. Fields other
+// than Type apply only to the git merger.
+type mergerConfig struct {
+	// Type selects the implementation: "noop" or "git".
+	Type string `yaml:"type"`
+	// RemoteURL is the repository the merger clones and pushes to. When empty
+	// the checkout is taken as provisioned by something else and used as it
+	// stands — which is how an externally-managed working tree, or one mounted
+	// into the container ready to go, is described.
+	RemoteURL string `yaml:"remoteUrl"`
+	// Remote is the git remote name for that URL. Defaults to "origin".
+	Remote string `yaml:"remote"`
+	// Target is the branch merges land on. Defaults to "main".
+	Target string `yaml:"target"`
+	// CheckoutPath is the working tree the merger owns. It is provisioned at
+	// startup if absent, and must not be shared by two different targets.
+	CheckoutPath string `yaml:"checkoutPath"`
+	// DefaultStrategy resolves a step whose strategy is DEFAULT. Defaults to
+	// REBASE.
+	DefaultStrategy string `yaml:"defaultStrategy"`
+	// CheckStaleness verifies each change still points at the commit its URI
+	// names before applying it. Defaults to true.
+	CheckStaleness *bool `yaml:"checkStaleness"`
+	// UpdateHeadBranch moves each change's head branch to the commit it landed
+	// as, so the provider marks it merged. Defaults to false.
+	UpdateHeadBranch bool `yaml:"updateHeadBranch"`
+	// AllowUnrelatedHistories lets a MERGE step integrate a change sharing no
+	// ancestry with the target. Defaults to false.
+	AllowUnrelatedHistories bool `yaml:"allowUnrelatedHistories"`
+	// FetchRefspecs are extra refspecs fetched on every cycle, for a remote
+	// that will not serve an unadvertised object by SHA.
+	FetchRefspecs []string `yaml:"fetchRefspecs"`
+	// MaxPushAttempts caps the reset/apply/push retry loop under contention.
+	// Zero uses the merger's own default.
+	MaxPushAttempts int `yaml:"maxPushAttempts"`
+	// CommitterName and CommitterEmail identify commits the merger creates.
+	CommitterName  string `yaml:"committerName"`
+	CommitterEmail string `yaml:"committerEmail"`
+	// TokenEnv names the environment variable holding the credential for an
+	// HTTPS remote — never the credential itself. Empty means the remote needs
+	// no token, which is the case for a local path and for SSH (where the
+	// merger passes the agent socket through instead).
+	TokenEnv string `yaml:"tokenEnv"`
+	// TokenUser is the username paired with the token in basic auth. Providers
+	// each have their own convention; defaults to "x-access-token".
+	TokenUser string `yaml:"tokenUser"`
+}
+
+// loadMergeConfig reads and validates the merge configuration at path.
+func loadMergeConfig(path string) (mergeConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return mergeConfig{}, fmt.Errorf("failed to read merge config %q: %w", path, err)
+	}
+
+	var cfg mergeConfig
+	if err := yamlv3.Unmarshal(data, &cfg); err != nil {
+		return mergeConfig{}, fmt.Errorf("failed to parse merge config %q: %w", path, err)
+	}
+
+	if err := cfg.normalizeAndValidate(); err != nil {
+		return mergeConfig{}, fmt.Errorf("invalid merge config %q: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// usesGit reports whether any configured queue resolves to the git merger, and
+// so whether the process needs a git runtime at all.
+func (c mergeConfig) usesGit() bool {
+	if c.Defaults.Merger.Type == mergerTypeGit {
+		return true
+	}
+	for _, q := range c.Queues {
+		if q.Merger != nil && q.Merger.Type == mergerTypeGit {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeAndValidate applies defaults and rejects a configuration that could
+// not produce working mergers.
+func (c *mergeConfig) normalizeAndValidate() error {
+	if err := c.Defaults.Merger.normalizeAndValidate("defaults"); err != nil {
+		return err
+	}
+
+	seen := make(map[string]bool, len(c.Queues))
+	// Two queues may legitimately share one merge target, but two *different*
+	// targets sharing a working tree would have each merger reset and push the
+	// other's work mid-flight. Only the second is an error, so the check is on
+	// conflicting settings rather than on reuse.
+	byCheckout := make(map[string]mergerConfig)
+	if c.Defaults.Merger.Type == mergerTypeGit {
+		byCheckout[c.Defaults.Merger.CheckoutPath] = c.Defaults.Merger
+	}
+
+	for i := range c.Queues {
+		q := &c.Queues[i]
+		if q.Name == "" {
+			return fmt.Errorf("queue entry %d has an empty name", i)
+		}
+		if seen[q.Name] {
+			return fmt.Errorf("queue %q appears more than once", q.Name)
+		}
+		seen[q.Name] = true
+
+		if q.Merger == nil {
+			continue
+		}
+		where := fmt.Sprintf("queue %q", q.Name)
+		if err := q.Merger.normalizeAndValidate(where); err != nil {
+			return err
+		}
+		if q.Merger.Type != mergerTypeGit {
+			continue
+		}
+		if prior, ok := byCheckout[q.Merger.CheckoutPath]; ok {
+			if diff, differs := prior.firstDifference(*q.Merger); differs {
+				return fmt.Errorf(
+					"%s reuses checkout %q but differs from an earlier queue in %s; queues sharing a checkout share one merger instance, so give each configuration its own checkout",
+					where, q.Merger.CheckoutPath, diff,
+				)
+			}
+		}
+		byCheckout[q.Merger.CheckoutPath] = *q.Merger
+	}
+	return nil
+}
+
+// normalizeAndValidate fills in defaults and checks the fields the selected
+// type requires. where names the config location for error messages.
+func (m *mergerConfig) normalizeAndValidate(where string) error {
+	if m.Type == "" {
+		m.Type = mergerTypeNoop
+	}
+	switch m.Type {
+	case mergerTypeNoop:
+		return nil
+	case mergerTypeGit:
+	default:
+		return fmt.Errorf("%s: unknown merger type %q (want %q or %q)", where, m.Type, mergerTypeNoop, mergerTypeGit)
+	}
+
+	if m.CheckoutPath == "" {
+		return fmt.Errorf("%s: git merger requires checkoutPath", where)
+	}
+	if m.TokenEnv != "" && m.RemoteURL == "" {
+		return fmt.Errorf("%s: tokenEnv is set but remoteUrl is not, so there is no remote to authenticate to", where)
+	}
+	if m.Remote == "" {
+		m.Remote = "origin"
+	}
+	if m.Target == "" {
+		m.Target = "main"
+	}
+	if m.TokenUser == "" {
+		m.TokenUser = "x-access-token"
+	}
+	if m.CheckStaleness == nil {
+		enabled := true
+		m.CheckStaleness = &enabled
+	}
+	// An explicit empty list and an omitted one both mean "no extra refspecs".
+	// Collapsing them keeps two queues that say it differently from reading as
+	// a difference when checkouts are compared.
+	if len(m.FetchRefspecs) == 0 {
+		m.FetchRefspecs = nil
+	}
+	if _, err := parseStrategy(m.DefaultStrategy); err != nil {
+		return fmt.Errorf("%s: %w", where, err)
+	}
+	return nil
+}
+
+// firstDifference reports the first field in which two git mergers disagree,
+// rendered for an error message, and whether there was one.
+//
+// Every field is compared, not only the ones naming the target. Queues sharing
+// a checkout share a single merger instance, built from whichever queue reached
+// the builder first, so any field that instance is constructed from has to
+// agree — a queue asking for SQUASH_REBASE and silently merging with REBASE
+// writes the wrong history and reports nothing.
+//
+// The comparison is reflective rather than field by field so that a field added
+// to mergerConfig later is covered without anyone remembering to extend this.
+// That is the failure mode worth designing against: the old three-field
+// comparison was correct when the merger consumed three fields, and quietly
+// stopped being correct as it grew to consume eleven.
+func (m mergerConfig) firstDifference(other mergerConfig) (string, bool) {
+	mine, theirs := reflect.ValueOf(m), reflect.ValueOf(other)
+	t := mine.Type()
+	for i := 0; i < t.NumField(); i++ {
+		a, b := mine.Field(i), theirs.Field(i)
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			continue
+		}
+		name := t.Field(i).Tag.Get("yaml")
+		if name == "" {
+			name = t.Field(i).Name
+		}
+		return fmt.Sprintf("%s (%s vs %s)", name, renderMergerField(a), renderMergerField(b)), true
+	}
+	return "", false
+}
+
+// renderMergerField formats one field for an error message, following a pointer
+// so an optional bool reads as its value rather than as an address.
+func renderMergerField(v reflect.Value) string {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return "unset"
+		}
+		v = v.Elem()
+	}
+	return fmt.Sprintf("%v", v.Interface())
+}
+
+// provisions reports whether this target names a remote to build its checkout
+// from, as opposed to relying on one that already exists.
+func (m mergerConfig) provisions() bool {
+	return m.Type == mergerTypeGit && m.RemoteURL != ""
+}
+
+// strategy returns the configured default strategy, already validated.
+func (m mergerConfig) strategy() mergestrategypb.Strategy {
+	s, _ := parseStrategy(m.DefaultStrategy)
+	return s
+}
+
+// token reads the credential this target's TokenEnv names. Reporting whether
+// the variable was set (rather than just returning "") keeps "no credential
+// configured" distinct from "configured but empty", which is almost always a
+// deployment mistake worth failing on.
+func (m mergerConfig) token() (string, bool) {
+	if m.TokenEnv == "" {
+		return "", false
+	}
+	return os.LookupEnv(m.TokenEnv)
+}
+
+// needsHTTPCredential reports whether this target is reached over HTTP(S) and
+// so can carry a token. A local path or an SSH remote authenticates by other
+// means, and writing an Authorization header for one would be inert at best.
+func (m mergerConfig) needsHTTPCredential() bool {
+	if m.TokenEnv == "" {
+		return false
+	}
+	lower := strings.ToLower(m.RemoteURL)
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
+}

--- a/service/runway/server/config_test.go
+++ b/service/runway/server/config_test.go
@@ -1,0 +1,401 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mergestrategypb "github.com/uber/submitqueue/api/base/mergestrategy/protopb"
+)
+
+// writeConfig writes a merge config file and returns its path.
+func writeConfig(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "merge.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestLoadMergeConfig_Defaults(t *testing.T) {
+	path := writeConfig(t, `
+defaults:
+  merger: {type: noop}
+queues:
+  - name: demo
+    merger:
+      type: git
+      remoteUrl: https://example.com/o/r.git
+      checkoutPath: /var/checkouts/r
+`)
+
+	cfg, err := loadMergeConfig(path)
+	require.NoError(t, err)
+
+	demo := cfg.Queues[0].Merger
+	require.NotNil(t, demo)
+	assert.Equal(t, "origin", demo.Remote)
+	assert.Equal(t, "main", demo.Target)
+	assert.Equal(t, "x-access-token", demo.TokenUser)
+	assert.Equal(t, mergestrategypb.Strategy_REBASE, demo.strategy())
+	require.NotNil(t, demo.CheckStaleness)
+	assert.True(t, *demo.CheckStaleness, "staleness checking is on unless turned off")
+	assert.False(t, demo.UpdateHeadBranch)
+	assert.True(t, cfg.usesGit())
+}
+
+func TestLoadMergeConfig_ExplicitValuesWin(t *testing.T) {
+	path := writeConfig(t, `
+defaults:
+  merger: {type: noop}
+queues:
+  - name: demo
+    merger:
+      type: git
+      remoteUrl: https://example.com/o/r.git
+      remote: upstream
+      target: trunk
+      checkoutPath: /var/checkouts/r
+      defaultStrategy: SQUASH_REBASE
+      checkStaleness: false
+      updateHeadBranch: true
+      tokenEnv: SOME_TOKEN
+      tokenUser: oauth2
+`)
+
+	cfg, err := loadMergeConfig(path)
+	require.NoError(t, err)
+
+	demo := cfg.Queues[0].Merger
+	assert.Equal(t, "upstream", demo.Remote)
+	assert.Equal(t, "trunk", demo.Target)
+	assert.Equal(t, "oauth2", demo.TokenUser)
+	assert.Equal(t, mergestrategypb.Strategy_SQUASH_REBASE, demo.strategy())
+	require.NotNil(t, demo.CheckStaleness)
+	assert.False(t, *demo.CheckStaleness)
+	assert.True(t, demo.UpdateHeadBranch)
+}
+
+func TestLoadMergeConfig_NoopOnlyNeedsNoGit(t *testing.T) {
+	path := writeConfig(t, `
+defaults:
+  merger: {type: noop}
+queues:
+  - name: demo
+`)
+
+	cfg, err := loadMergeConfig(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.usesGit(), "a noop-only deployment must not require a git runtime")
+}
+
+func TestLoadMergeConfig_EmptyFileIsNoop(t *testing.T) {
+	cfg, err := loadMergeConfig(writeConfig(t, ""))
+	require.NoError(t, err)
+	assert.Equal(t, mergerTypeNoop, cfg.Defaults.Merger.Type)
+	assert.False(t, cfg.usesGit())
+}
+
+func TestLoadMergeConfig_SharedCheckoutForSameTargetIsAllowed(t *testing.T) {
+	// Two queues landing on one target must resolve to one merger instance, so
+	// sharing a checkout is the correct configuration rather than a mistake.
+	path := writeConfig(t, `
+defaults:
+  merger: {type: noop}
+queues:
+  - name: a
+    merger: {type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r}
+  - name: b
+    merger: {type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r}
+`)
+
+	_, err := loadMergeConfig(path)
+	require.NoError(t, err)
+}
+
+func TestLoadMergeConfig_SharedCheckoutToleratesEquivalentSpellings(t *testing.T) {
+	// Sharing is judged on the normalized configuration, so a queue that omits
+	// a defaulted field and one that states the default explicitly agree. An
+	// empty refspec list and an omitted one likewise mean the same thing.
+	path := writeConfig(t, `
+defaults:
+  merger: {type: noop}
+queues:
+  - name: a
+    merger: {type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r}
+  - name: b
+    merger:
+      type: git
+      remoteUrl: https://example.com/o/r.git
+      checkoutPath: /var/checkouts/r
+      remote: origin
+      target: main
+      checkStaleness: true
+      fetchRefspecs: []
+`)
+
+	_, err := loadMergeConfig(path)
+	require.NoError(t, err)
+}
+
+func TestLoadMergeConfig_RejectsSharedCheckoutWithDivergentMergerFields(t *testing.T) {
+	// A shared checkout means a shared merger instance, built from whichever
+	// queue reached the builder first. Any field that instance is constructed
+	// from must agree, or the second queue silently runs with the first's
+	// value — merging with a strategy it never asked for, and saying nothing.
+	tests := []struct {
+		name string
+		b    string
+	}{
+		{
+			name: "default strategy",
+			b:    "{type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r, defaultStrategy: REBASE}",
+		},
+		{
+			name: "update head branch",
+			b:    "{type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r, updateHeadBranch: true}",
+		},
+		{
+			name: "staleness checking",
+			b:    "{type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r, checkStaleness: false}",
+		},
+		{
+			name: "push attempts",
+			b:    "{type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r, maxPushAttempts: 7}",
+		},
+		{
+			name: "committer identity",
+			b:    "{type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r, committerEmail: other@example.com}",
+		},
+		{
+			name: "fetch refspecs",
+			b:    "{type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r, fetchRefspecs: [+refs/pull/*:refs/pull/*]}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeConfig(t, `
+defaults:
+  merger: {type: noop}
+queues:
+  - name: a
+    merger: {type: git, remoteUrl: https://example.com/o/r.git, checkoutPath: /var/checkouts/r, defaultStrategy: SQUASH_REBASE, committerEmail: a@example.com}
+  - name: b
+    merger: `+tt.b+`
+`)
+			_, err := loadMergeConfig(path)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestMergerConfig_FirstDifference(t *testing.T) {
+	// The differing field is named rather than left to the reader, because
+	// "these two queues disagree somewhere" is not enough to act on when a
+	// merger has fifteen fields. This is asserted on the returned value rather
+	// than on an error string so it stays a test of behavior.
+	base := mergerConfig{Type: mergerTypeGit, RemoteURL: "https://example.com/o/r.git", Remote: "origin", Target: "main"}
+	enabled, disabled := true, false
+
+	tests := []struct {
+		name        string
+		other       mergerConfig
+		wantDiffers bool
+		wantField   string
+	}{
+		{name: "identical", other: base},
+		{
+			name:        "target",
+			other:       func() mergerConfig { c := base; c.Target = "release"; return c }(),
+			wantDiffers: true, wantField: "target",
+		},
+		{
+			name:        "default strategy",
+			other:       func() mergerConfig { c := base; c.DefaultStrategy = "REBASE"; return c }(),
+			wantDiffers: true, wantField: "defaultStrategy",
+		},
+		{
+			name:        "optional bool set on one side only",
+			other:       func() mergerConfig { c := base; c.CheckStaleness = &enabled; return c }(),
+			wantDiffers: true, wantField: "checkStaleness",
+		},
+		{
+			name:        "refspecs",
+			other:       func() mergerConfig { c := base; c.FetchRefspecs = []string{"+refs/pull/*:refs/pull/*"}; return c }(),
+			wantDiffers: true, wantField: "fetchRefspecs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diff, differs := base.firstDifference(tt.other)
+			assert.Equal(t, tt.wantDiffers, differs)
+			if !tt.wantDiffers {
+				assert.Empty(t, diff)
+				return
+			}
+			assert.True(t, strings.HasPrefix(diff, tt.wantField+" "),
+				"the difference should lead with the field name, got %q", diff)
+		})
+	}
+
+	// Two pointers to equal values are not a difference: queues spelling an
+	// optional bool differently must still share a checkout.
+	a, b := base, base
+	a.CheckStaleness, b.CheckStaleness = &enabled, &enabled
+	_, differs := a.firstDifference(b)
+	assert.False(t, differs, "distinct pointers to the same value are not a difference")
+
+	b.CheckStaleness = &disabled
+	diff, differs := a.firstDifference(b)
+	assert.True(t, differs)
+	assert.Equal(t, "checkStaleness (true vs false)", diff,
+		"an optional bool reads as its value, not as a pointer address")
+}
+
+func TestLoadMergeConfig_Rejects(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{
+			name: "unknown merger type",
+			contents: `
+defaults:
+  merger: {type: magic}
+`,
+		},
+		{
+			name: "git without checkout path",
+			contents: `
+defaults:
+  merger: {type: git, remoteUrl: https://example.com/o/r.git}
+`,
+		},
+		{
+			name: "token without a remote to authenticate to",
+			contents: `
+defaults:
+  merger: {type: git, checkoutPath: /var/checkouts/r, tokenEnv: SOME_TOKEN}
+`,
+		},
+		{
+			name: "unknown default strategy",
+			contents: `
+defaults:
+  merger:
+    type: git
+    remoteUrl: https://example.com/o/r.git
+    checkoutPath: /var/checkouts/r
+    defaultStrategy: FAST_FORWARD
+`,
+		},
+		{
+			name: "queue without a name",
+			contents: `
+defaults:
+  merger: {type: noop}
+queues:
+  - merger: {type: noop}
+`,
+		},
+		{
+			name: "duplicate queue",
+			contents: `
+defaults:
+  merger: {type: noop}
+queues:
+  - name: a
+    merger: {type: noop}
+  - name: a
+    merger: {type: noop}
+`,
+		},
+		{
+			// Two mergers over one working tree would reset and push it out
+			// from under each other mid-merge.
+			name: "same checkout for different targets",
+			contents: `
+defaults:
+  merger: {type: noop}
+queues:
+  - name: a
+    merger: {type: git, remoteUrl: https://example.com/o/r.git, target: main, checkoutPath: /var/checkouts/r}
+  - name: b
+    merger: {type: git, remoteUrl: https://example.com/o/r.git, target: release, checkoutPath: /var/checkouts/r}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadMergeConfig(writeConfig(t, tt.contents))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestMergerConfig_NeedsHTTPCredential(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  mergerConfig
+		want bool
+	}{
+		{
+			name: "https remote with token",
+			cfg:  mergerConfig{RemoteURL: "https://example.com/o/r.git", TokenEnv: "T"},
+			want: true,
+		},
+		{
+			name: "https remote without token",
+			cfg:  mergerConfig{RemoteURL: "https://example.com/o/r.git"},
+			want: false,
+		},
+		{
+			// The credential is an HTTP header; over SSH there is nothing to
+			// attach it to, and the merger passes the agent socket instead.
+			name: "ssh remote",
+			cfg:  mergerConfig{RemoteURL: "ssh://git@example.com/o/r.git", TokenEnv: "T"},
+			want: false,
+		},
+		{
+			name: "local path used by the hermetic e2e",
+			cfg:  mergerConfig{RemoteURL: "file:///srv/git/sandbox.git", TokenEnv: "T"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cfg.needsHTTPCredential())
+		})
+	}
+}
+
+func TestMergerConfig_Provisions(t *testing.T) {
+	// A checkout with no remote named is one something else built; the wiring
+	// must use it as it stands rather than trying to create it.
+	external := mergerConfig{Type: mergerTypeGit, CheckoutPath: "/var/checkouts/r"}
+	assert.False(t, external.provisions())
+
+	owned := mergerConfig{Type: mergerTypeGit, CheckoutPath: "/var/checkouts/r", RemoteURL: "https://example.com/o/r.git"}
+	assert.True(t, owned.provisions())
+}

--- a/service/runway/server/gitruntime.go
+++ b/service/runway/server/gitruntime.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	gitmerger "github.com/uber/submitqueue/runway/extension/merger/git"
+)
+
+// resolveGitRuntime determines the pinned git runtime the merger invokes.
+//
+// The merger requires all three paths to be absolute and present — it refuses
+// to construct otherwise, deliberately, so that a merge can never silently pick
+// up a different git than the one the deployment intended. Requiring an
+// operator to supply all three by hand turns that safeguard into a boot-time
+// trap, so each is derived from the installed git when its environment
+// override is unset. GIT_EXECUTABLE, GIT_EXEC_PATH, and GIT_TEMPLATE_DIR still
+// take precedence, which is how a deployment pins a git other than the one on
+// PATH.
+func resolveGitRuntime(ctx context.Context) (gitmerger.GitRuntime, error) {
+	executable, err := resolveGitExecutable()
+	if err != nil {
+		return gitmerger.GitRuntime{}, err
+	}
+
+	execPath, err := resolveGitExecPath(ctx, executable)
+	if err != nil {
+		return gitmerger.GitRuntime{}, err
+	}
+
+	templateDir, err := resolveGitTemplateDir(execPath)
+	if err != nil {
+		return gitmerger.GitRuntime{}, err
+	}
+
+	return gitmerger.GitRuntime{
+		Executable:  executable,
+		ExecPath:    execPath,
+		TemplateDir: templateDir,
+	}, nil
+}
+
+// resolveGitExecutable returns the absolute path to the git binary.
+func resolveGitExecutable() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("GIT_EXECUTABLE")); v != "" {
+		return absolutePath("GIT_EXECUTABLE", v)
+	}
+	found, err := exec.LookPath("git")
+	if err != nil {
+		return "", fmt.Errorf("no git on PATH and GIT_EXECUTABLE is unset: %w", err)
+	}
+	return absolutePath("git resolved from PATH", found)
+}
+
+// resolveGitExecPath returns the directory holding git's helper executables,
+// asking the resolved binary itself rather than guessing.
+func resolveGitExecPath(ctx context.Context, executable string) (string, error) {
+	if v := strings.TrimSpace(os.Getenv("GIT_EXEC_PATH")); v != "" {
+		return absolutePath("GIT_EXEC_PATH", v)
+	}
+
+	cmd := exec.CommandContext(ctx, executable, "--exec-path")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%s --exec-path: %w: %s", executable, err, strings.TrimSpace(stderr.String()))
+	}
+	out := strings.TrimSpace(stdout.String())
+	if out == "" {
+		return "", fmt.Errorf("%s --exec-path returned nothing; set GIT_EXEC_PATH", executable)
+	}
+	return absolutePath("git --exec-path", out)
+}
+
+// resolveGitTemplateDir locates git's repository templates.
+//
+// Git exposes no query for this the way it does for the exec path, but it does
+// install both under one prefix — the exec path is <prefix>/lib/git-core or
+// <prefix>/libexec/git-core, and the templates sit at
+// <prefix>/share/git-core/templates. Deriving from the exec path therefore
+// keeps the templates matched to the same installation, which a hardcoded
+// system path would not.
+func resolveGitTemplateDir(execPath string) (string, error) {
+	if v := strings.TrimSpace(os.Getenv("GIT_TEMPLATE_DIR")); v != "" {
+		return absolutePath("GIT_TEMPLATE_DIR", v)
+	}
+
+	prefix := filepath.Dir(filepath.Dir(execPath))
+	candidates := []string{
+		filepath.Join(prefix, "share", "git-core", "templates"),
+		"/usr/share/git-core/templates",
+	}
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"could not locate git templates near exec path %q (tried %s); set GIT_TEMPLATE_DIR",
+		execPath, strings.Join(candidates, ", "),
+	)
+}
+
+// absolutePath makes a resolved runtime path absolute, naming where it came
+// from so a bad value points at the thing that supplied it.
+func absolutePath(source, path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("%s: could not resolve %q to an absolute path: %w", source, path, err)
+	}
+	return abs, nil
+}

--- a/service/runway/server/main.go
+++ b/service/runway/server/main.go
@@ -170,7 +170,7 @@ func run() error {
 		gate,
 	)
 
-	mergerFactory, err := newMergerFactory(logger, scope.SubScope("merger"))
+	mergerFactory, err := newMergerFactory(ctx, logger, scope.SubScope("merger"))
 	if err != nil {
 		return fmt.Errorf("failed to create merger factory: %w", err)
 	}
@@ -304,76 +304,210 @@ func run() error {
 	return err
 }
 
-// newMergerFactory returns a merger.Factory for the server. MERGER selects the
-// implementation explicitly; when it is unset the choice falls back to the merge
-// environment — MERGE_CHECKOUT_PATH wires the git-backed merger built from the
-// MERGE_* / GIT_* environment, and its absence wires the noop merger so local
-// development and compose runs need no git checkout.
-func newMergerFactory(logger *zap.Logger, scope tally.Scope) (merger.Factory, error) {
+// newMergerFactory builds the mergers for the server.
+//
+// MERGER pins every queue to one implementation explicitly, which is how a test
+// holds the service to a fake without a git checkout. Left unset, each queue
+// resolves its own merge target through the merge configuration, so a
+// deployment can serve several repositories from one Runway.
+//
+// The fake is reachable only through MERGER, never through the configuration
+// file: an implementation whose outcomes are steered by markers in a change URI
+// has no business being selectable by a production config.
+func newMergerFactory(ctx context.Context, logger *zap.Logger, scope tally.Scope) (merger.Factory, error) {
 	switch impl := strings.ToLower(strings.TrimSpace(os.Getenv("MERGER"))); impl {
 	case "fake":
 		// Marker-driven outcomes, for e2e tests that need Runway to fail on
 		// demand without a git checkout. Never production.
-		logger.Info("MERGER=fake; using marker-driven fake merger")
+		logger.Info("MERGER=fake; using marker-driven fake merger for every queue")
 		return &fakeMergerFactory{seq: new(atomic.Uint64)}, nil
 	case "noop":
-		logger.Info("MERGER=noop; using noop merger")
+		logger.Info("MERGER=noop; using noop merger for every queue")
 		return &noopMergerFactory{seq: new(atomic.Uint64)}, nil
 	case "", "git":
-		// Fall through to the merge-environment default below.
+		// Fall through to the configured per-queue merge targets.
 	default:
 		return nil, fmt.Errorf("invalid MERGER %q", impl)
 	}
 
-	checkoutPath := os.Getenv("MERGE_CHECKOUT_PATH")
-	if checkoutPath == "" {
-		logger.Info("MERGE_CHECKOUT_PATH not set; using noop merger")
-		return &noopMergerFactory{seq: new(atomic.Uint64)}, nil
-	}
-
-	defaultStrategy, err := parseStrategy(os.Getenv("MERGE_DEFAULT_STRATEGY"))
+	cfg, err := loadMergeConfigFromEnv(logger)
 	if err != nil {
 		return nil, err
 	}
 
-	target := envOr("MERGE_TARGET", "main")
-	m, err := gitmerger.NewMerger(gitmerger.Params{
+	// The git runtime is resolved only when something actually needs it, so a
+	// deployment running nothing but the noop merger does not require git to be
+	// installed at all.
+	var runtime gitmerger.GitRuntime
+	if cfg.usesGit() {
+		runtime, err = resolveGitRuntime(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve git runtime: %w", err)
+		}
+		logger.Info("git runtime resolved",
+			zap.String("executable", runtime.Executable),
+			zap.String("exec_path", runtime.ExecPath),
+			zap.String("template_dir", runtime.TemplateDir),
+		)
+	}
+
+	builder := &mergerBuilder{
+		ctx:      ctx,
+		logger:   logger,
+		scope:    scope,
+		runtime:  runtime,
+		byTarget: make(map[string]merger.Factory),
+		seq:      new(atomic.Uint64),
+	}
+
+	fallback, err := builder.build(cfg.Defaults.Merger, "defaults")
+	if err != nil {
+		return nil, err
+	}
+
+	byQueue := make(map[string]merger.Factory, len(cfg.Queues))
+	for _, q := range cfg.Queues {
+		if q.Merger == nil {
+			continue
+		}
+		m, err := builder.build(*q.Merger, fmt.Sprintf("queue %q", q.Name))
+		if err != nil {
+			return nil, err
+		}
+		byQueue[q.Name] = m
+	}
+
+	logger.Info("mergers configured",
+		zap.String("default_type", cfg.Defaults.Merger.Type),
+		zap.Int("queue_overrides", len(byQueue)),
+	)
+	return mergerRegistry{byQueue: byQueue, fallback: fallback}, nil
+}
+
+// loadMergeConfigFromEnv reads the merge configuration file when one is
+// configured, and otherwise reconstructs the equivalent single-queue
+// configuration from the MERGE_* environment.
+//
+// The environment path predates the file and remains the shortest way to run
+// one merge target, so it stays supported rather than being migrated away;
+// expressing it as the same config type means there is still only one code path
+// building mergers.
+func loadMergeConfigFromEnv(logger *zap.Logger) (mergeConfig, error) {
+	if path := os.Getenv("MERGE_CONFIG_PATH"); path != "" {
+		cfg, err := loadMergeConfig(path)
+		if err != nil {
+			return mergeConfig{}, err
+		}
+		logger.Info("merge config loaded", zap.String("path", path), zap.Int("queues", len(cfg.Queues)))
+		return cfg, nil
+	}
+
+	checkoutPath := os.Getenv("MERGE_CHECKOUT_PATH")
+	if checkoutPath == "" {
+		logger.Info("neither MERGE_CONFIG_PATH nor MERGE_CHECKOUT_PATH set; using noop merger")
+		return mergeConfig{Defaults: queueMergeConfig{Merger: mergerConfig{Type: mergerTypeNoop}}}, nil
+	}
+
+	checkStaleness := envBool("MERGE_CHECK_STALENESS", true)
+	cfg := mergeConfig{Defaults: queueMergeConfig{Merger: mergerConfig{
+		Type:            mergerTypeGit,
 		CheckoutPath:    checkoutPath,
 		Remote:          envOr("MERGE_REMOTE", "origin"),
-		Target:          target,
-		DefaultStrategy: defaultStrategy,
-		Runtime: gitmerger.GitRuntime{
-			Executable:  os.Getenv("GIT_EXECUTABLE"),
-			ExecPath:    os.Getenv("GIT_EXEC_PATH"),
-			TemplateDir: os.Getenv("GIT_TEMPLATE_DIR"),
-		},
-		CommitterName:  os.Getenv("MERGE_COMMITTER_NAME"),
-		CommitterEmail: os.Getenv("MERGE_COMMITTER_EMAIL"),
-		FetchRefspecs:  splitRefspecs(os.Getenv("MERGE_FETCH_REFSPECS")),
-		CheckStaleness: envBool("MERGE_CHECK_STALENESS", true),
+		Target:          envOr("MERGE_TARGET", "main"),
+		DefaultStrategy: os.Getenv("MERGE_DEFAULT_STRATEGY"),
+		CheckStaleness:  &checkStaleness,
 		// Off by default: it lifts git's refusal to join two unrelated history
 		// graphs, which is a safeguard everywhere except a queue whose purpose
 		// is importing one repository's history into another.
 		AllowUnrelatedHistories: envBool("MERGE_ALLOW_UNRELATED_HISTORIES", false),
-		Logger:                  logger.Sugar(),
-		MetricsScope:            scope,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to build git merger: %w", err)
+		UpdateHeadBranch:        envBool("MERGE_UPDATE_HEAD_BRANCH", false),
+		FetchRefspecs:           splitRefspecs(os.Getenv("MERGE_FETCH_REFSPECS")),
+		CommitterName:           os.Getenv("MERGE_COMMITTER_NAME"),
+		CommitterEmail:          os.Getenv("MERGE_COMMITTER_EMAIL"),
+	}}}
+	if err := cfg.normalizeAndValidate(); err != nil {
+		return mergeConfig{}, fmt.Errorf("invalid MERGE_* environment: %w", err)
 	}
-	logger.Info("git merger configured",
-		zap.String("checkout", checkoutPath),
-		zap.String("target", target),
-		zap.String("default_strategy", defaultStrategy.String()),
-	)
-	return &gitMergerFactory{merger: m}, nil
+	return cfg, nil
 }
 
-// gitMergerFactory returns a single git-backed merger for every queue. The
-// merger owns one checkout and serializes its own operations, so one instance
-// is shared across queues — which is why this is the one merger factory that
-// does not forward its Config. A deployment that lands multiple targets wires a
-// factory with a per-queue map instead.
+// mergerBuilder constructs merger factories, reusing one git instance per merge
+// target.
+//
+// Sharing matters: a git merger serializes its own operations against the
+// working tree it owns, so two queues landing on the same target must be the
+// same instance to be serialized against each other. Two instances would hold
+// separate locks over one working tree and reset it out from under each other
+// mid-merge. A noop target has no such constraint and is built per queue, so it
+// carries the queue's own config.
+type mergerBuilder struct {
+	ctx     context.Context
+	logger  *zap.Logger
+	scope   tally.Scope
+	runtime gitmerger.GitRuntime
+	// byTarget caches one merger per checkout path. Keying on the path alone is
+	// safe only because validation has already rejected two queues that share a
+	// checkout and disagree anywhere in their merger config: the cached instance
+	// is built from whichever queue arrived first, so a divergent second queue
+	// would silently run with the first one's settings. Widening what may share
+	// a checkout means widening that check with it.
+	byTarget map[string]merger.Factory
+	// seq is the process-wide counter the noop mergers mint revision ids from,
+	// held here so ids stay unique across every queue.
+	seq *atomic.Uint64
+}
+
+func (b *mergerBuilder) build(cfg mergerConfig, where string) (merger.Factory, error) {
+	if cfg.Type != mergerTypeGit {
+		return &noopMergerFactory{seq: b.seq}, nil
+	}
+
+	if existing, ok := b.byTarget[cfg.CheckoutPath]; ok {
+		return existing, nil
+	}
+
+	if cfg.provisions() {
+		if err := provisionCheckout(b.ctx, b.logger.Sugar(), b.runtime, cfg); err != nil {
+			return nil, fmt.Errorf("%s: failed to provision checkout: %w", where, err)
+		}
+	}
+
+	m, err := gitmerger.NewMerger(gitmerger.Params{
+		CheckoutPath:            cfg.CheckoutPath,
+		Remote:                  cfg.Remote,
+		Target:                  cfg.Target,
+		DefaultStrategy:         cfg.strategy(),
+		Runtime:                 b.runtime,
+		MaxPushAttempts:         cfg.MaxPushAttempts,
+		FetchRefspecs:           cfg.FetchRefspecs,
+		CheckStaleness:          *cfg.CheckStaleness,
+		UpdateHeadBranch:        cfg.UpdateHeadBranch,
+		AllowUnrelatedHistories: cfg.AllowUnrelatedHistories,
+		CommitterName:           cfg.CommitterName,
+		CommitterEmail:          cfg.CommitterEmail,
+		Logger:                  b.logger.Sugar(),
+		MetricsScope:            b.scope,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to build git merger: %w", where, err)
+	}
+
+	b.logger.Info("git merger configured",
+		zap.String("checkout", cfg.CheckoutPath),
+		zap.String("target", cfg.Target),
+		zap.String("default_strategy", cfg.strategy().String()),
+		zap.Bool("update_head_branch", cfg.UpdateHeadBranch),
+	)
+	f := &gitMergerFactory{merger: m}
+	b.byTarget[cfg.CheckoutPath] = f
+	return f, nil
+}
+
+// gitMergerFactory returns one git-backed merger for every queue routed to it.
+// The merger owns one checkout and serializes its own operations, so a single
+// instance is shared — which is why this is the one merger factory that does
+// not forward its Config. Queues landing on different targets get different
+// instances of it, resolved through mergerRegistry.
 type gitMergerFactory struct {
 	merger merger.Merger
 }
@@ -402,6 +536,24 @@ type fakeMergerFactory struct {
 
 func (f *fakeMergerFactory) For(cfg merger.Config) (merger.Merger, error) {
 	return fake.New(cfg, f.seq), nil
+}
+
+// mergerRegistry resolves each queue's merger factory, falling back to the
+// default for a queue with no entry of its own.
+//
+// It holds factories rather than mergers so the queue's Config reaches the
+// implementation: whether an entry yields one shared instance or a fresh
+// per-queue one is the factory's business, not the registry's.
+type mergerRegistry struct {
+	byQueue  map[string]merger.Factory
+	fallback merger.Factory
+}
+
+func (r mergerRegistry) For(cfg merger.Config) (merger.Merger, error) {
+	if f, ok := r.byQueue[cfg.QueueName]; ok {
+		return f.For(cfg)
+	}
+	return r.fallback.For(cfg)
 }
 
 // parseStrategy maps the MERGE_DEFAULT_STRATEGY env value to a concrete merge


### PR DESCRIPTION
## Summary

### Why?

Three things stopped Runway from performing a real merge. It resolved one merger for the whole process, so a deployment could serve only one repository. Nothing created the checkout the git merger requires, which it declares must already exist. And the container had no `git` binary, while the merger demanded three absolute runtime paths — so enabling it failed at startup with `git runtime executable is required` rather than working.

### What?

Merge targets come from `MERGE_CONFIG_PATH`, a YAML file with a `defaults` block and per-queue overrides. Each git target is provisioned at startup — repository initialised, remote configured, credential written, target branch checked out — idempotently, so a restart against a persisted volume costs nothing and a rotated token takes effect. The existing `MERGE_*` environment variables still configure a single target when no file is given.

Two queues naming one checkout resolve to the *same* merger instance, which is what serializes them: a git merger locks the working tree it owns, and two instances over one tree would reset it out from under each other mid-merge. That instance is built from whichever queue is reached first, so queues sharing a checkout have to agree on every field it is built from — not merely on the target. Any disagreement is rejected at startup, naming the field, because the alternative is a queue that asked for `SQUASH_REBASE` quietly merging with `REBASE` and reporting nothing. The comparison is structural rather than a list of fields to remember, so a field added to the merger later is covered on its own.

The credential never enters the remote URL. The merger folds git's stderr into the errors it returns, so a URL-embedded token would be reprinted into logs and dead-letter payloads by any failed fetch. It is written as an HTTP `Authorization` header into a `0600` config fragment the repository includes — which keeps it off the command line too. SSH needs no code at all: the merger already passes `SSH_AUTH_SOCK` and `GIT_SSH_COMMAND` through its scrubbed environment.

The git runtime is derived from the installed git when unset — executable from `PATH`, exec path from `git --exec-path`, templates from the matching install prefix — so the pinning safeguard stops being a boot-time trap. `git` is installed in the image.

## Test Plan

✅ `bazel test //service/runway/server:go_default_test` — provisioning runs against real git (pinned, as the merger does): clone into an empty directory, idempotent re-run, drifted remote URL corrected, non-default target branch, credential written `0600` and absent from the remote URL, stale fragment removed, unset token rejected, and git-runtime derivation with and without the environment overrides.

✅ Sharing a checkout is now judged on the whole merger configuration, not just the target: two queues that agree everywhere still share one instance, two that disagree in `defaultStrategy`, `updateHeadBranch`, `checkStaleness`, `maxPushAttempts`, the committer identity or the refspecs are rejected at load, and a queue spelling a default explicitly still counts as agreeing.

