### PR TITLE
test(e2e): hermetic end-to-end coverage of a real git merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,11 @@ clean-proto: ## Clean generated proto files
 deps: tidy-go ## Download and tidy Go dependencies
 	@echo "Dependencies installed!"
 
+e2e-git-test: ## Run the hermetic git E2E (real merger against a bare repo; no credentials)
+	@echo "Running hermetic git end-to-end tests..."
+	@$(BAZEL) test //test/e2e/submitqueue:go_default_test --test_output=errors \\
+		--test_filter='TestGitMergeE2E'
+
 e2e-test: ## Run end-to-end tests (hermetic; Bazel builds all inputs; runs in parallel)
 	@echo "Running end-to-end tests (parallel)..."
 	@$(BAZEL) test //test/e2e/... --test_output=errors
@@ -396,20 +401,16 @@ query-deps:
 query-targets:
 	@$(BAZEL) query //...
 
-# Run gateway client (connects to any running gateway service)
-run-client-submitqueue-gateway:
+run-client-submitqueue-gateway: ## Run the gateway client against a running gateway (SERVER_ADDR, MESSAGE)
 	@$(BAZEL) run //service/submitqueue/gateway/client:gateway -- -addr $(or $(SERVER_ADDR),localhost:8081) -message "$(or $(MESSAGE),ping)"
 
-# Run orchestrator client (connects to any running orchestrator service)
-run-client-submitqueue-orchestrator:
+run-client-submitqueue-orchestrator: ## Run the orchestrator client against a running orchestrator (SERVER_ADDR, MESSAGE)
 	@$(BAZEL) run //service/submitqueue/orchestrator/client:orchestrator -- -addr $(or $(SERVER_ADDR),localhost:8082) -message "$(or $(MESSAGE),ping)"
 
-# Run stovepipe client (connects to any running stovepipe service)
-run-client-stovepipe:
+run-client-stovepipe: ## Run the Stovepipe client against a running Stovepipe (SERVER_ADDR, MESSAGE)
 	@$(BAZEL) run //service/stovepipe/client:stovepipe -- -addr $(or $(SERVER_ADDR),localhost:8083) -message "$(or $(MESSAGE),ping)"
 
-# Run runway client (connects to any running runway service)
-run-client-runway:
+run-client-runway: ## Run the Runway client against a running Runway (SERVER_ADDR, MESSAGE)
 	@$(BAZEL) run //service/runway/client:runway -- -addr $(or $(SERVER_ADDR),localhost:8086) -message "$(or $(MESSAGE),ping)"
 
 run-queue-admin: ## Run queue-admin CLI (use ARGS to pass arguments, e.g. make run-queue-admin ARGS="list-topics")
@@ -436,4 +437,4 @@ tidy-go: ## Run go mod tidy
 help: ## Show this help message
 	@echo "Available targets:"
 	@echo ""
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/service/submitqueue/BUILD.bazel
+++ b/service/submitqueue/BUILD.bazel
@@ -1,4 +1,7 @@
 exports_files(
-    ["docker-compose.yml"],
+    [
+        "docker-compose.git.yml",
+        "docker-compose.yml",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/service/submitqueue/demo/provider/local/BUILD.bazel
+++ b/service/submitqueue/demo/provider/local/BUILD.bazel
@@ -1,0 +1,14 @@
+"""Demo provider configuration for a plain git remote (no provider).
+
+Consumed by the hermetic git E2E, which bind-mounts this directory into the
+orchestrator and runway containers.
+"""
+
+filegroup(
+    name = "config",
+    srcs = [
+        "merge.yaml",
+        "profiles.yaml",
+    ],
+    visibility = ["//test:__subpackages__"],
+)

--- a/service/submitqueue/demo/provider/local/merge.yaml
+++ b/service/submitqueue/demo/provider/local/merge.yaml
@@ -1,0 +1,32 @@
+# Merge targets for the "local" example: a plain git remote with no provider.
+#
+# This is what the hermetic git E2E (`make e2e-git-test`) runs against — a bare
+# repository on a shared volume, addressed by path. It exercises the whole merge
+# machinery (real fetch, cherry-pick, push, head-branch update) with no
+# credential, no network, and no provider account, which is what lets it gate PRs
+# in CI.
+#
+# It doubles as the worked example of a non-GitHub target: nothing below names a
+# provider, because the merger does not have one. See ../README.md.
+
+defaults:
+  # Any queue without an entry below does not merge for real.
+  merger: {type: noop}
+
+queues:
+  - name: e2e-git-queue
+    merger:
+      type: git
+      # A local path needs no credential, so no tokenEnv is named.
+      remoteUrl: file:///srv/git/sandbox.git
+      remote: origin
+      target: main
+      # Provisioned at startup: cloned, remote configured, target checked out.
+      checkoutPath: /var/runway/checkouts/sandbox
+      defaultStrategy: REBASE
+      checkStaleness: true
+      # Rewriting strategies leave the change's original head unreachable from
+      # the target, so its branch is moved to the commit it landed as. On a
+      # provider this is what makes the change show as merged; here it is simply
+      # observable as the branch having moved.
+      updateHeadBranch: true

--- a/service/submitqueue/demo/provider/local/profiles.yaml
+++ b/service/submitqueue/demo/provider/local/profiles.yaml
@@ -1,0 +1,20 @@
+# Extension profiles for the "local" example: a plain git remote with no provider.
+#
+# There is no provider to ask about a change, and no CI to run, so both edge
+# integrations stay fake. What this example exercises is the merge itself — see
+# merge.yaml.
+
+defaults:
+  # A local git remote has no API to fetch change metadata from; the fake
+  # echoes back each URI it is given.
+  changeProvider: {type: fake}
+  # Every build succeeds immediately, so a land completes in seconds.
+  buildRunner: {type: fake}
+  # Serialize conservatively unless a queue says otherwise.
+  analyzer: {type: all}
+
+queues:
+  - name: e2e-git-queue
+    # Maximum parallelism: batches never conflict, so the test controls
+    # ordering through what it lands rather than through the analyzer.
+    analyzer: {type: none}

--- a/service/submitqueue/docker-compose.git.yml
+++ b/service/submitqueue/docker-compose.git.yml
@@ -1,0 +1,45 @@
+# Compose overlay: point Runway at a real git merge target.
+#
+# Layered over docker-compose.yml, which it does not modify:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.git.yml up
+#
+# Used by the hermetic git E2E (`make e2e-git-test`), which merges it through
+# testutil.WithOverlay. Everything else about the stack — the services, their
+# databases, the consumer gate — comes from the base file, so a service added
+# there reaches this variant too.
+#
+# The merge target is a bare repository on a shared volume, addressed by path.
+# That exercises the whole merge path (git in the image, checkout provisioning,
+# real cherry-pick and push, head-branch updates) with no credential, no
+# network, and no account anywhere — which is what lets it gate a pull request.
+#
+# Required in the environment, all owned by the test:
+#   SQ_PROVIDER_CONFIG_DIR   profiles.yaml / merge.yaml selecting each queue's
+#                            extensions (service/submitqueue/demo/provider/local)
+#   SQ_GIT_SANDBOX_DIR       the bare repository the merger fetches and pushes
+#   SQ_RUNWAY_CHECKOUT_DIR   storage for the working trees the merger owns
+
+services:
+  orchestrator-service:
+    environment:
+      # Which change provider, build runner, and conflict analyzer each queue
+      # resolves to. Everything at the edges stays fake here; only the merge is
+      # real.
+      - PROFILES_CONFIG_PATH=/etc/submitqueue/profiles.yaml
+    volumes:
+      - ${SQ_PROVIDER_CONFIG_DIR}:/etc/submitqueue:ro
+
+  runway-service:
+    environment:
+      # Per-queue merge targets. Without this Runway falls back to the noop
+      # merger and nothing would actually be pushed.
+      - MERGE_CONFIG_PATH=/etc/submitqueue/merge.yaml
+    volumes:
+      - ${SQ_PROVIDER_CONFIG_DIR}:/etc/submitqueue:ro
+      - ${SQ_GIT_SANDBOX_DIR}:/srv/git
+      # A checkout is state, not image content, so it is mounted rather than
+      # baked in — and mounting it is also what makes the path writable by a
+      # service running as a non-root user, which the E2E does so its bind
+      # mounts stay readable from the host.
+      - ${SQ_RUNWAY_CHECKOUT_DIR}:/var/runway/checkouts

--- a/service/submitqueue/gateway/server/queues.yaml
+++ b/service/submitqueue/gateway/server/queues.yaml
@@ -11,3 +11,6 @@ queues:
   # exercise the conflict-analysis error path. See newQueueRegistry in the
   # orchestrator example server.
   - name: e2e-conflict-error-queue
+  # Used by the hermetic git E2E, where Runway is wired to a real git merger
+  # against a bare repository. See service/submitqueue/example/provider/local.
+  - name: e2e-git-queue

--- a/test/e2e/submitqueue/BUILD.bazel
+++ b/test/e2e/submitqueue/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = [
+        "git_suite_test.go",
         "harness_test.go",
         "suite_test.go",
     ],
@@ -10,11 +11,23 @@ go_test(
         "//platform/extension/counter/mysql/schema",
         "//platform/extension/messagequeue/mysql/schema",
         "//service/runway/server:docker_test_context",
+        "//service/submitqueue:docker-compose.git.yml",
         "//service/submitqueue:docker-compose.yml",
+        "//service/submitqueue/demo/provider/local:config",
         "//service/submitqueue/gateway/server:docker_test_context",
         "//service/submitqueue/orchestrator/server:docker_test_context",
         "//submitqueue/extension/storage/mysql/schema",
+        "@git",
+        "@git//:git_receive_pack",
+        "@git//:git_upload_archive",
+        "@git//:git_upload_pack",
+        "@git//:templates",
     ],
+    # The git suite drives the bare repository with the same pinned git the
+    # merger uses, rather than whatever the host has installed.
+    env = {
+        "SUBMITQUEUE_TEST_GIT": "$(location @git//:git)",
+    },
     tags = [
         "e2e",
         "integration",

--- a/test/e2e/submitqueue/git_suite_test.go
+++ b/test/e2e/submitqueue/git_suite_test.go
@@ -1,0 +1,467 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Hermetic end-to-end coverage of a *real* merge.
+//
+// The tier-1 suite (suite_test.go) runs Runway on the noop merger, so "landed"
+// there proves the pipeline's choreography and nothing about git. This suite
+// points Runway at a bare repository on a shared volume and asserts against the
+// repository itself: what reached the target branch, in what order, and in how
+// many ref updates.
+//
+// It needs no credential, no network, and no account anywhere, because none of
+// that is what the merge machinery depends on — which is what lets these
+// assertions gate a pull request. What it deliberately cannot cover is the half
+// that is specific to a change provider: reading change metadata, that
+// provider's CI, and a real change being marked merged. That is the manual
+// tier; see doc/howto/PROVIDER-E2E.md.
+package e2e_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	changepb "github.com/uber/submitqueue/api/base/change/protopb"
+	mergestrategypb "github.com/uber/submitqueue/api/base/mergestrategy/protopb"
+	gatewaypb "github.com/uber/submitqueue/api/submitqueue/gateway/protopb"
+	"github.com/uber/submitqueue/submitqueue/entity"
+	"github.com/uber/submitqueue/test/testutil"
+	"google.golang.org/grpc"
+)
+
+// gitQueue is the queue wired to the git merger in
+// service/submitqueue/demo/provider/local/merge.yaml.
+const gitQueue = "e2e-git-queue"
+
+// sandboxRemote is the host name used in git:// change URIs. The merger reads
+// the commit and ref out of the URI and reaches the repository through its own
+// configured remote, so this identifies the change rather than routing to it.
+const sandboxRemote = "git.example.com"
+
+type GitMergeSuite struct {
+	suite.Suite
+	ctx           context.Context
+	log           *testutil.TestLogger
+	stack         *testutil.ComposeStack
+	gatewayClient gatewaypb.SubmitQueueGatewayClient
+	db            *sql.DB
+	queueDB       *sql.DB
+
+	// git is the pinned git the test drives the bare repository with — the same
+	// build the merger uses inside the container.
+	git string
+	// bare is the host path of the repository Runway merges into.
+	bare string
+	// work is a clone the test authors changes in, standing in for a developer.
+	work string
+}
+
+func TestGitMergeE2E(t *testing.T) {
+	suite.Run(t, new(GitMergeSuite))
+}
+
+func (s *GitMergeSuite) SetupSuite() {
+	t := s.T()
+	s.ctx = context.Background()
+	s.log = testutil.NewTestLogger(t)
+
+	s.git = pinnedGit(t)
+	containerUser := dockerContainerUser(t)
+	t.Setenv("SQ_CONTAINER_USER", containerUser)
+	t.Setenv("SQ_CONSUMER_GATE_DIR", t.TempDir())
+
+	// The bare repository lives in a host directory bind-mounted into Runway, so
+	// the test can seed it and read back exactly what the merger pushed.
+	sandbox := t.TempDir()
+	s.bare = filepath.Join(sandbox, "sandbox.git")
+	s.work = filepath.Join(t.TempDir(), "work")
+	t.Setenv("SQ_GIT_SANDBOX_DIR", sandbox)
+	// Runway provisions its working trees here. Mounted rather than left to the
+	// image because the service runs as the host user (so its bind mounts stay
+	// readable from the host), which cannot create directories under /var.
+	t.Setenv("SQ_RUNWAY_CHECKOUT_DIR", t.TempDir())
+	s.seedRepository()
+
+	// The committed example configuration is what selects the git merger, so
+	// the suite runs the real file rather than generating one. Runfiles are
+	// symlinks into the execroot, which a container cannot follow through a
+	// bind mount, so the files are staged as real copies first.
+	t.Setenv("SQ_PROVIDER_CONFIG_DIR", s.stageProviderConfig())
+
+	// The base stack plus an overlay naming only what differs: Runway's merge
+	// target. Sharing the base file means a service added there reaches this
+	// suite too, which a copied compose file would silently miss.
+	composeFile := testutil.Runfile("service/submitqueue/docker-compose.yml")
+	s.stack = testutil.NewComposeStack(t, s.log, s.ctx, composeFile, "e2e-submitqueue-git",
+		testutil.WithOverlay(testutil.Runfile("service/submitqueue/docker-compose.git.yml")),
+		testutil.WithBuildContext(map[string]string{
+			".docker-bin/gateway":                                "service/submitqueue/gateway/server/gateway_linux",
+			".docker-bin/orchestrator":                           "service/submitqueue/orchestrator/server/orchestrator_linux",
+			".docker-bin/runway":                                 "service/runway/server/runway_linux",
+			"service/submitqueue/gateway/server/Dockerfile":      "service/submitqueue/gateway/server/Dockerfile",
+			"service/submitqueue/gateway/server/queues.yaml":     "service/submitqueue/gateway/server/queues.yaml",
+			"service/submitqueue/orchestrator/server/Dockerfile": "service/submitqueue/orchestrator/server/Dockerfile",
+			"service/runway/server/Dockerfile":                   "service/runway/server/Dockerfile",
+		}))
+
+	require.NoError(t, s.stack.Up(), "failed to start compose stack")
+
+	var err error
+	s.db, err = s.stack.ConnectMySQLService("mysql-app")
+	require.NoError(t, err)
+	s.queueDB, err = s.stack.ConnectMySQLService("mysql-queue")
+	require.NoError(t, err)
+
+	testutil.ApplySchema(t, s.log, s.db, testutil.SchemaDir("submitqueue/extension/storage/mysql/schema"))
+	testutil.ApplySchema(t, s.log, s.db, testutil.SchemaDir("platform/extension/counter/mysql/schema"))
+	testutil.ApplySchema(t, s.log, s.queueDB, testutil.SchemaDir("platform/extension/messagequeue/mysql/schema"))
+
+	var conn *grpc.ClientConn
+	conn, err = s.stack.ConnectGRPC("gateway-service", 8080)
+	require.NoError(t, err)
+	s.gatewayClient = gatewaypb.NewSubmitQueueGatewayClient(conn)
+
+	s.log.Logf("git merge E2E suite ready (bare repo at %s)", s.bare)
+}
+
+func (s *GitMergeSuite) TearDownSuite() {
+	if s.db != nil {
+		s.db.Close()
+	}
+	if s.queueDB != nil {
+		s.queueDB.Close()
+	}
+}
+
+// --- assertions against the repository itself ---
+
+func (s *GitMergeSuite) TestLand_SingleChange_ReachesTheTargetBranch() {
+	before := s.mainSHA()
+	head := s.pushChange("feature/single", map[string]string{"single.txt": "single\n"}, "add single")
+
+	sqid := s.land(gitQueue, s.uri("feature/single", head))
+	s.requireStatus(sqid, entity.RequestStatusLanded)
+
+	// The commit on the target is a *new* object: REBASE replays the change
+	// rather than moving the target to it.
+	s.NotEqual(before, s.mainSHA())
+	s.NotEqual(head, s.mainSHA())
+	s.Equal([]string{"add single"}, s.subjectsSince(before))
+	s.Equal("single\n", s.fileOnMain("single.txt"))
+}
+
+func (s *GitMergeSuite) TestLand_Stack_LandsInOrderInOneRefUpdate() {
+	// The property that distinguishes a submit queue from merging changes one
+	// at a time: a stack reaches the target as a single atomic ref update, so
+	// no reader ever observes it half-landed.
+	before := s.mainSHA()
+	updatesBefore := s.mainRefUpdateCount()
+
+	first := s.pushChange("feature/stack-1", map[string]string{"one.txt": "one\n"}, "add one")
+	second := s.pushChangeOnto(first, "feature/stack-2", map[string]string{"two.txt": "two\n"}, "add two")
+	third := s.pushChangeOnto(second, "feature/stack-3", map[string]string{"three.txt": "three\n"}, "add three")
+
+	sqid := s.land(gitQueue,
+		s.uri("feature/stack-1", first),
+		s.uri("feature/stack-2", second),
+		s.uri("feature/stack-3", third),
+	)
+	s.requireStatus(sqid, entity.RequestStatusLanded)
+
+	s.Equal([]string{"add one", "add two", "add three"}, s.subjectsSince(before),
+		"the stack must land in the order it was submitted")
+	s.Equal(1, s.mainRefUpdateCount()-updatesBefore,
+		"the whole stack must reach the target in exactly one ref update")
+}
+
+func (s *GitMergeSuite) TestLand_MovesEachChangeHeadBranchToItsLandedCommit() {
+	// What makes a provider mark a rebased change merged: its head branch is moved
+	// to the commit the change became, so the head is reachable from the target.
+	before := s.mainSHA()
+	first := s.pushChange("feature/head-1", map[string]string{"h1.txt": "h1\n"}, "add h1")
+	second := s.pushChange("feature/head-2", map[string]string{"h2.txt": "h2\n"}, "add h2")
+
+	sqid := s.land(gitQueue, s.uri("feature/head-1", first), s.uri("feature/head-2", second))
+	s.requireStatus(sqid, entity.RequestStatusLanded)
+
+	landed := s.shasSince(before)
+	s.Require().Len(landed, 2)
+
+	// Each change gets its own landed commit, not the final tip.
+	s.Equal(landed[0], s.branchSHA("feature/head-1"))
+	s.Equal(landed[1], s.branchSHA("feature/head-2"))
+	s.NotEqual(s.branchSHA("feature/head-1"), s.branchSHA("feature/head-2"))
+
+	// Reachability is the property a provider actually reads.
+	s.True(s.isAncestorOfMain(s.branchSHA("feature/head-1")))
+	s.True(s.isAncestorOfMain(s.branchSHA("feature/head-2")))
+}
+
+func (s *GitMergeSuite) TestLand_Conflict_FailsAndLeavesTheTargetUntouched() {
+	// Two changes editing the same line from the same base: the first lands,
+	// the second cannot be replayed onto it.
+	base := s.mainSHA()
+	winner := s.pushChangeOnto(base, "feature/conflict-a", map[string]string{"contested.txt": "alpha\n"}, "contest alpha")
+	loser := s.pushChangeOnto(base, "feature/conflict-b", map[string]string{"contested.txt": "beta\n"}, "contest beta")
+
+	s.requireStatus(s.land(gitQueue, s.uri("feature/conflict-a", winner)), entity.RequestStatusLanded)
+	afterWinner := s.mainSHA()
+
+	s.requireStatus(s.land(gitQueue, s.uri("feature/conflict-b", loser)), entity.RequestStatusError)
+	s.Equal(afterWinner, s.mainSHA(), "a conflicting change must not move the target")
+	s.Equal("alpha\n", s.fileOnMain("contested.txt"))
+
+	// The change is left exactly as its author pushed it.
+	s.Equal(loser, s.branchSHA("feature/conflict-b"))
+}
+
+func (s *GitMergeSuite) TestLand_ResubmittedAfterLanding_IsRejectedAsStale() {
+	// Landing a change moves its head branch to the commit it became, so the
+	// URI that was submitted no longer describes where that branch points. The
+	// staleness check catches exactly that, which is what stops a change from
+	// being replayed onto the target a second time.
+	head := s.pushChange("feature/already", map[string]string{"already.txt": "already\n"}, "add already")
+	s.requireStatus(s.land(gitQueue, s.uri("feature/already", head)), entity.RequestStatusLanded)
+
+	settled := s.mainSHA()
+	updates := s.mainRefUpdateCount()
+	landedAs := s.branchSHA("feature/already")
+	s.NotEqual(head, landedAs, "the head branch moved to the landed commit")
+
+	s.requireStatus(s.land(gitQueue, s.uri("feature/already", head)), entity.RequestStatusError)
+	s.Equal(settled, s.mainSHA(), "a stale resubmission must not move the target")
+	s.Equal(updates, s.mainRefUpdateCount(), "and must not push at all")
+	s.Equal(landedAs, s.branchSHA("feature/already"), "nor disturb the change's branch")
+}
+
+// --- gateway helpers ---
+
+// land submits a request and returns its sqid. Repeated URIs are the stack, in
+// the order they must be applied.
+func (s *GitMergeSuite) land(queue string, uris ...string) string {
+	resp, err := s.gatewayClient.Land(s.ctx, &gatewaypb.LandRequest{
+		Queue:    queue,
+		Change:   &changepb.Change{Uris: uris},
+		Strategy: mergestrategypb.Strategy_REBASE,
+	})
+	s.Require().NoError(err, "Land failed for queue %s", queue)
+	s.Require().NotEmpty(resp.Sqid)
+	return resp.Sqid
+}
+
+// requireStatus waits for the request to reach a terminal status and asserts
+// which one. Bazel's test timeout is the only deadline.
+func (s *GitMergeSuite) requireStatus(sqid string, want entity.RequestStatus) {
+	var got entity.RequestStatus
+	pollUntil(persistPollInterval, func() bool {
+		resp, err := s.gatewayClient.GetRequestSummaryByID(s.ctx, &gatewaypb.GetRequestSummaryByIDRequest{Sqid: sqid, Queue: gitQueue})
+		if err != nil || resp.Request == nil {
+			return false
+		}
+		got = entity.RequestStatus(resp.Request.Status)
+		s.log.Logf("request %s status=%q (awaiting terminal)", sqid, got)
+		return isTerminalStatus(got)
+	})
+	s.Require().Equal(want, got, "request %s reached the wrong terminal status", sqid)
+}
+
+// uri builds the git:// change URI for a branch pinned at a commit. The ref is
+// percent-encoded so a branch name containing slashes stays one path segment.
+func (s *GitMergeSuite) uri(branch, sha string) string {
+	ref := "refs/heads/" + branch
+	return fmt.Sprintf("git://%s/sandbox/%s/%s", sandboxRemote, url.PathEscape(ref), sha)
+}
+
+// --- repository helpers ---
+
+// stageProviderConfig copies the committed example configuration into a directory
+// the containers can bind-mount, and returns its path.
+func (s *GitMergeSuite) stageProviderConfig() string {
+	t := s.T()
+	staged := t.TempDir()
+	for _, name := range []string{"merge.yaml", "profiles.yaml"} {
+		contents, err := os.ReadFile(testutil.Runfile("service/submitqueue/demo/provider/local/" + name))
+		require.NoError(t, err, "reading example config %s", name)
+		require.NoError(t, os.WriteFile(filepath.Join(staged, name), contents, 0o644))
+	}
+	return staged
+}
+
+// pinnedGit resolves the git build the test target supplies, rather than
+// whatever git the host has. The assertions here depend on repository
+// mechanics, and an ambient git brings ambient configuration — hooks, signing,
+// templates — with it.
+//
+// rules_go expands $(location) to an execroot-relative path, which for an
+// external output has to be re-rooted under the runfiles directory the test
+// runs from.
+func pinnedGit(t *testing.T) string {
+	t.Helper()
+	path := os.Getenv("SUBMITQUEUE_TEST_GIT")
+	require.NotEmpty(t, path, "SUBMITQUEUE_TEST_GIT must be set by the test target")
+
+	if absolute, err := filepath.Abs(path); err == nil {
+		if _, err := os.Stat(absolute); err == nil {
+			return absolute
+		}
+	}
+
+	slashed := filepath.ToSlash(path)
+	external := ""
+	if strings.HasPrefix(slashed, "external/") {
+		external = strings.TrimPrefix(slashed, "external/")
+	} else if i := strings.Index(slashed, "/external/"); i >= 0 {
+		external = slashed[i+len("/external/"):]
+	}
+	require.NotEmpty(t, external, "SUBMITQUEUE_TEST_GIT=%q is not a runfile", path)
+
+	root := os.Getenv("TEST_SRCDIR")
+	require.NotEmpty(t, root)
+	candidate := filepath.Join(root, filepath.FromSlash(external))
+	_, err := os.Stat(candidate)
+	require.NoError(t, err)
+	return candidate
+}
+
+// seedRepository creates the bare repository Runway merges into, plus a working
+// clone the test authors changes in.
+func (s *GitMergeSuite) seedRepository() {
+	t := s.T()
+	s.runGit(filepath.Dir(s.bare), "init", "--bare", "-b", "main", s.bare)
+	// Bare repositories do not log ref updates by default, and the reflog is
+	// how this suite counts pushes to prove a stack lands atomically.
+	s.runGit(s.bare, "config", "core.logAllRefUpdates", "true")
+
+	s.runGit(filepath.Dir(s.work), "clone", s.bare, s.work)
+	s.configureWorkClone()
+
+	require.NoError(t, os.WriteFile(filepath.Join(s.work, "seed.txt"), []byte("seed\n"), 0o644))
+	s.runGit(s.work, "add", ".")
+	s.runGit(s.work, "commit", "-m", "seed")
+	s.runGit(s.work, "push", "origin", "main")
+}
+
+func (s *GitMergeSuite) configureWorkClone() {
+	for _, kv := range [][2]string{
+		{"user.name", "E2E Author"},
+		{"user.email", "author@example.com"},
+		{"commit.gpgsign", "false"},
+	} {
+		s.runGit(s.work, "config", kv[0], kv[1])
+	}
+	// Neutralize any system-installed hooks that would reject test commits.
+	hooks := filepath.Join(s.work, ".no-hooks")
+	require.NoError(s.T(), os.MkdirAll(hooks, 0o755))
+	s.runGit(s.work, "config", "core.hooksPath", hooks)
+}
+
+// pushChange authors a change branched off the current target tip and pushes
+// it, returning its head SHA — all a change URI ever carries.
+func (s *GitMergeSuite) pushChange(branch string, files map[string]string, message string) string {
+	return s.pushChangeOnto("origin/main", branch, files, message)
+}
+
+// pushChangeOnto is pushChange based at an explicit start point, for building a
+// change that stacks on another rather than on the target.
+func (s *GitMergeSuite) pushChangeOnto(base, branch string, files map[string]string, message string) string {
+	s.runGit(s.work, "fetch", "origin")
+	s.runGit(s.work, "checkout", "-B", branch, base)
+	for path, contents := range files {
+		require.NoError(s.T(), os.WriteFile(filepath.Join(s.work, path), []byte(contents), 0o644))
+	}
+	s.runGit(s.work, "add", ".")
+	s.runGit(s.work, "commit", "-m", message)
+	s.runGit(s.work, "push", "-f", "origin", branch)
+	return s.runGit(s.work, "rev-parse", "HEAD")
+}
+
+// mainSHA is the current tip of the target branch on the bare repository.
+func (s *GitMergeSuite) mainSHA() string {
+	return s.runGit(s.bare, "rev-parse", "refs/heads/main")
+}
+
+// branchSHA is the current tip of a change's head branch.
+func (s *GitMergeSuite) branchSHA(branch string) string {
+	return s.runGit(s.bare, "rev-parse", "refs/heads/"+branch)
+}
+
+// shasSince lists the commits added to the target since a known point, oldest
+// first.
+func (s *GitMergeSuite) shasSince(since string) []string {
+	out := s.runGit(s.bare, "rev-list", "--reverse", since+"..refs/heads/main")
+	return strings.Fields(out)
+}
+
+// subjectsSince lists the messages of the commits added to the target since a
+// known point, oldest first — the readable form of what landed and in what
+// order.
+func (s *GitMergeSuite) subjectsSince(since string) []string {
+	out := s.runGit(s.bare, "log", "--reverse", "--format=%s", since+"..refs/heads/main")
+	var subjects []string
+	for _, line := range strings.Split(out, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			subjects = append(subjects, trimmed)
+		}
+	}
+	return subjects
+}
+
+// fileOnMain reads a file's contents at the target tip.
+func (s *GitMergeSuite) fileOnMain(path string) string {
+	return s.runGit(s.bare, "show", "refs/heads/main:"+path) + "\n"
+}
+
+// isAncestorOfMain reports whether a commit is reachable from the target — the
+// property a provider reads to decide a change has merged.
+func (s *GitMergeSuite) isAncestorOfMain(sha string) bool {
+	cmd := exec.Command(s.git, "merge-base", "--is-ancestor", sha, "refs/heads/main")
+	cmd.Dir = s.bare
+	return cmd.Run() == nil
+}
+
+// mainRefUpdateCount is how many times the target branch has been updated,
+// read from the bare repository's reflog. One land must cost exactly one,
+// however many changes it carried.
+func (s *GitMergeSuite) mainRefUpdateCount() int {
+	out := s.runGit(s.bare, "reflog", "show", "--format=%H", "refs/heads/main")
+	count := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// runGit runs the pinned git and returns its trimmed stdout, failing the test
+// on a non-zero exit.
+func (s *GitMergeSuite) runGit(dir string, args ...string) string {
+	s.T().Helper()
+	cmd := exec.Command(s.git, args...)
+	cmd.Dir = dir
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	require.NoError(s.T(), err, "git %s in %s: %s", strings.Join(args, " "), dir, stderr.String())
+	return strings.TrimSpace(string(out))
+}

--- a/test/testutil/compose.go
+++ b/test/testutil/compose.go
@@ -38,14 +38,33 @@ import (
 
 // ComposeStack manages a docker-compose stack for testing.
 type ComposeStack struct {
-	composeFile string
-	projectName string
-	t           *testing.T
-	log         *TestLogger
-	ctx         context.Context
-	composeCmd  []string  // docker-compose command (either ["docker-compose"] or ["docker", "compose"])
-	composeEnv  []string  // environment shared by compose commands
-	logCmd      *exec.Cmd // background "docker compose logs -f" process
+	composeFiles []string
+	projectName  string
+	t            *testing.T
+	log          *TestLogger
+	ctx          context.Context
+	composeCmd   []string  // docker-compose command (either ["docker-compose"] or ["docker", "compose"])
+	composeEnv   []string  // environment shared by compose commands
+	logCmd       *exec.Cmd // background "docker compose logs -f" process
+}
+
+// fileArgs returns the "-f <path>" pairs naming this stack's compose files, in
+// the order compose must merge them.
+func (s *ComposeStack) fileArgs() []string {
+	args := make([]string, 0, len(s.composeFiles)*2)
+	for _, f := range s.composeFiles {
+		args = append(args, "-f", f)
+	}
+	return args
+}
+
+// command builds a compose invocation for this stack, with the compose files
+// and project name already applied.
+func (s *ComposeStack) command(args ...string) []string {
+	full := append([]string{}, s.composeCmd[1:]...)
+	full = append(full, s.fileArgs()...)
+	full = append(full, "-p", s.projectName)
+	return append(full, args...)
 }
 
 // getDockerComposeCommand returns the docker compose command to use.
@@ -68,6 +87,8 @@ type composeOptions struct {
 	// buildContextFiles maps a path inside the synthesized docker build
 	// context to the workspace-relative runfile it is staged from.
 	buildContextFiles map[string]string
+	// overlays are additional compose files merged over the base one, in order.
+	overlays []string
 }
 
 // WithBuildContext stages the given files into a synthesized docker build
@@ -81,6 +102,22 @@ type composeOptions struct {
 func WithBuildContext(files map[string]string) ComposeOption {
 	return func(o *composeOptions) {
 		o.buildContextFiles = files
+	}
+}
+
+// WithOverlay merges additional compose files over the base one, in the order
+// given, exactly as `docker compose -f base.yml -f overlay.yml` does.
+//
+// It exists so a variant stack can state only what differs from the base —
+// a couple of environment variables and volumes — instead of copying the whole
+// service definition. A copy is the thing that rots: services added to the base
+// file never reach the duplicate, and nothing fails until the variant is run.
+//
+// Each overlay must be declared as a `data` dependency of the test target, and
+// each participates in the input hash alongside the base file.
+func WithOverlay(paths ...string) ComposeOption {
+	return func(o *composeOptions) {
+		o.overlays = append(o.overlays, paths...)
 	}
 }
 
@@ -98,15 +135,17 @@ func NewComposeStack(t *testing.T, log *TestLogger, ctx context.Context, compose
 	// Setup Docker environment
 	setupDockerEnv(t)
 
-	// Get absolute path to compose file
-	absPath, err := filepath.Abs(composeFile)
-	require.NoError(t, err, "failed to get absolute path to compose file")
-
 	// The image prefix is derived from the content of the declared inputs, so
-	// the compose file participates in the hash alongside the staged build
+	// every compose file participates in the hash alongside the staged build
 	// context files.
 	inputHash := sha256.New()
-	hashFile(t, inputHash, composeFile, absPath)
+	composeFiles := make([]string, 0, 1+len(options.overlays))
+	for _, file := range append([]string{composeFile}, options.overlays...) {
+		absPath, err := filepath.Abs(file)
+		require.NoError(t, err, "failed to get absolute path to compose file %s", file)
+		hashFile(t, inputHash, file, absPath)
+		composeFiles = append(composeFiles, absPath)
+	}
 
 	buildContextDir := ""
 	if len(options.buildContextFiles) > 0 {
@@ -119,13 +158,13 @@ func NewComposeStack(t *testing.T, log *TestLogger, ctx context.Context, compose
 	projectName := fmt.Sprintf("sq-test-%s-%s", testContext, timestamp)
 
 	stack := &ComposeStack{
-		composeFile: absPath,
-		projectName: projectName,
-		t:           t,
-		log:         log,
-		ctx:         ctx,
-		composeCmd:  getDockerComposeCommand(),
-		composeEnv:  composeEnvironment(inputHash.Sum(nil), buildContextDir),
+		composeFiles: composeFiles,
+		projectName:  projectName,
+		t:            t,
+		log:          log,
+		ctx:          ctx,
+		composeCmd:   getDockerComposeCommand(),
+		composeEnv:   composeEnvironment(inputHash.Sum(nil), buildContextDir),
 	}
 
 	// Register cleanup
@@ -136,7 +175,8 @@ func NewComposeStack(t *testing.T, log *TestLogger, ctx context.Context, compose
 			log.Logf("SKIP_CLEANUP=true - keeping containers for inspection")
 			log.Logf("Container prefix: %s", projectName)
 			composeCmd := strings.Join(stack.composeCmd, " ")
-			log.Logf("Clean up manually: %s -f %s -p %s down -v", composeCmd, absPath, projectName)
+			log.Logf("Clean up manually: %s %s -p %s down -v",
+				composeCmd, strings.Join(stack.fileArgs(), " "), projectName)
 			return
 		}
 
@@ -151,9 +191,9 @@ func NewComposeStack(t *testing.T, log *TestLogger, ctx context.Context, compose
 // Uses --wait to block until all services with healthcheck directives are healthy.
 func (s *ComposeStack) Up() error {
 	s.t.Helper()
-	s.log.Logf("Starting compose stack from %s", s.composeFile)
+	s.log.Logf("Starting compose stack from %s", strings.Join(s.composeFiles, " + "))
 
-	args := append(s.composeCmd[1:], "-f", s.composeFile, "-p", s.projectName, "up", "-d", "--build", "--wait")
+	args := s.command("up", "-d", "--build", "--wait")
 	cmd := exec.CommandContext(s.ctx, s.composeCmd[0], args...)
 	cmd.Env = s.composeEnv
 	cmd.Stdout = os.Stdout
@@ -174,7 +214,7 @@ func (s *ComposeStack) Up() error {
 func (s *ComposeStack) down() {
 	s.log.Logf("Stopping compose stack")
 
-	args := append(s.composeCmd[1:], "-f", s.composeFile, "-p", s.projectName, "down", "-v")
+	args := s.command("down", "-v")
 	cmd := exec.CommandContext(s.ctx, s.composeCmd[0], args...)
 	cmd.Env = s.composeEnv
 	cmd.Stdout = os.Stdout
@@ -189,7 +229,7 @@ func (s *ComposeStack) down() {
 // container logs to stderr in real time. Using os.Stderr instead of t.Log()
 // because t.Log() buffers output until the test finishes.
 func (s *ComposeStack) tailLogs() {
-	args := append(s.composeCmd[1:], "-f", s.composeFile, "-p", s.projectName, "logs", "-f")
+	args := s.command("logs", "-f")
 	cmd := exec.Command(s.composeCmd[0], args...)
 	cmd.Env = s.composeEnv
 	cmd.Stdout = os.Stderr
@@ -214,7 +254,7 @@ func (s *ComposeStack) stopLogs() {
 func (s *ComposeStack) ServicePort(serviceName string, containerPort int) (int, error) {
 	s.t.Helper()
 
-	args := append(s.composeCmd[1:], "-f", s.composeFile, "-p", s.projectName, "port", serviceName, fmt.Sprintf("%d", containerPort))
+	args := s.command("port", serviceName, fmt.Sprintf("%d", containerPort))
 	cmd := exec.CommandContext(s.ctx, s.composeCmd[0], args...)
 	cmd.Env = s.composeEnv
 
@@ -342,7 +382,7 @@ func (s *ComposeStack) StopService(serviceName string, timeoutSec int) error {
 
 	s.log.Logf("Stopping service %s (timeout %ds)", serviceName, timeoutSec)
 
-	args := append(s.composeCmd[1:], "-f", s.composeFile, "-p", s.projectName,
+	args := s.command(
 		"stop", "-t", fmt.Sprintf("%d", timeoutSec), serviceName)
 	cmd := exec.CommandContext(s.ctx, s.composeCmd[0], args...)
 	cmd.Env = s.composeEnv
@@ -363,7 +403,7 @@ func (s *ComposeStack) ServiceExitCode(serviceName string) (int, error) {
 	s.t.Helper()
 
 	// Get container ID for the service
-	args := append(s.composeCmd[1:], "-f", s.composeFile, "-p", s.projectName,
+	args := s.command(
 		"ps", "-a", "-q", serviceName)
 	cmd := exec.CommandContext(s.ctx, s.composeCmd[0], args...)
 	cmd.Env = s.composeEnv


### PR DESCRIPTION
## Summary
### Why?

The existing E2E suite runs Runway on the noop merger, so a request reaching `landed` proves the pipeline's choreography and nothing at all about git. Every risky part of merging for real — the `git` binary in the image, checkout provisioning, the apply and push, head-branch updates — had no automated coverage through the stack.

None of that needs a provider. The merger speaks `git://` against any remote, so pointing it at a bare repository on a shared volume exercises the whole merge path with no credential, no network, and no account anywhere — which is what lets these assertions gate a pull request.

### What?

A second suite lands `git://` changes and asserts against the repository itself rather than against request status: which commits reached the target, in what order, and in how many ref updates. A three-change stack must arrive in exactly **one** ref update, counted from the target's reflog — the property that distinguishes a submit queue from merging changes one at a time, and one that is hard to check against a live provider.

It also pins two behaviors worth not regressing: a conflicting change leaves the target untouched, and re-submitting a change after it has landed is rejected as stale (landing moved its head branch, so the URI no longer describes where that branch points).

`testutil.NewComposeStack` gained `WithOverlay`, so the suite states only what differs from the base stack — Runway's merge target — instead of copying the whole service definition. A copy is the thing that rots: services added to the base file never reach the duplicate, and nothing fails until the variant runs.

The suite drives the bare repository with the same pinned git the merger uses, rather than the host's, since these assertions depend on repository mechanics and an ambient git brings ambient configuration with it.

## Test Plan
✅ `make e2e-git-test` — the new suite.

✅ `make e2e-test` — both suites; the existing one is unchanged and still passes.

Also fixes `make help`, whose target regex excluded digits, so neither `e2e-test` nor `e2e-git-test` was ever listed.

## Issues

