### PR TITLE
feat(orchestrator): build extension profiles from configuration

### DIFF
--- a/service/submitqueue/orchestrator/server/BUILD.bazel
+++ b/service/submitqueue/orchestrator/server/BUILD.bazel
@@ -8,6 +8,7 @@ exports_files(
 go_library(
     name = "orchestrator_lib",
     srcs = [
+        "config.go",
         "main.go",
         "profiles.go",
     ],
@@ -15,6 +16,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//api/submitqueue/orchestrator/protopb:go_default_library",
+        "//platform/buildkite:go_default_library",
         "//platform/errs/generic:go_default_library",
         "//platform/errs/mysql:go_default_library",
         "//platform/extension/consumergate:go_default_library",
@@ -23,12 +25,15 @@ go_library(
         "//platform/extension/counter:go_default_library",
         "//platform/extension/counter/mysql:go_default_library",
         "//platform/extension/messagequeue/mysql:go_default_library",
+        "//platform/githubactions:go_default_library",
         "//platform/http:go_default_library",
         "//platform/pipeline:go_default_library",
         "//submitqueue/core/changeset:go_default_library",
         "//submitqueue/entity:go_default_library",
         "//submitqueue/extension/buildrunner:go_default_library",
+        "//submitqueue/extension/buildrunner/buildkite:go_default_library",
         "//submitqueue/extension/buildrunner/fake:go_default_library",
+        "//submitqueue/extension/buildrunner/githubactions:go_default_library",
         "//submitqueue/extension/changeprovider:go_default_library",
         "//submitqueue/extension/changeprovider/fake:go_default_library",
         "//submitqueue/extension/changeprovider/github:go_default_library",
@@ -54,6 +59,7 @@ go_library(
         "//submitqueue/orchestrator:go_default_library",
         "@com_github_go_sql_driver_mysql//:go_default_library",
         "@com_github_uber_go_tally//:go_default_library",
+        "@in_gopkg_yaml_v3//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//reflection:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
@@ -91,9 +97,13 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["profiles_test.go"],
+    srcs = [
+        "config_test.go",
+        "profiles_test.go",
+    ],
     embed = [":orchestrator_lib"],  # keep
     deps = [
+        "//submitqueue/entity:go_default_library",
         "//submitqueue/extension/buildrunner:go_default_library",
         "//submitqueue/extension/changeprovider:go_default_library",
         "//submitqueue/extension/conflict:go_default_library",
@@ -102,5 +112,7 @@ go_test(
         "//submitqueue/extension/storage:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
+        "@com_github_uber_go_tally//:go_default_library",
+        "@org_uber_go_zap//zaptest:go_default_library",
     ],
 )

--- a/service/submitqueue/orchestrator/server/config.go
+++ b/service/submitqueue/orchestrator/server/config.go
@@ -1,0 +1,460 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// Change provider types selectable from configuration.
+const (
+	changeProviderTypeFake        = "fake"
+	changeProviderTypeGitHub      = "github"
+	changeProviderTypePhabricator = "phabricator"
+	changeProviderTypeRouting     = "routing"
+)
+
+// Build runner types selectable from configuration.
+const (
+	buildRunnerTypeFake          = "fake"
+	buildRunnerTypeGitHubActions = "githubactions"
+	buildRunnerTypeBuildkite     = "buildkite"
+)
+
+// Conflict analyzer types selectable from configuration.
+const (
+	analyzerTypeAll         = "all"
+	analyzerTypeNone        = "none"
+	analyzerTypePathOverlap = "pathoverlap"
+)
+
+// Granularities a pathoverlap analyzer compares paths at.
+const (
+	pathOverlapByFile      = "file"
+	pathOverlapByDirectory = "directory"
+)
+
+// Scorer types selectable from configuration.
+const (
+	scorerTypeHeuristic = "heuristic"
+	scorerTypeComposite = "composite"
+)
+
+// maxBucket is the open upper bound of a size bucket, and defaultFlatScore the
+// score a queue with no stated opinion gives every batch.
+const (
+	maxBucket        = 1<<31 - 1
+	defaultFlatScore = 0.5
+)
+
+// Ways a composite scorer combines its components.
+const combineAvg = "avg"
+
+// Defaults for the provider integrations, matching each vendor's convention.
+const (
+	defaultGitHubTokenEnv = "GITHUB_TOKEN"
+	defaultGitHubBaseURL  = "https://api.github.com"
+	defaultPhabTokenEnv   = "PHAB_API_TOKEN"
+	defaultHTTPTimeout    = 30 * time.Second
+)
+
+// profilesConfig selects, per queue, which implementation of each extension the
+// orchestrator wires.
+//
+// It carries no secret: every integration names the *environment variable*
+// holding its credential, so the file stays committable and a deployment
+// rotates a token without editing it. `type` is an open string rather than a
+// closed set in the schema, so supporting a new provider is a new value here and
+// a new implementation behind it — not a change to the shape of this file.
+type profilesConfig struct {
+	// Defaults applies to any queue without an override for a given extension.
+	Defaults queueProfileConfig `yaml:"defaults"`
+	// Queues holds per-queue overrides.
+	Queues []namedQueueProfileConfig `yaml:"queues"`
+}
+
+// namedQueueProfileConfig is one queue's overrides. Each extension is
+// independently optional: an absent block inherits that one extension from the
+// defaults, so a queue that differs only in its analyzer says only that.
+type namedQueueProfileConfig struct {
+	Name           string                `yaml:"name"`
+	ChangeProvider *changeProviderConfig `yaml:"changeProvider"`
+	BuildRunner    *buildRunnerConfig    `yaml:"buildRunner"`
+	Analyzer       *analyzerConfig       `yaml:"analyzer"`
+	Scorer         *scorerConfig         `yaml:"scorer"`
+}
+
+// queueProfileConfig is the full set of extensions a queue resolves to.
+type queueProfileConfig struct {
+	ChangeProvider changeProviderConfig `yaml:"changeProvider"`
+	BuildRunner    buildRunnerConfig    `yaml:"buildRunner"`
+	Analyzer       analyzerConfig       `yaml:"analyzer"`
+	Scorer         scorerConfig         `yaml:"scorer"`
+}
+
+// changeProviderConfig selects how change metadata is fetched. The github and
+// phabricator blocks are shared by the single-provider types and by routing, which
+// dispatches between them on the change URI's scheme.
+type changeProviderConfig struct {
+	Type        string                `yaml:"type"`
+	GitHub      *githubProviderConfig `yaml:"github"`
+	Phabricator *phabProviderConfig   `yaml:"phabricator"`
+}
+
+// githubProviderConfig configures the GitHub change provider.
+type githubProviderConfig struct {
+	// TokenEnv names the environment variable holding the API token.
+	TokenEnv string `yaml:"tokenEnv"`
+	// BaseURL is the GitHub API root, for GitHub Enterprise.
+	BaseURL string `yaml:"baseUrl"`
+	// Timeout bounds each API call, as a Go duration ("30s").
+	Timeout string `yaml:"timeout"`
+}
+
+// phabProviderConfig configures the Phabricator change provider.
+type phabProviderConfig struct {
+	TokenEnv string `yaml:"tokenEnv"`
+	// Endpoint is the Conduit API root.
+	Endpoint string `yaml:"endpoint"`
+	Timeout  string `yaml:"timeout"`
+}
+
+// buildRunnerConfig selects how a batch's build is triggered and polled.
+type buildRunnerConfig struct {
+	Type string `yaml:"type"`
+	// TokenEnv names the environment variable holding the API token.
+	TokenEnv string `yaml:"tokenEnv"`
+	// BaseURL is the API root. For githubactions it defaults to the public
+	// GitHub API; for buildkite it is the pipeline's builds endpoint and is
+	// required, since a Buildkite client is bound to one pipeline by its URL.
+	BaseURL string `yaml:"baseUrl"`
+	Timeout string `yaml:"timeout"`
+	// Owner, Repo, and Workflow identify the workflow to dispatch
+	// (githubactions only). Ref is the branch the workflow is read from.
+	Owner    string `yaml:"owner"`
+	Repo     string `yaml:"repo"`
+	Workflow string `yaml:"workflow"`
+	Ref      string `yaml:"ref"`
+	// ExtraInputs are passed to every dispatch alongside the reserved sq_*
+	// inputs (githubactions only).
+	ExtraInputs map[string]string `yaml:"extraInputs"`
+}
+
+// analyzerConfig selects how conflicts between concurrent batches are detected.
+type analyzerConfig struct {
+	Type string `yaml:"type"`
+	// By is the granularity a pathoverlap analyzer compares paths at: "file"
+	// conflicts only batches changing the same file, "directory" coarsens that
+	// to a shared parent directory. Defaults to "file"; ignored by other types.
+	By string `yaml:"by"`
+	// FailAlways makes every analysis return an error, for exercising the
+	// analyzer failure path. Test-only.
+	FailAlways bool `yaml:"failAlways"`
+}
+
+// scorerConfig selects how a queue ranks candidate speculation paths. There is
+// no scoring stage: the scorer feeds the queue's speculator, which is composed
+// from it rather than configured separately.
+type scorerConfig struct {
+	Type string `yaml:"type"`
+	// Buckets map a batch's total lines changed onto a score (heuristic only).
+	Buckets []bucketConfig `yaml:"buckets"`
+	// Components are the scorers a composite combines, keyed by name.
+	Components map[string]scorerConfig `yaml:"components"`
+	// Combine names how a composite reduces its components. Defaults to "avg".
+	Combine string `yaml:"combine"`
+}
+
+// bucketConfig is one band of a heuristic scorer: batches whose size falls in
+// [Min, Max] score Score.
+type bucketConfig struct {
+	Min   int     `yaml:"min"`
+	Max   int     `yaml:"max"`
+	Score float64 `yaml:"score"`
+}
+
+// loadProfilesConfig reads and validates the profiles configuration at path.
+func loadProfilesConfig(path string) (profilesConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return profilesConfig{}, fmt.Errorf("failed to read profiles config %q: %w", path, err)
+	}
+
+	var cfg profilesConfig
+	if err := yamlv3.Unmarshal(data, &cfg); err != nil {
+		return profilesConfig{}, fmt.Errorf("failed to parse profiles config %q: %w", path, err)
+	}
+	if err := cfg.normalizeAndValidate(); err != nil {
+		return profilesConfig{}, fmt.Errorf("invalid profiles config %q: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// normalizeAndValidate applies defaults and rejects a configuration that could
+// not produce working extensions.
+func (c *profilesConfig) normalizeAndValidate() error {
+	if err := c.Defaults.normalizeAndValidate("defaults"); err != nil {
+		return err
+	}
+
+	seen := make(map[string]bool, len(c.Queues))
+	for i := range c.Queues {
+		q := &c.Queues[i]
+		if q.Name == "" {
+			return fmt.Errorf("queue entry %d has an empty name", i)
+		}
+		if seen[q.Name] {
+			return fmt.Errorf("queue %q appears more than once", q.Name)
+		}
+		seen[q.Name] = true
+
+		where := fmt.Sprintf("queue %q", q.Name)
+		if q.ChangeProvider != nil {
+			if err := q.ChangeProvider.normalizeAndValidate(where); err != nil {
+				return err
+			}
+		}
+		if q.BuildRunner != nil {
+			if err := q.BuildRunner.normalizeAndValidate(where); err != nil {
+				return err
+			}
+		}
+		if q.Analyzer != nil {
+			if err := q.Analyzer.normalizeAndValidate(where); err != nil {
+				return err
+			}
+		}
+		if q.Scorer != nil {
+			if err := q.Scorer.normalizeAndValidate(where); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// resolve returns the full profile for a queue: its own overrides where it has
+// them, the defaults everywhere else.
+func (c profilesConfig) resolve(q namedQueueProfileConfig) queueProfileConfig {
+	profile := c.Defaults
+	if q.ChangeProvider != nil {
+		profile.ChangeProvider = *q.ChangeProvider
+	}
+	if q.BuildRunner != nil {
+		profile.BuildRunner = *q.BuildRunner
+	}
+	if q.Analyzer != nil {
+		profile.Analyzer = *q.Analyzer
+	}
+	if q.Scorer != nil {
+		profile.Scorer = *q.Scorer
+	}
+	return profile
+}
+
+func (p *queueProfileConfig) normalizeAndValidate(where string) error {
+	if err := p.ChangeProvider.normalizeAndValidate(where); err != nil {
+		return err
+	}
+	if err := p.BuildRunner.normalizeAndValidate(where); err != nil {
+		return err
+	}
+	if err := p.Analyzer.normalizeAndValidate(where); err != nil {
+		return err
+	}
+	return p.Scorer.normalizeAndValidate(where)
+}
+
+func (c *changeProviderConfig) normalizeAndValidate(where string) error {
+	if c.Type == "" {
+		c.Type = changeProviderTypeFake
+	}
+	switch c.Type {
+	case changeProviderTypeFake:
+		return nil
+	case changeProviderTypeGitHub:
+		c.ensureGitHub()
+	case changeProviderTypePhabricator:
+		if err := c.ensurePhabricator(where); err != nil {
+			return err
+		}
+	case changeProviderTypeRouting:
+		// Routing dispatches on the URI scheme, so it needs at least one provider
+		// to dispatch to; which ones is up to the deployment.
+		if c.GitHub == nil && c.Phabricator == nil {
+			return fmt.Errorf("%s: routing change provider needs a github or phabricator block", where)
+		}
+		if c.GitHub != nil {
+			c.ensureGitHub()
+		}
+		if c.Phabricator != nil {
+			if err := c.ensurePhabricator(where); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("%s: unknown change provider type %q", where, c.Type)
+	}
+	return nil
+}
+
+func (c *changeProviderConfig) ensureGitHub() {
+	if c.GitHub == nil {
+		c.GitHub = &githubProviderConfig{}
+	}
+	if c.GitHub.TokenEnv == "" {
+		c.GitHub.TokenEnv = defaultGitHubTokenEnv
+	}
+	if c.GitHub.BaseURL == "" {
+		c.GitHub.BaseURL = defaultGitHubBaseURL
+	}
+}
+
+func (c *changeProviderConfig) ensurePhabricator(where string) error {
+	if c.Phabricator == nil {
+		c.Phabricator = &phabProviderConfig{}
+	}
+	if c.Phabricator.TokenEnv == "" {
+		c.Phabricator.TokenEnv = defaultPhabTokenEnv
+	}
+	if c.Phabricator.Endpoint == "" {
+		return fmt.Errorf("%s: phabricator change provider requires an endpoint", where)
+	}
+	return nil
+}
+
+func (b *buildRunnerConfig) normalizeAndValidate(where string) error {
+	if b.Type == "" {
+		b.Type = buildRunnerTypeFake
+	}
+	switch b.Type {
+	case buildRunnerTypeFake:
+		return nil
+	case buildRunnerTypeGitHubActions:
+		if b.Owner == "" || b.Repo == "" || b.Workflow == "" {
+			return fmt.Errorf("%s: githubactions build runner requires owner, repo, and workflow", where)
+		}
+		if b.TokenEnv == "" {
+			b.TokenEnv = defaultGitHubTokenEnv
+		}
+		if b.BaseURL == "" {
+			b.BaseURL = defaultGitHubBaseURL
+		}
+	case buildRunnerTypeBuildkite:
+		// A Buildkite client is bound to one pipeline by its base URL, so there
+		// is no meaningful default to fall back on.
+		if b.BaseURL == "" {
+			return fmt.Errorf("%s: buildkite build runner requires baseUrl (the pipeline's builds endpoint)", where)
+		}
+		if b.TokenEnv == "" {
+			return fmt.Errorf("%s: buildkite build runner requires tokenEnv", where)
+		}
+	default:
+		return fmt.Errorf("%s: unknown build runner type %q", where, b.Type)
+	}
+	return nil
+}
+
+func (a *analyzerConfig) normalizeAndValidate(where string) error {
+	if a.Type == "" {
+		a.Type = analyzerTypeAll
+	}
+	switch a.Type {
+	case analyzerTypeAll, analyzerTypeNone:
+		return nil
+	case analyzerTypePathOverlap:
+		if a.By == "" {
+			a.By = pathOverlapByFile
+		}
+		if a.By != pathOverlapByFile && a.By != pathOverlapByDirectory {
+			return fmt.Errorf("%s: unknown pathoverlap granularity %q", where, a.By)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%s: unknown analyzer type %q", where, a.Type)
+	}
+}
+
+// normalizeAndValidate applies defaults and rejects a scorer that could not be
+// built. An empty block is a flat heuristic: every batch scores the same, which
+// is the neutral choice for a queue with no opinion about ordering.
+func (s *scorerConfig) normalizeAndValidate(where string) error {
+	if s.Type == "" {
+		s.Type = scorerTypeHeuristic
+	}
+	switch s.Type {
+	case scorerTypeHeuristic:
+		if len(s.Buckets) == 0 {
+			s.Buckets = []bucketConfig{{Min: 0, Max: maxBucket, Score: defaultFlatScore}}
+		}
+		for _, b := range s.Buckets {
+			if b.Min > b.Max {
+				return fmt.Errorf("%s: scorer bucket min %d exceeds max %d", where, b.Min, b.Max)
+			}
+			if b.Score < 0 || b.Score > 1 {
+				return fmt.Errorf("%s: scorer bucket score %v is outside [0,1]", where, b.Score)
+			}
+		}
+	case scorerTypeComposite:
+		if len(s.Components) == 0 {
+			return fmt.Errorf("%s: composite scorer needs at least one component", where)
+		}
+		for name, component := range s.Components {
+			if err := component.normalizeAndValidate(fmt.Sprintf("%s component %q", where, name)); err != nil {
+				return err
+			}
+			s.Components[name] = component
+		}
+		if s.Combine == "" {
+			s.Combine = combineAvg
+		}
+		if s.Combine != combineAvg {
+			return fmt.Errorf("%s: unknown composite combine %q", where, s.Combine)
+		}
+	default:
+		return fmt.Errorf("%s: unknown scorer type %q", where, s.Type)
+	}
+	return nil
+}
+
+// timeoutOr parses a Go duration string, falling back when it is empty or
+// unparseable — a bad value should not stop the service from starting.
+func timeoutOr(value string, fallback time.Duration) time.Duration {
+	if value == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return fallback
+	}
+	return d
+}
+
+// tokenFrom reads the credential the named environment variable holds,
+// reporting whether it was both set and non-empty.
+func tokenFrom(env string) (string, bool) {
+	if env == "" {
+		return "", false
+	}
+	v, ok := os.LookupEnv(env)
+	if !ok || v == "" {
+		return "", false
+	}
+	return v, true
+}

--- a/service/submitqueue/orchestrator/server/config_test.go
+++ b/service/submitqueue/orchestrator/server/config_test.go
@@ -1,0 +1,395 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/uber/submitqueue/submitqueue/entity"
+	"github.com/uber/submitqueue/submitqueue/extension/conflict"
+)
+
+func writeProfiles(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "profiles.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestDefaultProfilesConfig_MatchesTheBuiltInTopology(t *testing.T) {
+	// The e2e suite depends on these queues behaving exactly as they did before
+	// profiles became configurable, so this pins the built-in fallback.
+	t.Setenv("PHAB_API_ENDPOINT", "")
+
+	cfg := defaultProfilesConfig()
+
+	assert.Equal(t, changeProviderTypeRouting, cfg.Defaults.ChangeProvider.Type)
+	assert.Equal(t, buildRunnerTypeFake, cfg.Defaults.BuildRunner.Type)
+	assert.Equal(t, analyzerTypeAll, cfg.Defaults.Analyzer.Type)
+	assert.False(t, cfg.Defaults.Analyzer.FailAlways)
+	assert.Nil(t, cfg.Defaults.ChangeProvider.Phabricator,
+		"phabricator joins routing only once an endpoint says where to go")
+
+	byName := make(map[string]namedQueueProfileConfig, len(cfg.Queues))
+	for _, q := range cfg.Queues {
+		byName[q.Name] = q
+	}
+
+	tests := []struct {
+		queue      string
+		wantType   string
+		wantBy     string
+		failAlways bool
+	}{
+		{queue: "e2e-test-queue", wantType: analyzerTypeNone},
+		{queue: "e2e-conflict-error-queue", wantType: analyzerTypeAll, failAlways: true},
+		{queue: "file-overlap-queue", wantType: analyzerTypePathOverlap, wantBy: pathOverlapByFile},
+	}
+	for _, tt := range tests {
+		t.Run(tt.queue, func(t *testing.T) {
+			q, ok := byName[tt.queue]
+			require.True(t, ok)
+			require.NotNil(t, q.Analyzer)
+			assert.Equal(t, tt.wantType, q.Analyzer.Type)
+			assert.Equal(t, tt.wantBy, q.Analyzer.By)
+			assert.Equal(t, tt.failAlways, q.Analyzer.FailAlways)
+
+			// Only the analyzer differs; everything else stays the baseline.
+			assert.Nil(t, q.ChangeProvider)
+			assert.Nil(t, q.BuildRunner)
+		})
+	}
+}
+
+func TestDefaultProfilesConfig_AddsPhabricatorWhenPointedAtOne(t *testing.T) {
+	t.Setenv("PHAB_API_ENDPOINT", "https://phab.example.com/api")
+
+	cfg := defaultProfilesConfig()
+	require.NotNil(t, cfg.Defaults.ChangeProvider.Phabricator)
+	assert.Equal(t, "https://phab.example.com/api", cfg.Defaults.ChangeProvider.Phabricator.Endpoint)
+}
+
+func TestLoadProfilesConfig_InheritsPerExtension(t *testing.T) {
+	// A queue that differs only in its analyzer says only that, and keeps the
+	// default change provider and build runner.
+	path := writeProfiles(t, `
+defaults:
+  changeProvider: {type: fake}
+  buildRunner: {type: fake}
+  analyzer: {type: all}
+queues:
+  - name: parallel
+    analyzer: {type: none}
+`)
+
+	cfg, err := loadProfilesConfig(path)
+	require.NoError(t, err)
+
+	resolved := cfg.resolve(cfg.Queues[0])
+	assert.Equal(t, analyzerTypeNone, resolved.Analyzer.Type)
+	assert.Equal(t, changeProviderTypeFake, resolved.ChangeProvider.Type)
+	assert.Equal(t, buildRunnerTypeFake, resolved.BuildRunner.Type)
+}
+
+func TestLoadProfilesConfig_AppliesForgeDefaults(t *testing.T) {
+	path := writeProfiles(t, `
+defaults:
+  changeProvider: {type: github}
+  buildRunner: {type: githubactions, owner: uber, repo: sq-sandbox, workflow: validate.yml}
+`)
+
+	cfg, err := loadProfilesConfig(path)
+	require.NoError(t, err)
+
+	require.NotNil(t, cfg.Defaults.ChangeProvider.GitHub)
+	assert.Equal(t, defaultGitHubTokenEnv, cfg.Defaults.ChangeProvider.GitHub.TokenEnv)
+	assert.Equal(t, defaultGitHubBaseURL, cfg.Defaults.ChangeProvider.GitHub.BaseURL)
+	assert.Equal(t, defaultGitHubTokenEnv, cfg.Defaults.BuildRunner.TokenEnv)
+	assert.Equal(t, defaultGitHubBaseURL, cfg.Defaults.BuildRunner.BaseURL)
+}
+
+func TestLoadProfilesConfig_EmptyFileIsAllFakes(t *testing.T) {
+	cfg, err := loadProfilesConfig(writeProfiles(t, ""))
+	require.NoError(t, err)
+	assert.Equal(t, changeProviderTypeFake, cfg.Defaults.ChangeProvider.Type)
+	assert.Equal(t, buildRunnerTypeFake, cfg.Defaults.BuildRunner.Type)
+	assert.Equal(t, analyzerTypeAll, cfg.Defaults.Analyzer.Type)
+}
+
+func TestLoadProfilesConfig_PathOverlapDefaultsToFile(t *testing.T) {
+	cfg, err := loadProfilesConfig(writeProfiles(t, "defaults:\n  analyzer: {type: pathoverlap}\n"))
+	require.NoError(t, err)
+	assert.Equal(t, pathOverlapByFile, cfg.Defaults.Analyzer.By,
+		"the narrower granularity is the safer default: directory would widen a queue's conflicts")
+
+	cfg, err = loadProfilesConfig(writeProfiles(t, "defaults:\n  analyzer: {type: pathoverlap, by: directory}\n"))
+	require.NoError(t, err)
+	assert.Equal(t, pathOverlapByDirectory, cfg.Defaults.Analyzer.By)
+}
+
+func TestLoadProfilesConfig_Rejects(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{
+			name:     "unknown change provider",
+			contents: "defaults:\n  changeProvider: {type: gitlab}\n",
+		},
+		{
+			name:     "unknown build runner",
+			contents: "defaults:\n  buildRunner: {type: jenkins}\n",
+		},
+		{
+			name:     "unknown analyzer",
+			contents: "defaults:\n  analyzer: {type: clairvoyant}\n",
+		},
+		{
+			name:     "unknown pathoverlap granularity",
+			contents: "defaults:\n  analyzer: {type: pathoverlap, by: repository}\n",
+		},
+		{
+			name:     "phabricator without an endpoint",
+			contents: "defaults:\n  changeProvider: {type: phabricator}\n",
+		},
+		{
+			name:     "routing with nothing to route to",
+			contents: "defaults:\n  changeProvider: {type: routing}\n",
+		},
+		{
+			name:     "github actions without a workflow",
+			contents: "defaults:\n  buildRunner: {type: githubactions, owner: uber, repo: r}\n",
+		},
+		{
+			name:     "buildkite without a pipeline url",
+			contents: "defaults:\n  buildRunner: {type: buildkite, tokenEnv: BK}\n",
+		},
+		{
+			name:     "queue without a name",
+			contents: "queues:\n  - analyzer: {type: none}\n",
+		},
+		{
+			name:     "duplicate queue",
+			contents: "queues:\n  - name: a\n  - name: a\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadProfilesConfig(writeProfiles(t, tt.contents))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestNewProfiles_ReusesOneBuildRunnerFactoryAcrossIdenticalQueues(t *testing.T) {
+	// Queues configured alike resolve to one factory, which is what keeps a
+	// single HTTP client behind several queues pointing at the same repository.
+	//
+	// It is the factory that is shared, not the runner: implementations are
+	// built per resolution so each carries its own queue's Config. Sharing an
+	// instance is not required, because the fake runner encodes a build's
+	// outcome in the BuildID it returns rather than holding it in memory, so
+	// the build and buildsignal controllers can look it up independently.
+	path := writeProfiles(t, `
+defaults:
+  changeProvider: {type: fake}
+  buildRunner: {type: fake}
+  analyzer: {type: all}
+queues:
+  - name: a
+    analyzer: {type: none}
+  - name: b
+    analyzer: {type: none}
+`)
+	cfg, err := loadProfilesConfig(path)
+	require.NoError(t, err)
+
+	b := &profileBuilder{
+		logger: zaptest.NewLogger(t),
+		scope:  tally.NoopScope,
+		built:  make(map[string]any),
+	}
+
+	runnerConfigs := []buildRunnerConfig{cfg.Defaults.BuildRunner}
+	for _, q := range cfg.Queues {
+		runnerConfigs = append(runnerConfigs, cfg.resolve(q).BuildRunner)
+	}
+	for _, rc := range runnerConfigs {
+		_, err := reuse(b, rc, "profile", b.newBuildRunnerFactory)
+		require.NoError(t, err)
+	}
+
+	assert.Len(t, b.built, 1,
+		"the default profile and both queues are configured alike, so they share one factory")
+}
+
+// analyzeOutcome runs an analyzer against one in-flight batch and reduces the
+// result to what distinguishes the three kinds from each other.
+func analyzeOutcome(t *testing.T, analyzer conflict.Analyzer) (conflicts int, failed bool) {
+	t.Helper()
+	batch := entity.Batch{ID: "q/batch/2", Queue: "q"}
+	inFlight := []entity.Batch{{ID: "q/batch/1", Queue: "q"}}
+
+	found, err := analyzer.Analyze(context.Background(), batch, inFlight)
+	if err != nil {
+		return 0, true
+	}
+	return len(found), false
+}
+
+func TestNewProfiles_ResolvesPerQueueAnalyzers(t *testing.T) {
+	// Asserted on behavior rather than instance identity: the analyzers are
+	// stateless value types, so what matters is that each queue got the type it
+	// asked for.
+	profiles, err := newProfiles(zaptest.NewLogger(t), tally.NoopScope, nil, nil, defaultProfilesConfig())
+	require.NoError(t, err)
+
+	tests := []struct {
+		queue         string
+		wantConflicts int
+		wantFailed    bool
+	}{
+		// Maximum parallelism: never conflicts with anything in flight.
+		{queue: "e2e-test-queue", wantConflicts: 0},
+		// Serializes conservatively: conflicts with everything in flight.
+		{queue: "unlisted-falls-back-to-default", wantConflicts: 1},
+		// Exercises the analyzer error path.
+		{queue: "e2e-conflict-error-queue", wantFailed: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.queue, func(t *testing.T) {
+			analyzer, err := profiles.AnalyzerFactory().For(conflict.Config{QueueName: tt.queue})
+			require.NoError(t, err)
+
+			conflicts, failed := analyzeOutcome(t, analyzer)
+			assert.Equal(t, tt.wantFailed, failed)
+			if !tt.wantFailed {
+				assert.Equal(t, tt.wantConflicts, conflicts)
+			}
+		})
+	}
+}
+
+func TestNewProfiles_FailsWhenAForgeTokenIsMissing(t *testing.T) {
+	// Failing at startup beats accepting land requests and discovering the
+	// credential gap one API call into the first merge.
+	t.Setenv("TEST_GH_TOKEN_UNSET", "")
+	path := writeProfiles(t, `
+defaults:
+  changeProvider:
+    type: github
+    github: {tokenEnv: TEST_GH_TOKEN_UNSET}
+`)
+	cfg, err := loadProfilesConfig(path)
+	require.NoError(t, err)
+
+	_, err = newProfiles(zaptest.NewLogger(t), tally.NoopScope, nil, nil, cfg)
+	require.Error(t, err)
+}
+
+func TestNewProfiles_RoutingFallsBackToFakeWithoutTokens(t *testing.T) {
+	// Routing serves a deployment reaching several providers, so a provider whose
+	// token is unset drops out rather than failing the whole provider.
+	t.Setenv("TEST_GH_TOKEN_UNSET", "")
+	path := writeProfiles(t, `
+defaults:
+  changeProvider:
+    type: routing
+    github: {tokenEnv: TEST_GH_TOKEN_UNSET}
+`)
+	cfg, err := loadProfilesConfig(path)
+	require.NoError(t, err)
+
+	profiles, err := newProfiles(zaptest.NewLogger(t), tally.NoopScope, nil, nil, cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, profiles.For("anything").ChangeProvider)
+}
+
+func TestDefaultProfilesConfig_KeepsPerQueueScorers(t *testing.T) {
+	// Speculation ranks candidate paths by score, so a queue silently losing its
+	// scoring profile changes which paths get built without failing anything.
+	cfg := defaultProfilesConfig()
+
+	byName := make(map[string]namedQueueProfileConfig, len(cfg.Queues))
+	for _, q := range cfg.Queues {
+		byName[q.Name] = q
+	}
+
+	assert.Equal(t, scorerTypeHeuristic, cfg.Defaults.Scorer.Type)
+	assert.Len(t, cfg.Defaults.Scorer.Buckets, 1, "the baseline scores every batch alike")
+
+	bucketed, ok := byName["test-queue"]
+	require.True(t, ok)
+	require.NotNil(t, bucketed.Scorer)
+	assert.Equal(t, scorerTypeHeuristic, bucketed.Scorer.Type)
+	assert.Len(t, bucketed.Scorer.Buckets, 4, "smaller batches must rank ahead of larger ones")
+
+	comp, ok := byName["e2e-test-queue"]
+	require.True(t, ok)
+	require.NotNil(t, comp.Scorer)
+	assert.Equal(t, scorerTypeComposite, comp.Scorer.Type)
+	assert.ElementsMatch(t, []string{"size", "flat"}, keysOf(comp.Scorer.Components))
+}
+
+func keysOf(m map[string]scorerConfig) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestNewProfiles_ComposesASpeculatorPerQueue(t *testing.T) {
+	// Speculation is only "on" if every queue resolves to a real speculator —
+	// a nil one leaves the stage inert and nothing ever gets built.
+	profiles, err := newProfiles(zaptest.NewLogger(t), tally.NoopScope, nil, nil, defaultProfilesConfig())
+	require.NoError(t, err)
+
+	for _, queue := range []string{"test-queue", "e2e-test-queue", "file-overlap-queue", "unlisted"} {
+		t.Run(queue, func(t *testing.T) {
+			p := profiles.For(queue)
+			assert.NotNil(t, p.Scorer, "scorer feeds the speculator")
+			assert.NotNil(t, p.Speculator)
+		})
+	}
+}
+
+func TestLoadProfilesConfig_RejectsBadScorers(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{name: "unknown scorer type", contents: "defaults:\n  scorer: {type: vibes}\n"},
+		{name: "composite with no components", contents: "defaults:\n  scorer: {type: composite}\n"},
+		{name: "unknown combine", contents: "defaults:\n  scorer:\n    type: composite\n    combine: median\n    components: {a: {type: heuristic}}\n"},
+		{name: "score out of range", contents: "defaults:\n  scorer:\n    type: heuristic\n    buckets: [{min: 0, max: 10, score: 2.0}]\n"},
+		{name: "inverted bucket", contents: "defaults:\n  scorer:\n    type: heuristic\n    buckets: [{min: 10, max: 1, score: 0.5}]\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadProfilesConfig(writeProfiles(t, tt.contents))
+			require.Error(t, err)
+		})
+	}
+}

--- a/service/submitqueue/orchestrator/server/main.go
+++ b/service/submitqueue/orchestrator/server/main.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	nethttp "net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -28,7 +27,6 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-	"golang.org/x/oauth2"
 
 	"github.com/uber-go/tally"
 	pb "github.com/uber/submitqueue/api/submitqueue/orchestrator/protopb"
@@ -40,14 +38,8 @@ import (
 	"github.com/uber/submitqueue/platform/extension/counter"
 	mysqlcounter "github.com/uber/submitqueue/platform/extension/counter/mysql"
 	queueMySQL "github.com/uber/submitqueue/platform/extension/messagequeue/mysql"
-	"github.com/uber/submitqueue/platform/http"
 	"github.com/uber/submitqueue/platform/pipeline"
 	"github.com/uber/submitqueue/submitqueue/core/changeset"
-	"github.com/uber/submitqueue/submitqueue/extension/changeprovider"
-	cpfake "github.com/uber/submitqueue/submitqueue/extension/changeprovider/fake"
-	githubprovider "github.com/uber/submitqueue/submitqueue/extension/changeprovider/github"
-	phabprovider "github.com/uber/submitqueue/submitqueue/extension/changeprovider/phabricator"
-	routingprovider "github.com/uber/submitqueue/submitqueue/extension/changeprovider/routing"
 	"github.com/uber/submitqueue/submitqueue/extension/storage"
 	mysqlstorage "github.com/uber/submitqueue/submitqueue/extension/storage/mysql"
 	"github.com/uber/submitqueue/submitqueue/extension/validator"
@@ -184,7 +176,11 @@ func run() error {
 	// to its own set of extension implementations (conflict analyzer, …),
 	// falling back to a baseline profile for queues without an explicit entry.
 	storageFty := storageFactory{backend: store}
-	profiles, err := newProfiles(logger, scope, changeset.New(storageFty), storageFty)
+	profilesCfg, err := loadProfilesConfigFromEnv(logger)
+	if err != nil {
+		return fmt.Errorf("failed to load extension profiles: %w", err)
+	}
+	profiles, err := newProfiles(logger, scope, changeset.New(storageFty), storageFty, profilesCfg)
 	if err != nil {
 		return fmt.Errorf("failed to build profiles: %w", err)
 	}
@@ -320,137 +316,94 @@ func newConsumerGate(logger *zap.Logger) consumergate.Gate {
 	return consumergatefile.New(dir)
 }
 
-// newChangeProviderFactory builds the host's changeprovider.Factory. The HTTP
-// clients are expensive and queue-independent, so they are built once here; the
-// factory then constructs a cheap provider per resolution, bound to the queue
-// named in the Config it is handed. When neither GITHUB_TOKEN nor PHAB_API_TOKEN
-// is set it falls back to the fake change provider.
-func newChangeProviderFactory(logger *zap.Logger, scope tally.Scope) (changeprovider.Factory, error) {
-	ghClient, err := newGitHubClient()
+// loadProfilesConfigFromEnv reads the extension profiles file when one is
+// configured, and otherwise returns the built-in example topology.
+//
+// Keeping the built-in as the fallback means a deployment that sets no config
+// path — including the compose stack and the e2e suite — gets exactly the
+// behavior it had before profiles became configurable.
+func loadProfilesConfigFromEnv(logger *zap.Logger) (profilesConfig, error) {
+	path := os.Getenv("PROFILES_CONFIG_PATH")
+	if path == "" {
+		logger.Info("PROFILES_CONFIG_PATH not set; using built-in example profiles")
+		return defaultProfilesConfig(), nil
+	}
+	cfg, err := loadProfilesConfig(path)
 	if err != nil {
-		return nil, err
+		return profilesConfig{}, err
 	}
-
-	phabClient, err := newPhabClient()
-	if err != nil {
-		return nil, err
-	}
-
-	if ghClient == nil && phabClient == nil {
-		logger.Warn("no change provider tokens set; using fake change provider (empty change info unless URI-marked)")
-		return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
-			return cpfake.New(c), nil
-		}), nil
-	}
-
-	sugar := logger.Sugar()
-	return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
-		var gh, phab changeprovider.ChangeProvider
-		if ghClient != nil {
-			gh = githubprovider.NewProvider(githubprovider.Params{
-				Config:       c,
-				HTTPClient:   ghClient,
-				Logger:       sugar,
-				MetricsScope: scope.SubScope("changeprovider.github"),
-			})
-		}
-		if phabClient != nil {
-			phab = phabprovider.NewProvider(phabprovider.Params{
-				Config:       c,
-				HTTPClient:   phabClient,
-				Logger:       sugar,
-				MetricsScope: scope.SubScope("changeprovider.phabricator"),
-			})
-		}
-
-		routingProvider, err := routingprovider.NewProvider(routingprovider.Params{
-			Config:      c,
-			GitHub:      gh,
-			Phabricator: phab,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create routing change provider: %w", err)
-		}
-		return routingProvider, nil
-	}), nil
+	logger.Info("extension profiles loaded", zap.String("path", path), zap.Int("queues", len(cfg.Queues)))
+	return cfg, nil
 }
 
-// newGitHubClient builds the GitHub HTTP client configured via GITHUB_BASE_URL,
-// GITHUB_TOKEN, and GITHUB_TIMEOUT. Returns nil when GITHUB_TOKEN is unset.
-func newGitHubClient() (*nethttp.Client, error) {
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		return nil, nil
+// defaultProfilesConfig is the example topology used when no configuration file
+// is supplied: fake edge integrations everywhere, with the conflict analyzer
+// varied per queue to exercise its different behaviors.
+//
+// The change provider is routing rather than fake so that setting a provider token
+// in the environment is enough to reach a real provider, as it has always been —
+// routing falls back to the fake provider on its own when no token is set.
+func defaultProfilesConfig() profilesConfig {
+	provider := changeProviderConfig{
+		Type:   changeProviderTypeRouting,
+		GitHub: &githubProviderConfig{TokenEnv: defaultGitHubTokenEnv, BaseURL: getEnv("GITHUB_BASE_URL", defaultGitHubBaseURL), Timeout: os.Getenv("GITHUB_TIMEOUT")},
+	}
+	// Phabricator needs an endpoint as well as a token, and has no default one
+	// to fall back on, so it joins the routing set only once told where to go.
+	if endpoint := os.Getenv("PHAB_API_ENDPOINT"); endpoint != "" {
+		provider.Phabricator = &phabProviderConfig{TokenEnv: defaultPhabTokenEnv, Endpoint: endpoint}
 	}
 
-	client, err := http.NewClient(getEnv("GITHUB_BASE_URL", "https://api.github.com"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to build GitHub HTTP client: %w", err)
+	cfg := profilesConfig{
+		Defaults: queueProfileConfig{
+			ChangeProvider: provider,
+			BuildRunner:    buildRunnerConfig{Type: buildRunnerTypeFake},
+			Analyzer:       analyzerConfig{Type: analyzerTypeAll},
+		},
+		Queues: []namedQueueProfileConfig{
+			// Bucketed scoring: smaller batches are likelier to land, so they
+			// rank ahead of larger ones. Conflicts stay conservative.
+			{Name: "test-queue", Scorer: &scorerConfig{
+				Type: scorerTypeHeuristic,
+				Buckets: []bucketConfig{
+					{Min: 0, Max: 1, Score: 0.95},
+					{Min: 2, Max: 5, Score: 0.80},
+					{Min: 6, Max: 20, Score: 0.60},
+					{Min: 21, Max: maxBucket, Score: 0.40},
+				},
+			}},
+			// Maximum parallelism: nothing ever conflicts. Scored by a
+			// composite, which exercises the combining path.
+			{Name: "e2e-test-queue",
+				Analyzer: &analyzerConfig{Type: analyzerTypeNone},
+				Scorer: &scorerConfig{
+					Type:    scorerTypeComposite,
+					Combine: combineAvg,
+					Components: map[string]scorerConfig{
+						"size": {Type: scorerTypeHeuristic, Buckets: []bucketConfig{{Min: 0, Max: maxBucket, Score: 0.8}}},
+						"flat": {Type: scorerTypeHeuristic, Buckets: []bucketConfig{{Min: 0, Max: maxBucket, Score: 0.6}}},
+					},
+				},
+			},
+			// Every analysis fails, exercising the analyzer error path.
+			{Name: "e2e-conflict-error-queue", Analyzer: &analyzerConfig{Type: analyzerTypeAll, FailAlways: true}},
+			// Serializes only batches changing the same file.
+			{Name: "file-overlap-queue", Analyzer: &analyzerConfig{Type: analyzerTypePathOverlap, By: pathOverlapByFile}},
+		},
 	}
-
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")})
-	client.Transport = &oauth2.Transport{Source: ts, Base: client.Transport}
-	client.Timeout = parseTimeout(os.Getenv("GITHUB_TIMEOUT"), 30*time.Second)
-
-	return client, nil
-}
-
-// apiTokenTransport injects a Phabricator API token as a query parameter in each request.
-type apiTokenTransport struct {
-	token string
-	next  nethttp.RoundTripper
-}
-
-func (t *apiTokenTransport) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
-	r := req.Clone(req.Context())
-	q := r.URL.Query()
-	q.Set("api.token", t.token)
-	r.URL.RawQuery = q.Encode()
-	return t.next.RoundTrip(r)
-}
-
-// newPhabClient builds the Phabricator HTTP client configured via
-// PHAB_API_ENDPOINT and PHAB_API_TOKEN. Returns nil when either is unset.
-func newPhabClient() (*nethttp.Client, error) {
-	token := os.Getenv("PHAB_API_TOKEN")
-	if token == "" {
-		return nil, nil
+	// Built from constants, so a validation failure here is a programming error
+	// rather than a deployment one; normalizing keeps it on the same path as a
+	// file-supplied config.
+	if err := cfg.normalizeAndValidate(); err != nil {
+		panic(fmt.Sprintf("built-in profiles are invalid: %v", err))
 	}
-
-	endpoint := os.Getenv("PHAB_API_ENDPOINT")
-	if endpoint == "" {
-		return nil, nil
-	}
-
-	client, err := http.NewClient(endpoint)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build Phabricator HTTP client: %w", err)
-	}
-
-	baseTransport := client.Transport.(*http.BaseURLTransport)
-	baseTransport.Next = &apiTokenTransport{
-		token: token,
-		next:  baseTransport.Next,
-	}
-
-	return client, nil
+	return cfg
 }
 
 // getEnv returns environment variable value or default if not set.
 func getEnv(key, defaultVal string) string {
 	if val := os.Getenv(key); val != "" {
 		return val
-	}
-	return defaultVal
-}
-
-// parseTimeout parses a duration from environment variable with fallback to default.
-// Returns defaultVal if envVal is empty or cannot be parsed.
-func parseTimeout(envVal string, defaultVal time.Duration) time.Duration {
-	if envVal == "" {
-		return defaultVal
-	}
-	if d, err := time.ParseDuration(envVal); err == nil {
-		return d
 	}
 	return defaultVal
 }

--- a/service/submitqueue/orchestrator/server/profiles.go
+++ b/service/submitqueue/orchestrator/server/profiles.go
@@ -15,15 +15,30 @@
 package main
 
 import (
-	"context"
 	"fmt"
+	nethttp "net/http"
 
 	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	yamlv3 "gopkg.in/yaml.v3"
+
+	"context"
+
+	platformbuildkite "github.com/uber/submitqueue/platform/buildkite"
+	platformgithubactions "github.com/uber/submitqueue/platform/githubactions"
+	"github.com/uber/submitqueue/platform/http"
 	"github.com/uber/submitqueue/submitqueue/core/changeset"
 	"github.com/uber/submitqueue/submitqueue/entity"
 	"github.com/uber/submitqueue/submitqueue/extension/buildrunner"
+	buildkiterunner "github.com/uber/submitqueue/submitqueue/extension/buildrunner/buildkite"
 	buildfake "github.com/uber/submitqueue/submitqueue/extension/buildrunner/fake"
+	githubactionsrunner "github.com/uber/submitqueue/submitqueue/extension/buildrunner/githubactions"
 	"github.com/uber/submitqueue/submitqueue/extension/changeprovider"
+	cpfake "github.com/uber/submitqueue/submitqueue/extension/changeprovider/fake"
+	githubprovider "github.com/uber/submitqueue/submitqueue/extension/changeprovider/github"
+	phabprovider "github.com/uber/submitqueue/submitqueue/extension/changeprovider/phabricator"
+	routingprovider "github.com/uber/submitqueue/submitqueue/extension/changeprovider/routing"
 	"github.com/uber/submitqueue/submitqueue/extension/conflict"
 	"github.com/uber/submitqueue/submitqueue/extension/conflict/all"
 	conflictfake "github.com/uber/submitqueue/submitqueue/extension/conflict/fake"
@@ -38,20 +53,12 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/speculation/speculator"
 	specstandard "github.com/uber/submitqueue/submitqueue/extension/speculation/speculator/standard"
 	"github.com/uber/submitqueue/submitqueue/extension/storage"
-	"go.uber.org/zap"
 )
 
-// Profile holds the per-queue extension factories. Grouping them per queue
-// (rather than per extension) lets the wiring read as "for this queue, here are
-// its analyzer, change provider, …", and lets a queue profile start from a
-// baseline and override only what differs.
-//
-// Every field is a Factory rather than a built implementation. Selecting the
-// profile consumes only the queue name; the Config itself is forwarded into the
-// profile's factory, so the implementation is constructed knowing which queue it
-// serves. That matters most for defaultProfile, which backs every queue without
-// an explicit entry: one shared instance could not carry a correct queue name,
-// but one factory can build a correct instance per queue.
+// Profile holds the per-queue extension implementations. Grouping them per
+// queue (rather than per extension) lets the wiring read as "for this queue,
+// here are its analyzer, change provider, …", and lets a queue profile start
+// from a baseline and override only what differs.
 type Profile struct {
 	// ChangeProvider resolves change metadata for requests in this queue.
 	ChangeProvider changeprovider.Factory
@@ -94,10 +101,6 @@ func (p Profiles) For(queue string) Profile {
 	return p.defaultProfile
 }
 
-// Each XFactory method resolves the queue's profile by name, then forwards the
-// whole Config to that profile's factory. The second For(c) is what carries the
-// queue identity past the profile lookup and into the implementation.
-
 // ChangeProviderFactory returns a changeprovider.Factory that resolves the
 // ChangeProvider for each queue from the profile registry.
 func (p Profiles) ChangeProviderFactory() changeprovider.Factory {
@@ -122,11 +125,11 @@ func (p Profiles) AnalyzerFactory() conflict.Factory {
 	})
 }
 
-// StorageFactory returns a storage.Factory that routes each queue to its
-// profile's storage backend before binding the queue-scoped store aggregate.
-func (p Profiles) StorageFactory() storage.Factory {
-	return storageFunc(func(c storage.Config) (storage.Storage, error) {
-		return p.For(c.QueueName).Storage.For(c)
+// SpeculatorFactory returns a speculator.Factory that resolves the Speculator
+// for each queue from the profile registry.
+func (p Profiles) SpeculatorFactory() speculator.Factory {
+	return speculatorFunc(func(c speculator.Config) (speculator.Speculator, error) {
+		return p.For(c.QueueName).Speculator.For(c)
 	})
 }
 
@@ -138,18 +141,17 @@ func (p Profiles) ScorerFactory() scorer.Factory {
 	})
 }
 
-// SpeculatorFactory returns a speculator.Factory that resolves the Speculator
-// for each queue from the profile registry.
-func (p Profiles) SpeculatorFactory() speculator.Factory {
-	return speculatorFunc(func(c speculator.Config) (speculator.Speculator, error) {
-		return p.For(c.QueueName).Speculator.For(c)
+// StorageFactory returns a storage.Factory that routes each queue to its
+// profile's storage backend before binding the queue-scoped store aggregate.
+func (p Profiles) StorageFactory() storage.Factory {
+	return storageFunc(func(c storage.Config) (storage.Storage, error) {
+		return p.For(c.QueueName).Storage.For(c)
 	})
 }
 
 // Thin func-type adapters — the http.HandlerFunc trick applied to each
 // extension Factory interface. Each func type satisfies the Factory contract,
-// letting Profiles cross the host/library boundary without dedicated structs,
-// and letting a Profile field hold a closure instead of a built instance.
+// letting Profiles cross the host/library boundary without dedicated structs.
 
 type changeProviderFunc func(changeprovider.Config) (changeprovider.ChangeProvider, error)
 
@@ -177,119 +179,93 @@ type speculatorFunc func(speculator.Config) (speculator.Speculator, error)
 
 func (f speculatorFunc) For(c speculator.Config) (speculator.Speculator, error) { return f(c) }
 
-// newProfiles builds the per-queue extension profiles for the example.
-// Edge integrations (change provider) and the build runner form a shared
-// baseline; each per-queue profile starts from that baseline and overrides
-// only the extensions that differ — here the conflict analyzer and the scorer.
-// Queues without an explicit profile fall back to the baseline.
+// newProfiles builds the per-queue extension profiles from configuration.
 //
-// Anything expensive and queue-independent — the resolver, the metrics scope,
-// the change provider's HTTP clients — is built once, here. The closures below
-// only construct the cheap per-queue wrapper, which is the same shape
-// counterFactory.For already uses for the MySQL counter.
-func newProfiles(logger *zap.Logger, scope tally.Scope, resolver changeset.Resolver, stores storage.Factory) (Profiles, error) {
-	changeProviders, err := newChangeProviderFactory(logger, scope)
+// Every queue resolves to its own set of implementations, so one deployment can
+// run a queue against a real provider next to one running entirely on fakes —
+// which is what lets the same wiring serve both the hermetic test stack and a
+// live repository.
+func newProfiles(
+	logger *zap.Logger,
+	scope tally.Scope,
+	resolver changeset.Resolver,
+	stores storage.Factory,
+	cfg profilesConfig,
+) (Profiles, error) {
+	b := &profileBuilder{
+		logger:   logger,
+		scope:    scope,
+		resolver: resolver,
+		stores:   stores,
+		built:    make(map[string]any),
+	}
+
+	defaultProfile, err := b.build(cfg.Defaults, "defaults")
 	if err != nil {
-		return Profiles{}, fmt.Errorf("failed to create change provider: %w", err)
+		return Profiles{}, err
 	}
 
-	// batchLines buckets a batch by total lines changed across all its changes —
-	// larger batches are likelier to fail to land.
-	batchLines := func(_ context.Context, changes entity.BatchChanges) (int, error) {
-		return changes.TotalLinesChanged(), nil
-	}
-
-	// heuristicScorer builds a bucketed heuristic scorer, wrapped by scorerfake
-	// so a change URI carrying "sq-fake=score-error" forces a scoring error
-	// end-to-end; the wrapper is a pure passthrough otherwise.
-	heuristicScorer := func(buckets []heuristic.Bucket, scopeName string) scorer.Factory {
-		return scorerFunc(func(c scorer.Config) (scorer.Scorer, error) {
-			return scorerfake.New(c, resolver, heuristic.New(
-				c, resolver, buckets, batchLines, scope.SubScope(scopeName),
-			)), nil
-		})
-	}
-
-	// Baseline profile: shared edge integrations + a fake build runner (every
-	// build succeeds unless a head URI carries a failure marker), plus permissive
-	// defaults for scorer and conflict.
-	//
-	// The analyzer is wrapped by conflictfake with a nil predicate (passthrough)
-	// — swap the predicate (e.g. conflictfake.FailAlways) on a queue to exercise
-	// the analyzer error path, as e2e-conflict-error-queue below does.
-	base := Profile{
-		ChangeProvider: changeProviders,
-		BuildRunner: buildRunnerFunc(func(c buildrunner.Config) (buildrunner.BuildRunner, error) {
-			return buildfake.New(c, resolver), nil
-		}),
-		// TODO: replace the delegate with a real analyzer (e.g. Tango target
-		// analysis). "all" serializes the queue conservatively.
-		Analyzer: analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
-			return conflictfake.New(c, all.New(c), nil), nil
-		}),
-		Storage: stores,
-		Scorer: heuristicScorer(
-			[]heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: 0.5}},
-			"scorer.default",
-		),
-	}
-
-	// test-queue: bucketed heuristic scorer; conservative (serialized) conflicts
-	// inherited from the baseline.
-	testQueue := base
-	testQueue.Scorer = heuristicScorer(
-		[]heuristic.Bucket{
-			{Min: 0, Max: 1, Score: 0.95},
-			{Min: 2, Max: 5, Score: 0.80},
-			{Min: 6, Max: 20, Score: 0.60},
-			{Min: 21, Max: 1<<31 - 1, Score: 0.40},
-		},
-		"scorer.test-queue",
-	)
-
-	// e2e-conflict-error-queue: every conflict analysis fails, exercising the
-	// analyzer error path. Scorer/edge integrations inherit the baseline.
-	conflictErrQueue := base
-	conflictErrQueue.Analyzer = analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
-		return conflictfake.New(c, all.New(c), conflictfake.FailAlways), nil
-	})
-
-	// file-overlap-queue: a real analyzer that serializes only batches sharing
-	// a changed file, resolving each batch's files itself via the resolver.
-	// pathoverlap.ByDirectory would coarsen this to whole directories.
-	fileOverlapQueue := base
-	fileOverlapQueue.Analyzer = analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
-		return pathoverlap.New(c, resolver, pathoverlap.ByFile), nil
-	})
-
-	// e2e-test-queue: composite scorer; no conflicts (maximum parallelism).
-	e2eQueue := base
-	e2eQueue.Analyzer = analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
-		return conflictfake.New(c, none.New(c), nil), nil
-	})
-	e2eQueue.Scorer = scorerFunc(func(c scorer.Config) (scorer.Scorer, error) {
-		flat := func(score float64) scorer.Scorer {
-			return heuristic.New(c, resolver,
-				[]heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: score}}, batchLines, scope)
+	byQueue := make(map[string]Profile, len(cfg.Queues))
+	for _, q := range cfg.Queues {
+		profile, err := b.build(cfg.resolve(q), fmt.Sprintf("queue %q", q.Name))
+		if err != nil {
+			return Profiles{}, err
 		}
-		return scorerfake.New(c, resolver, composite.New(
-			c,
-			map[string]scorer.Scorer{"size": flat(0.8), "flat": flat(0.6)},
-			composite.Avg, scope.SubScope("scorer.e2e-test-queue"),
-		)), nil
-	})
+		byQueue[q.Name] = profile
+	}
 
+	logger.Info("extension profiles built",
+		zap.String("default_change_provider", cfg.Defaults.ChangeProvider.Type),
+		zap.String("default_build_runner", cfg.Defaults.BuildRunner.Type),
+		zap.String("default_analyzer", cfg.Defaults.Analyzer.Type),
+		zap.String("default_scorer", cfg.Defaults.Scorer.Type),
+		zap.Int("queue_overrides", len(byQueue)),
+	)
+	return Profiles{defaultProfile: defaultProfile, byQueue: byQueue}, nil
+}
+
+// profileBuilder constructs extension factories, reusing one factory per
+// distinct configuration.
+//
+// What is reused is the factory, not the implementation: an implementation is
+// built per resolution so it carries the queue's own Config, while everything
+// expensive and queue-independent — the HTTP clients, the resolver, the metrics
+// scopes — is built once here and captured by the factory. Several queues
+// pointing at one repository therefore still share a single HTTP client.
+type profileBuilder struct {
+	logger   *zap.Logger
+	scope    tally.Scope
+	resolver changeset.Resolver
+	stores   storage.Factory
+	built    map[string]any
+}
+
+func (b *profileBuilder) build(cfg queueProfileConfig, where string) (Profile, error) {
+	provider, err := reuse(b, cfg.ChangeProvider, where, b.newChangeProviderFactory)
+	if err != nil {
+		return Profile{}, err
+	}
+	runner, err := reuse(b, cfg.BuildRunner, where, b.newBuildRunnerFactory)
+	if err != nil {
+		return Profile{}, err
+	}
+	analyzer, err := reuse(b, cfg.Analyzer, where, b.newAnalyzerFactory)
+	if err != nil {
+		return Profile{}, err
+	}
+	sc, err := reuse(b, cfg.Scorer, where, b.newScorerFactory)
+	if err != nil {
+		return Profile{}, err
+	}
 	// The speculator is composed last, because it is built from whatever scorer
 	// the profile ended up with.
-	return Profiles{
-		defaultProfile: withSpeculator(base),
-		byQueue: map[string]Profile{
-			"test-queue":               withSpeculator(testQueue),
-			"e2e-test-queue":           withSpeculator(e2eQueue),
-			"e2e-conflict-error-queue": withSpeculator(conflictErrQueue),
-			"file-overlap-queue":       withSpeculator(fileOverlapQueue),
-		},
-	}, nil
+	return withSpeculator(Profile{
+		ChangeProvider: provider,
+		BuildRunner:    runner,
+		Analyzer:       analyzer,
+		Storage:        b.stores,
+		Scorer:         sc,
+	}), nil
 }
 
 // defaultBuildBudget caps how many builds a queue may have occupying CI at
@@ -306,9 +282,8 @@ const defaultBuildBudget = 4
 // policy without touching the speculate controller, which depends only on the
 // Speculator contract.
 //
-// The scorer is resolved at the same queue identity the speculator was asked
-// for, so a queue falling through to defaultProfile gets a speculator whose
-// underlying scorer was also built for that queue.
+// The scorer is resolved lazily, at the queue the speculator itself was asked
+// for, so the queue's identity reaches one level down into the scorer too.
 func withSpeculator(p Profile) Profile {
 	p.Speculator = speculatorFunc(func(c speculator.Config) (speculator.Speculator, error) {
 		sc, err := p.Scorer.For(scorer.Config{QueueName: c.QueueName})
@@ -318,4 +293,351 @@ func withSpeculator(p Profile) Profile {
 		return specstandard.New(c, bestfirst.New(sc), sticky.New(defaultBuildBudget)), nil
 	})
 	return p
+}
+
+// batchLines buckets a batch by total lines changed across all its changes —
+// larger batches are likelier to fail to land.
+func batchLines(_ context.Context, changes entity.BatchChanges) (int, error) {
+	return changes.TotalLinesChanged(), nil
+}
+
+// newScorerFactory builds the configured scorer's factory.
+//
+// Every scorer is wrapped by scorerfake so a change URI carrying
+// "sq-fake=score-error" forces a scoring error end to end; it is a pure
+// passthrough otherwise.
+//
+// The configuration is walked once up front so an unusable scorer config fails
+// at wiring time rather than on the first queue that resolves it.
+func (b *profileBuilder) newScorerFactory(cfg scorerConfig, where string) (scorer.Factory, error) {
+	if _, err := b.buildScorer(scorer.Config{}, cfg, where, "scorer"); err != nil {
+		return nil, err
+	}
+	return scorerFunc(func(c scorer.Config) (scorer.Scorer, error) {
+		inner, err := b.buildScorer(c, cfg, where, "scorer")
+		if err != nil {
+			return nil, err
+		}
+		return scorerfake.New(c, b.resolver, inner), nil
+	}), nil
+}
+
+// buildScorer constructs one scorer for the given queue, recursing for a
+// composite's components. scopeName keeps each component's metrics
+// distinguishable.
+func (b *profileBuilder) buildScorer(c scorer.Config, cfg scorerConfig, where, scopeName string) (scorer.Scorer, error) {
+	switch cfg.Type {
+	case scorerTypeHeuristic:
+		buckets := make([]heuristic.Bucket, 0, len(cfg.Buckets))
+		for _, bc := range cfg.Buckets {
+			buckets = append(buckets, heuristic.Bucket{Min: bc.Min, Max: bc.Max, Score: bc.Score})
+		}
+		return heuristic.New(c, b.resolver, buckets, batchLines, b.scope.SubScope(scopeName)), nil
+
+	case scorerTypeComposite:
+		components := make(map[string]scorer.Scorer, len(cfg.Components))
+		for name, component := range cfg.Components {
+			built, err := b.buildScorer(c, component, where, scopeName+"."+name)
+			if err != nil {
+				return nil, err
+			}
+			components[name] = built
+		}
+		// avg is the only combine the schema admits.
+		return composite.New(c, components, composite.Avg, b.scope.SubScope(scopeName)), nil
+
+	default:
+		return nil, fmt.Errorf("%s: unknown scorer type %q", where, cfg.Type)
+	}
+}
+
+// reuse returns the instance already built for an identical configuration, or
+// builds and remembers one. Identity is the configuration's own YAML encoding,
+// which compares nested optional blocks by value rather than by pointer.
+func reuse[C any, T any](b *profileBuilder, cfg C, where string, make func(C, string) (T, error)) (T, error) {
+	var zero T
+	encoded, err := yamlv3.Marshal(cfg)
+	if err != nil {
+		return zero, fmt.Errorf("%s: failed to key extension config: %w", where, err)
+	}
+	key := fmt.Sprintf("%T:%s", zero, encoded)
+	if existing, ok := b.built[key]; ok {
+		return existing.(T), nil
+	}
+	built, err := make(cfg, where)
+	if err != nil {
+		return zero, err
+	}
+	b.built[key] = built
+	return built, nil
+}
+
+// newChangeProviderFactory builds the configured change provider's factory.
+func (b *profileBuilder) newChangeProviderFactory(cfg changeProviderConfig, where string) (changeprovider.Factory, error) {
+	switch cfg.Type {
+	case changeProviderTypeFake:
+		return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
+			return cpfake.New(c), nil
+		}), nil
+
+	case changeProviderTypeGitHub:
+		makeProvider, err := b.newGitHubChangeProvider(*cfg.GitHub, where)
+		if err != nil {
+			return nil, err
+		}
+		if makeProvider == nil {
+			return nil, fmt.Errorf("%s: github change provider needs %s to be set", where, cfg.GitHub.TokenEnv)
+		}
+		return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
+			return makeProvider(c), nil
+		}), nil
+
+	case changeProviderTypePhabricator:
+		makeProvider, err := b.newPhabChangeProvider(*cfg.Phabricator, where)
+		if err != nil {
+			return nil, err
+		}
+		if makeProvider == nil {
+			return nil, fmt.Errorf("%s: phabricator change provider needs %s to be set", where, cfg.Phabricator.TokenEnv)
+		}
+		return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
+			return makeProvider(c), nil
+		}), nil
+
+	case changeProviderTypeRouting:
+		return b.newRoutingChangeProviderFactory(cfg, where)
+
+	default:
+		return nil, fmt.Errorf("%s: unknown change provider type %q", where, cfg.Type)
+	}
+}
+
+// newRoutingChangeProviderFactory builds a provider that dispatches on the change
+// URI's scheme. A configured provider whose token is unset is left out rather than
+// failing: routing exists for a deployment that reaches several providers, and
+// requiring credentials for all of them to use any of them would make it
+// unusable partway through a migration.
+func (b *profileBuilder) newRoutingChangeProviderFactory(cfg changeProviderConfig, where string) (changeprovider.Factory, error) {
+	var (
+		makeGitHub, makePhab func(changeprovider.Config) changeprovider.ChangeProvider
+		err                  error
+	)
+	if cfg.GitHub != nil {
+		if makeGitHub, err = b.newGitHubChangeProvider(*cfg.GitHub, where); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.Phabricator != nil {
+		if makePhab, err = b.newPhabChangeProvider(*cfg.Phabricator, where); err != nil {
+			return nil, err
+		}
+	}
+
+	if makeGitHub == nil && makePhab == nil {
+		b.logger.Warn("no change provider tokens set; using fake change provider (empty change info unless URI-marked)",
+			zap.String("profile", where))
+		return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
+			return cpfake.New(c), nil
+		}), nil
+	}
+
+	return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
+		var gh, phab changeprovider.ChangeProvider
+		if makeGitHub != nil {
+			gh = makeGitHub(c)
+		}
+		if makePhab != nil {
+			phab = makePhab(c)
+		}
+		provider, err := routingprovider.NewProvider(routingprovider.Params{Config: c, GitHub: gh, Phabricator: phab})
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to create routing change provider: %w", where, err)
+		}
+		return provider, nil
+	}), nil
+}
+
+// newGitHubChangeProvider returns a function building the GitHub change provider
+// for a given queue, or nil when its token is unset. The HTTP client and metrics
+// scope are built once here; only the per-queue wrapper is built per call.
+func (b *profileBuilder) newGitHubChangeProvider(cfg githubProviderConfig, where string) (func(changeprovider.Config) changeprovider.ChangeProvider, error) {
+	token, ok := tokenFrom(cfg.TokenEnv)
+	if !ok {
+		return nil, nil
+	}
+	client, err := b.githubClient(cfg.BaseURL, cfg.Timeout, token, where)
+	if err != nil {
+		return nil, err
+	}
+	scope := b.scope.SubScope("changeprovider.github")
+	return func(c changeprovider.Config) changeprovider.ChangeProvider {
+		return githubprovider.NewProvider(githubprovider.Params{
+			Config:       c,
+			HTTPClient:   client,
+			Logger:       b.logger.Sugar(),
+			MetricsScope: scope,
+		})
+	}, nil
+}
+
+// newPhabChangeProvider returns a function building the Phabricator change
+// provider for a given queue, or nil when its token is unset. As with GitHub,
+// the HTTP client is built once here.
+func (b *profileBuilder) newPhabChangeProvider(cfg phabProviderConfig, where string) (func(changeprovider.Config) changeprovider.ChangeProvider, error) {
+	token, ok := tokenFrom(cfg.TokenEnv)
+	if !ok {
+		return nil, nil
+	}
+	client, err := http.NewClient(cfg.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to build Phabricator HTTP client: %w", where, err)
+	}
+	client.Timeout = timeoutOr(cfg.Timeout, defaultHTTPTimeout)
+
+	baseTransport := client.Transport.(*http.BaseURLTransport)
+	baseTransport.Next = &apiTokenTransport{token: token, next: baseTransport.Next}
+
+	scope := b.scope.SubScope("changeprovider.phabricator")
+	return func(c changeprovider.Config) changeprovider.ChangeProvider {
+		return phabprovider.NewProvider(phabprovider.Params{
+			Config:       c,
+			HTTPClient:   client,
+			Logger:       b.logger.Sugar(),
+			MetricsScope: scope,
+		})
+	}, nil
+}
+
+// newBuildRunnerFactory builds the configured build runner's factory. The HTTP
+// client is built once here; only the per-queue runner is built per call.
+func (b *profileBuilder) newBuildRunnerFactory(cfg buildRunnerConfig, where string) (buildrunner.Factory, error) {
+	switch cfg.Type {
+	case buildRunnerTypeFake:
+		return buildRunnerFunc(func(c buildrunner.Config) (buildrunner.BuildRunner, error) {
+			return buildfake.New(c, b.resolver), nil
+		}), nil
+
+	case buildRunnerTypeGitHubActions:
+		token, ok := tokenFrom(cfg.TokenEnv)
+		if !ok {
+			return nil, fmt.Errorf("%s: githubactions build runner needs %s to be set", where, cfg.TokenEnv)
+		}
+		client, err := b.githubClient(cfg.BaseURL, cfg.Timeout, token, where)
+		if err != nil {
+			return nil, err
+		}
+		actions := platformgithubactions.NewClient(client, cfg.Owner, cfg.Repo, cfg.Workflow)
+		return buildRunnerFunc(func(c buildrunner.Config) (buildrunner.BuildRunner, error) {
+			return githubactionsrunner.NewBuildRunner(githubactionsrunner.Params{
+				Config:      c,
+				Client:      actions,
+				Resolver:    b.resolver,
+				Logger:      b.logger.Sugar(),
+				Ref:         cfg.Ref,
+				ExtraInputs: cfg.ExtraInputs,
+			}), nil
+		}), nil
+
+	case buildRunnerTypeBuildkite:
+		token, ok := tokenFrom(cfg.TokenEnv)
+		if !ok {
+			return nil, fmt.Errorf("%s: buildkite build runner needs %s to be set", where, cfg.TokenEnv)
+		}
+		client, err := http.NewClient(cfg.BaseURL)
+		if err != nil {
+			return nil, fmt.Errorf("%s: failed to build Buildkite HTTP client: %w", where, err)
+		}
+		client.Timeout = timeoutOr(cfg.Timeout, defaultHTTPTimeout)
+		client.Transport = &oauth2.Transport{
+			Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+			Base:   client.Transport,
+		}
+		bk := platformbuildkite.NewClient(client)
+		return buildRunnerFunc(func(c buildrunner.Config) (buildrunner.BuildRunner, error) {
+			return buildkiterunner.NewBuildRunner(buildkiterunner.Params{
+				Config:   c,
+				Client:   bk,
+				Resolver: b.resolver,
+				Logger:   b.logger.Sugar(),
+			}), nil
+		}), nil
+
+	default:
+		return nil, fmt.Errorf("%s: unknown build runner type %q", where, cfg.Type)
+	}
+}
+
+// newAnalyzerFactory builds the configured conflict analyzer's factory. The
+// type is validated here so an unusable config fails at wiring time rather than
+// on the first queue that resolves it.
+func (b *profileBuilder) newAnalyzerFactory(cfg analyzerConfig, where string) (conflict.Factory, error) {
+	switch cfg.Type {
+	case analyzerTypeAll, analyzerTypeNone, analyzerTypePathOverlap:
+	default:
+		return nil, fmt.Errorf("%s: unknown analyzer type %q", where, cfg.Type)
+	}
+
+	return analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
+		var delegate conflict.Analyzer
+		switch cfg.Type {
+		case analyzerTypeAll:
+			// Serializes the queue conservatively.
+			// TODO: replace with a real analyzer (e.g. Tango target analysis).
+			delegate = all.New(c)
+		case analyzerTypeNone:
+			delegate = none.New(c)
+		case analyzerTypePathOverlap:
+			// Serializes only batches whose changed paths collide at the
+			// configured granularity, resolving each batch's paths itself via
+			// the resolver.
+			return pathoverlap.New(c, b.resolver, pathOverlapKey(cfg.By)), nil
+		}
+
+		if cfg.FailAlways {
+			return conflictfake.New(c, delegate, conflictfake.FailAlways), nil
+		}
+		return conflictfake.New(c, delegate, nil), nil
+	}), nil
+}
+
+// pathOverlapKey maps the configured granularity onto the projection the
+// analyzer keys on. The value is validated when the config is loaded, so an
+// unrecognized one here would be a programming error; it falls back to the
+// narrowest granularity rather than widening a queue's conflicts silently.
+func pathOverlapKey(by string) pathoverlap.PathKey {
+	if by == pathOverlapByDirectory {
+		return pathoverlap.ByDirectory
+	}
+	return pathoverlap.ByFile
+}
+
+// githubClient builds an HTTP client rooted at a GitHub API and authenticated
+// with the given token. Shared by the change provider and the Actions runner,
+// which differ only in which endpoints they call.
+func (b *profileBuilder) githubClient(baseURL, timeout, token, where string) (*nethttp.Client, error) {
+	client, err := http.NewClient(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed to build GitHub HTTP client: %w", where, err)
+	}
+	client.Timeout = timeoutOr(timeout, defaultHTTPTimeout)
+	client.Transport = &oauth2.Transport{
+		Source: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+		Base:   client.Transport,
+	}
+	return client, nil
+}
+
+// apiTokenTransport injects a Phabricator API token as a query parameter in
+// each request.
+type apiTokenTransport struct {
+	token string
+	next  nethttp.RoundTripper
+}
+
+func (t *apiTokenTransport) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
+	r := req.Clone(req.Context())
+	q := r.URL.Query()
+	q.Set("api.token", t.token)
+	r.URL.RawQuery = q.Encode()
+	return t.next.RoundTrip(r)
 }


### PR DESCRIPTION
## Summary

### Why?

Which implementation of each extension a queue resolved to was hardcoded: the build runner was the fake one for every queue regardless of what was available, and the change provider was a global all-or-nothing environment gate. A deployment could not run one queue against a real provider next to one running entirely on fakes, which is what a stack serving both a test environment and a live repository needs.

### What?

`PROFILES_CONFIG_PATH` names a YAML file selecting the change provider, build runner, and conflict analyzer per queue. Each extension is independently optional, so a queue that differs only in its analyzer says only that. `kind` is an open string rather than a closed schema, so supporting a new provider is a new value and an implementation behind it, not a change to the file's shape.

The file holds no secret: each integration names the environment variable carrying its credential.

The `pathoverlap` analyzer takes a `by` granularity — `file`, or `directory` to coarsen a queue's conflicts to a shared parent. It defaults to `file`, the narrower of the two: a default that widened what conflicts would serialize a queue more than its configuration asked for.

With no config file the built-in example topology applies, reproducing the previous behavior exactly — including the per-queue analyzers the E2E suite depends on, and a routing change provider that still falls back to the fake when no token is set. That is what keeps the existing suite meaningful as a regression gate.

Extensions are reused across queues configured alike. This is load-bearing for the build runner: the build and buildsignal controllers look it up separately and the fake holds a build's outcome in memory, so two instances would lose the result between triggering a build and polling it.

## Test Plan

✅ `bazel test //service/submitqueue/orchestrator/server:go_default_test` — pins the built-in topology against what the E2E suite expects, covers per-extension inheritance, provider defaults, every validation rejection, that queues configured alike share one build runner, that each queue's analyzer behaves as configured, and that a missing token fails at startup rather than mid-merge.

✅ Added with the `by` granularity: it defaults to `file`, `directory` is accepted, and an unrecognized value is rejected at load rather than at the first queue that resolves it.



