### PR TITLE
fix(extension): forward the per-queue Config down to every impl

### DIFF
--- a/runway/extension/merger/fake/fake.go
+++ b/runway/extension/merger/fake/fake.go
@@ -51,12 +51,21 @@ var _ merger.Merger = (*Merger)(nil)
 // Merger is a Merger that succeeds unless a marker token in a change URI
 // requests otherwise.
 type Merger struct {
-	seq atomic.Uint64
+	// cfg is the per-queue identity this merger was built for.
+	cfg merger.Config
+	// seq mints the synthetic revision ids returned by Merge. It is supplied by
+	// the caller so a factory that builds one Merger per queue can still hand
+	// out ids that are unique across every queue in the process.
+	seq *atomic.Uint64
 }
 
-// New returns a Merger that defaults to success and honors marker tokens
-// embedded in change URIs.
-func New() *Merger { return &Merger{} }
+// New returns a Merger bound to the queue named in cfg that defaults to success
+// and honors marker tokens embedded in change URIs. seq must be non-nil and is
+// shared, not owned: callers minting ids from more than one Merger must pass the
+// same counter to each.
+func New(cfg merger.Config, seq *atomic.Uint64) *Merger {
+	return &Merger{cfg: cfg, seq: seq}
+}
 
 // CheckMergeability reports the request as mergeable unless a recognized marker
 // token asks for a failure. Outputs are empty, as for any dry run.

--- a/runway/extension/merger/fake/fake_test.go
+++ b/runway/extension/merger/fake/fake_test.go
@@ -16,6 +16,7 @@ package fake
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,9 @@ import (
 	runwaypb "github.com/uber/submitqueue/api/runway/messagequeue/protopb"
 	"github.com/uber/submitqueue/runway/extension/merger"
 )
+
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = merger.Config{QueueName: "test-queue"}
 
 const baseURI = "github://github.example.com/uber/repo/pull/1/abcdef0123456789abcdef0123456789abcdef01"
 
@@ -54,7 +58,7 @@ func TestUnmarkedRequestSucceeds(t *testing.T) {
 	req := requestWith(baseURI)
 
 	t.Run("check mergeability reports no outputs", func(t *testing.T) {
-		res, err := New().CheckMergeability(context.Background(), req)
+		res, err := New(testCfg, new(atomic.Uint64)).CheckMergeability(context.Background(), req)
 		require.NoError(t, err)
 
 		assert.Equal(t, req.GetId(), res.GetId())
@@ -67,7 +71,7 @@ func TestUnmarkedRequestSucceeds(t *testing.T) {
 	})
 
 	t.Run("merge reports one output per step", func(t *testing.T) {
-		res, err := New().Merge(context.Background(), req)
+		res, err := New(testCfg, new(atomic.Uint64)).Merge(context.Background(), req)
 		require.NoError(t, err)
 
 		assert.Equal(t, req.GetId(), res.GetId())
@@ -102,10 +106,10 @@ func TestMarkedRequestFails(t *testing.T) {
 				fn   func(*runwaymq.MergeRequest) (*runwaymq.MergeResult, error)
 			}{
 				{"CheckMergeability", func(r *runwaymq.MergeRequest) (*runwaymq.MergeResult, error) {
-					return New().CheckMergeability(context.Background(), r)
+					return New(testCfg, new(atomic.Uint64)).CheckMergeability(context.Background(), r)
 				}},
 				{"Merge", func(r *runwaymq.MergeRequest) (*runwaymq.MergeResult, error) {
-					return New().Merge(context.Background(), r)
+					return New(testCfg, new(atomic.Uint64)).Merge(context.Background(), r)
 				}},
 			} {
 				t.Run(call.name, func(t *testing.T) {
@@ -129,7 +133,7 @@ func TestMarkedRequestFails(t *testing.T) {
 func TestUnrecognizedTokenSucceeds(t *testing.T) {
 	req := requestWith(baseURI + "?sq-fake=some-other-fakes-token")
 
-	res, err := New().Merge(context.Background(), req)
+	res, err := New(testCfg, new(atomic.Uint64)).Merge(context.Background(), req)
 	require.NoError(t, err)
 	assert.Equal(t, runwaypb.Outcome_SUCCEEDED, res.GetOutcome())
 }
@@ -144,7 +148,7 @@ func TestFirstRecognizedTokenWins(t *testing.T) {
 		},
 	}
 
-	_, err := New().Merge(context.Background(), req)
+	_, err := New(testCfg, new(atomic.Uint64)).Merge(context.Background(), req)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, merger.ErrConflict)
 	assert.NotErrorIs(t, err, merger.ErrInvalidRequest)

--- a/runway/extension/merger/noop/BUILD.bazel
+++ b/runway/extension/merger/noop/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "//api/base/mergestrategy/protopb:go_default_library",
         "//api/runway/messagequeue:go_default_library",
         "//api/runway/messagequeue/protopb:go_default_library",
+        "//runway/extension/merger:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/runway/extension/merger/noop/noop.go
+++ b/runway/extension/merger/noop/noop.go
@@ -31,11 +31,20 @@ var _ merger.Merger = (*Merger)(nil)
 
 // Merger is a no-op implementation that always succeeds.
 type Merger struct {
-	seq atomic.Uint64
+	// cfg is the per-queue identity this merger was built for.
+	cfg merger.Config
+	// seq mints the synthetic revision ids returned by Merge. It is supplied by
+	// the caller so a factory that builds one Merger per queue can still hand
+	// out ids that are unique across every queue in the process.
+	seq *atomic.Uint64
 }
 
-// New returns a new no-op Merger instance.
-func New() *Merger { return &Merger{} }
+// New returns a no-op Merger bound to the queue named in cfg. seq must be
+// non-nil and is shared, not owned: callers minting ids from more than one
+// Merger must pass the same counter to each.
+func New(cfg merger.Config, seq *atomic.Uint64) *Merger {
+	return &Merger{cfg: cfg, seq: seq}
+}
 
 func (v *Merger) CheckMergeability(_ context.Context, req *runwaymq.MergeRequest) (*runwaymq.MergeResult, error) {
 	steps := make([]*runwaymq.StepResult, len(req.GetSteps()))

--- a/runway/extension/merger/noop/noop_test.go
+++ b/runway/extension/merger/noop/noop_test.go
@@ -16,7 +16,10 @@ package noop
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+
+	"github.com/uber/submitqueue/runway/extension/merger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +28,9 @@ import (
 	runwaymq "github.com/uber/submitqueue/api/runway/messagequeue"
 	runwaypb "github.com/uber/submitqueue/api/runway/messagequeue/protopb"
 )
+
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = merger.Config{QueueName: "test-queue"}
 
 func testRequest() *runwaymq.MergeRequest {
 	return &runwaymq.MergeRequest{
@@ -46,7 +52,7 @@ func testRequest() *runwaymq.MergeRequest {
 }
 
 func TestCheckMergeability(t *testing.T) {
-	v := New()
+	v := New(testCfg, new(atomic.Uint64))
 	req := testRequest()
 
 	res, err := v.CheckMergeability(context.Background(), req)
@@ -62,7 +68,7 @@ func TestCheckMergeability(t *testing.T) {
 }
 
 func TestMerge(t *testing.T) {
-	v := New()
+	v := New(testCfg, new(atomic.Uint64))
 	req := testRequest()
 
 	res, err := v.Merge(context.Background(), req)
@@ -80,7 +86,7 @@ func TestMerge(t *testing.T) {
 }
 
 func TestMerge_UniqueOutputIDs(t *testing.T) {
-	v := New()
+	v := New(testCfg, new(atomic.Uint64))
 	req := testRequest()
 
 	res1, err := v.Merge(context.Background(), req)

--- a/service/runway/server/main.go
+++ b/service/runway/server/main.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -314,10 +315,10 @@ func newMergerFactory(logger *zap.Logger, scope tally.Scope) (merger.Factory, er
 		// Marker-driven outcomes, for e2e tests that need Runway to fail on
 		// demand without a git checkout. Never production.
 		logger.Info("MERGER=fake; using marker-driven fake merger")
-		return &fakeMergerFactory{merger: fake.New()}, nil
+		return &fakeMergerFactory{seq: new(atomic.Uint64)}, nil
 	case "noop":
 		logger.Info("MERGER=noop; using noop merger")
-		return &noopMergerFactory{}, nil
+		return &noopMergerFactory{seq: new(atomic.Uint64)}, nil
 	case "", "git":
 		// Fall through to the merge-environment default below.
 	default:
@@ -327,7 +328,7 @@ func newMergerFactory(logger *zap.Logger, scope tally.Scope) (merger.Factory, er
 	checkoutPath := os.Getenv("MERGE_CHECKOUT_PATH")
 	if checkoutPath == "" {
 		logger.Info("MERGE_CHECKOUT_PATH not set; using noop merger")
-		return &noopMergerFactory{}, nil
+		return &noopMergerFactory{seq: new(atomic.Uint64)}, nil
 	}
 
 	defaultStrategy, err := parseStrategy(os.Getenv("MERGE_DEFAULT_STRATEGY"))
@@ -370,7 +371,8 @@ func newMergerFactory(logger *zap.Logger, scope tally.Scope) (merger.Factory, er
 
 // gitMergerFactory returns a single git-backed merger for every queue. The
 // merger owns one checkout and serializes its own operations, so one instance
-// is shared across queues. A deployment that lands multiple targets wires a
+// is shared across queues — which is why this is the one merger factory that
+// does not forward its Config. A deployment that lands multiple targets wires a
 // factory with a per-queue map instead.
 type gitMergerFactory struct {
 	merger merger.Merger
@@ -380,20 +382,26 @@ func (f *gitMergerFactory) For(_ merger.Config) (merger.Merger, error) {
 	return f.merger, nil
 }
 
-type noopMergerFactory struct{}
-
-func (f *noopMergerFactory) For(_ merger.Config) (merger.Merger, error) {
-	return noop.New(), nil
+// noopMergerFactory builds a noop merger per queue, bound to that queue's
+// config. The synthetic revision-id counter is held here rather than on the
+// merger so ids stay unique across every queue in the process.
+type noopMergerFactory struct {
+	seq *atomic.Uint64
 }
 
-// fakeMergerFactory shares one fake merger across queues so the synthetic
-// revision ids it mints stay unique for the lifetime of the process.
+func (f *noopMergerFactory) For(cfg merger.Config) (merger.Merger, error) {
+	return noop.New(cfg, f.seq), nil
+}
+
+// fakeMergerFactory builds a fake merger per queue, bound to that queue's
+// config. As with noop, the revision-id counter lives on the factory so ids
+// stay unique for the lifetime of the process.
 type fakeMergerFactory struct {
-	merger merger.Merger
+	seq *atomic.Uint64
 }
 
-func (f *fakeMergerFactory) For(_ merger.Config) (merger.Merger, error) {
-	return f.merger, nil
+func (f *fakeMergerFactory) For(cfg merger.Config) (merger.Merger, error) {
+	return fake.New(cfg, f.seq), nil
 }
 
 // parseStrategy maps the MERGE_DEFAULT_STRATEGY env value to a concrete merge

--- a/service/stovepipe/server/main.go
+++ b/service/stovepipe/server/main.go
@@ -133,16 +133,16 @@ func (f *inMemoryCounterFactory) For(config counter.Config) (counter.Counter, er
 type fakeSourceControlFactory struct{}
 
 func (fakeSourceControlFactory) For(cfg sourcecontrol.Config) (sourcecontrol.SourceControl, error) {
-	return sourcecontrolfake.New([]string{fmt.Sprintf("git://%s/HEAD", cfg.QueueName)}), nil
+	return sourcecontrolfake.New(cfg, []string{fmt.Sprintf("git://%s/HEAD", cfg.QueueName)}), nil
 }
 
-// fakeBuildRunnerFactory is the example BuildRunner factory: every queue shares the same
-// stateless fake runner, which succeeds unless a caller embeds a failure marker in the head
-// URI. A real deployment supplies a backend-specific factory (e.g. Buildkite, per queue).
+// fakeBuildRunnerFactory is the example BuildRunner factory: every queue gets a stateless fake
+// runner bound to its own config, which succeeds unless a caller embeds a failure marker in the
+// head URI. A real deployment supplies a backend-specific factory (e.g. Buildkite, per queue).
 type fakeBuildRunnerFactory struct{}
 
-func (fakeBuildRunnerFactory) For(_ buildrunner.Config) (buildrunner.BuildRunner, error) {
-	return buildrunnerfake.New(), nil
+func (fakeBuildRunnerFactory) For(cfg buildrunner.Config) (buildrunner.BuildRunner, error) {
+	return buildrunnerfake.New(cfg), nil
 }
 
 func main() {

--- a/service/submitqueue/orchestrator/server/BUILD.bazel
+++ b/service/submitqueue/orchestrator/server/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//submitqueue/extension/speculation/speculator/standard:go_default_library",
         "//submitqueue/extension/storage:go_default_library",
         "//submitqueue/extension/storage/mysql:go_default_library",
+        "//submitqueue/extension/validator:go_default_library",
         "//submitqueue/extension/validator/fake:go_default_library",
         "//submitqueue/orchestrator:go_default_library",
         "@com_github_go_sql_driver_mysql//:go_default_library",

--- a/service/submitqueue/orchestrator/server/BUILD.bazel
+++ b/service/submitqueue/orchestrator/server/BUILD.bazel
@@ -92,7 +92,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["profiles_test.go"],
-    embed = [":go_default_library"],
+    embed = [":orchestrator_lib"],  # keep
     deps = [
         "//submitqueue/extension/buildrunner:go_default_library",
         "//submitqueue/extension/changeprovider:go_default_library",

--- a/service/submitqueue/orchestrator/server/BUILD.bazel
+++ b/service/submitqueue/orchestrator/server/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_cross_binary", "go_library", "go_test")
 
 exports_files(
     ["docker-compose.yml"],
@@ -87,4 +87,20 @@ filegroup(
         ":orchestrator_linux",
     ],
     visibility = ["//test:__subpackages__"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["profiles_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//submitqueue/extension/buildrunner:go_default_library",
+        "//submitqueue/extension/changeprovider:go_default_library",
+        "//submitqueue/extension/conflict:go_default_library",
+        "//submitqueue/extension/scorer:go_default_library",
+        "//submitqueue/extension/speculation/speculator:go_default_library",
+        "//submitqueue/extension/storage:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )

--- a/service/submitqueue/orchestrator/server/main.go
+++ b/service/submitqueue/orchestrator/server/main.go
@@ -50,6 +50,7 @@ import (
 	routingprovider "github.com/uber/submitqueue/submitqueue/extension/changeprovider/routing"
 	"github.com/uber/submitqueue/submitqueue/extension/storage"
 	mysqlstorage "github.com/uber/submitqueue/submitqueue/extension/storage/mysql"
+	"github.com/uber/submitqueue/submitqueue/extension/validator"
 	validatorfake "github.com/uber/submitqueue/submitqueue/extension/validator/fake"
 	"github.com/uber/submitqueue/submitqueue/orchestrator"
 	"go.uber.org/zap"
@@ -200,7 +201,7 @@ func run() error {
 		ChangeProvider: profiles.ChangeProviderFactory(),
 		Analyzer:       profiles.AnalyzerFactory(),
 		Speculator:     profiles.SpeculatorFactory(),
-		Validator:      validatorfake.NewFactory(),
+		Validator:      validatorFactory{},
 	}
 
 	// Assemble the pipeline: one call builds the topic registry, creates
@@ -334,7 +335,7 @@ func newChangeProvider(logger *zap.Logger, scope tally.Scope) (changeprovider.Ch
 
 	if ghProvider == nil && phabProvider == nil {
 		logger.Warn("no change provider tokens set; using fake change provider (empty change info unless URI-marked)")
-		return cpfake.New(), nil
+		return cpfake.New(changeprovider.Config{}), nil
 	}
 
 	routingProvider, err := routingprovider.NewProvider(routingprovider.Params{
@@ -464,4 +465,15 @@ func (f counterFactory) For(config counter.Config) (counter.Counter, error) {
 		return nil, fmt.Errorf("queue name must not be empty")
 	}
 	return mysqlcounter.NewCounter(f.db, f.scope, config.QueueName), nil
+}
+
+// validatorFactory routes every queue to the always-passing fake validator.
+// Choosing an impl per queue is host policy, so the adapter lives here rather
+// than in the extension package. A deployment with real validation swaps this
+// for a routing adapter.
+type validatorFactory struct{}
+
+// For returns the Validator bound to the queue named in config.
+func (validatorFactory) For(config validator.Config) (validator.Validator, error) {
+	return validatorfake.New(config), nil
 }

--- a/service/submitqueue/orchestrator/server/main.go
+++ b/service/submitqueue/orchestrator/server/main.go
@@ -320,38 +320,64 @@ func newConsumerGate(logger *zap.Logger) consumergate.Gate {
 	return consumergatefile.New(dir)
 }
 
-// newChangeProvider creates a routing ChangeProvider containing GitHub and Phab ChangeProviders.
-// When neither GITHUB_TOKEN nor PHAB_API_TOKEN is set, falls back to the fake change provider.
-func newChangeProvider(logger *zap.Logger, scope tally.Scope) (changeprovider.ChangeProvider, error) {
-	ghProvider, err := newGitHubChangeProvider(logger, scope)
+// newChangeProviderFactory builds the host's changeprovider.Factory. The HTTP
+// clients are expensive and queue-independent, so they are built once here; the
+// factory then constructs a cheap provider per resolution, bound to the queue
+// named in the Config it is handed. When neither GITHUB_TOKEN nor PHAB_API_TOKEN
+// is set it falls back to the fake change provider.
+func newChangeProviderFactory(logger *zap.Logger, scope tally.Scope) (changeprovider.Factory, error) {
+	ghClient, err := newGitHubClient()
 	if err != nil {
 		return nil, err
 	}
 
-	phabProvider, err := newPhabChangeProvider(logger, scope)
+	phabClient, err := newPhabClient()
 	if err != nil {
 		return nil, err
 	}
 
-	if ghProvider == nil && phabProvider == nil {
+	if ghClient == nil && phabClient == nil {
 		logger.Warn("no change provider tokens set; using fake change provider (empty change info unless URI-marked)")
-		return cpfake.New(changeprovider.Config{}), nil
+		return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
+			return cpfake.New(c), nil
+		}), nil
 	}
 
-	routingProvider, err := routingprovider.NewProvider(routingprovider.Params{
-		GitHub:      ghProvider,
-		Phabricator: phabProvider,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create routing change provider: %w", err)
-	}
-	return routingProvider, nil
+	sugar := logger.Sugar()
+	return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
+		var gh, phab changeprovider.ChangeProvider
+		if ghClient != nil {
+			gh = githubprovider.NewProvider(githubprovider.Params{
+				Config:       c,
+				HTTPClient:   ghClient,
+				Logger:       sugar,
+				MetricsScope: scope.SubScope("changeprovider.github"),
+			})
+		}
+		if phabClient != nil {
+			phab = phabprovider.NewProvider(phabprovider.Params{
+				Config:       c,
+				HTTPClient:   phabClient,
+				Logger:       sugar,
+				MetricsScope: scope.SubScope("changeprovider.phabricator"),
+			})
+		}
+
+		routingProvider, err := routingprovider.NewProvider(routingprovider.Params{
+			Config:      c,
+			GitHub:      gh,
+			Phabricator: phab,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create routing change provider: %w", err)
+		}
+		return routingProvider, nil
+	}), nil
 }
 
-// newGitHubChangeProvider creates a GitHub ChangeProvider configured via
-// GITHUB_BASE_URL, GITHUB_TOKEN, and GITHUB_TIMEOUT. Returns nil when
-// GITHUB_TOKEN is unset.
-func newGitHubChangeProvider(logger *zap.Logger, scope tally.Scope) (changeprovider.ChangeProvider, error) {
+// newGitHubClient builds the GitHub HTTP client configured via GITHUB_BASE_URL,
+// GITHUB_TOKEN, and GITHUB_TIMEOUT. Returns nil when GITHUB_TOKEN is unset.
+func newGitHubClient() (*nethttp.Client, error) {
 	if os.Getenv("GITHUB_TOKEN") == "" {
 		return nil, nil
 	}
@@ -365,11 +391,7 @@ func newGitHubChangeProvider(logger *zap.Logger, scope tally.Scope) (changeprovi
 	client.Transport = &oauth2.Transport{Source: ts, Base: client.Transport}
 	client.Timeout = parseTimeout(os.Getenv("GITHUB_TIMEOUT"), 30*time.Second)
 
-	return githubprovider.NewProvider(githubprovider.Params{
-		HTTPClient:   client,
-		Logger:       logger.Sugar(),
-		MetricsScope: scope.SubScope("changeprovider.github"),
-	}), nil
+	return client, nil
 }
 
 // apiTokenTransport injects a Phabricator API token as a query parameter in each request.
@@ -386,9 +408,9 @@ func (t *apiTokenTransport) RoundTrip(req *nethttp.Request) (*nethttp.Response, 
 	return t.next.RoundTrip(r)
 }
 
-// newPhabChangeProvider creates a Phabricator ChangeProvider configured via PHAB_API_ENDPOINT and PHAB_API_TOKEN.
-// Returns nil when PHAB_API_TOKEN or PHAB_API_ENDPOINT are unset.
-func newPhabChangeProvider(logger *zap.Logger, scope tally.Scope) (changeprovider.ChangeProvider, error) {
+// newPhabClient builds the Phabricator HTTP client configured via
+// PHAB_API_ENDPOINT and PHAB_API_TOKEN. Returns nil when either is unset.
+func newPhabClient() (*nethttp.Client, error) {
 	token := os.Getenv("PHAB_API_TOKEN")
 	if token == "" {
 		return nil, nil
@@ -410,11 +432,7 @@ func newPhabChangeProvider(logger *zap.Logger, scope tally.Scope) (changeprovide
 		next:  baseTransport.Next,
 	}
 
-	return phabprovider.NewProvider(phabprovider.Params{
-		HTTPClient:   client,
-		Logger:       logger.Sugar(),
-		MetricsScope: scope.SubScope("changeprovider.phabricator"),
-	}), nil
+	return client, nil
 }
 
 // getEnv returns environment variable value or default if not set.

--- a/service/submitqueue/orchestrator/server/profiles.go
+++ b/service/submitqueue/orchestrator/server/profiles.go
@@ -41,19 +41,26 @@ import (
 	"go.uber.org/zap"
 )
 
-// Profile holds the per-queue extension implementations. Grouping them per
-// queue (rather than per extension) lets the wiring read as "for this queue,
-// here are its analyzer, change provider, …", and lets a queue profile start
-// from a baseline and override only what differs.
+// Profile holds the per-queue extension factories. Grouping them per queue
+// (rather than per extension) lets the wiring read as "for this queue, here are
+// its analyzer, change provider, …", and lets a queue profile start from a
+// baseline and override only what differs.
+//
+// Every field is a Factory rather than a built implementation. Selecting the
+// profile consumes only the queue name; the Config itself is forwarded into the
+// profile's factory, so the implementation is constructed knowing which queue it
+// serves. That matters most for defaultProfile, which backs every queue without
+// an explicit entry: one shared instance could not carry a correct queue name,
+// but one factory can build a correct instance per queue.
 type Profile struct {
 	// ChangeProvider resolves change metadata for requests in this queue.
-	ChangeProvider changeprovider.ChangeProvider
+	ChangeProvider changeprovider.Factory
 
 	// BuildRunner triggers and polls builds for batches in this queue.
-	BuildRunner buildrunner.BuildRunner
+	BuildRunner buildrunner.Factory
 
 	// Analyzer detects conflicts between concurrent batches in this queue.
-	Analyzer conflict.Analyzer
+	Analyzer conflict.Factory
 
 	// Storage resolves the queue-scoped store aggregate for this queue. Every
 	// profile points at the shared backend by default; a deployment that
@@ -63,11 +70,11 @@ type Profile struct {
 	// Scorer holds this queue's scoring profile. There is no scoring stage: the
 	// scorer feeds the queue's speculator, which ranks candidate paths by how
 	// likely their assumptions are to hold.
-	Scorer scorer.Scorer
+	Scorer scorer.Factory
 
 	// Speculator decides which of this queue's speculation paths to build and
 	// which running ones to preempt, within the build budget.
-	Speculator speculator.Speculator
+	Speculator speculator.Factory
 }
 
 // Profiles maps a queue name to its extension Profile, falling back to a
@@ -87,11 +94,15 @@ func (p Profiles) For(queue string) Profile {
 	return p.defaultProfile
 }
 
+// Each XFactory method resolves the queue's profile by name, then forwards the
+// whole Config to that profile's factory. The second For(c) is what carries the
+// queue identity past the profile lookup and into the implementation.
+
 // ChangeProviderFactory returns a changeprovider.Factory that resolves the
 // ChangeProvider for each queue from the profile registry.
 func (p Profiles) ChangeProviderFactory() changeprovider.Factory {
 	return changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
-		return p.For(c.QueueName).ChangeProvider, nil
+		return p.For(c.QueueName).ChangeProvider.For(c)
 	})
 }
 
@@ -99,7 +110,7 @@ func (p Profiles) ChangeProviderFactory() changeprovider.Factory {
 // BuildRunner for each queue from the profile registry.
 func (p Profiles) BuildRunnerFactory() buildrunner.Factory {
 	return buildRunnerFunc(func(c buildrunner.Config) (buildrunner.BuildRunner, error) {
-		return p.For(c.QueueName).BuildRunner, nil
+		return p.For(c.QueueName).BuildRunner.For(c)
 	})
 }
 
@@ -107,7 +118,7 @@ func (p Profiles) BuildRunnerFactory() buildrunner.Factory {
 // each queue from the profile registry.
 func (p Profiles) AnalyzerFactory() conflict.Factory {
 	return analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
-		return p.For(c.QueueName).Analyzer, nil
+		return p.For(c.QueueName).Analyzer.For(c)
 	})
 }
 
@@ -119,17 +130,26 @@ func (p Profiles) StorageFactory() storage.Factory {
 	})
 }
 
+// ScorerFactory returns a scorer.Factory that resolves the Scorer for each
+// queue from the profile registry.
+func (p Profiles) ScorerFactory() scorer.Factory {
+	return scorerFunc(func(c scorer.Config) (scorer.Scorer, error) {
+		return p.For(c.QueueName).Scorer.For(c)
+	})
+}
+
 // SpeculatorFactory returns a speculator.Factory that resolves the Speculator
 // for each queue from the profile registry.
 func (p Profiles) SpeculatorFactory() speculator.Factory {
 	return speculatorFunc(func(c speculator.Config) (speculator.Speculator, error) {
-		return p.For(c.QueueName).Speculator, nil
+		return p.For(c.QueueName).Speculator.For(c)
 	})
 }
 
 // Thin func-type adapters — the http.HandlerFunc trick applied to each
 // extension Factory interface. Each func type satisfies the Factory contract,
-// letting Profiles cross the host/library boundary without dedicated structs.
+// letting Profiles cross the host/library boundary without dedicated structs,
+// and letting a Profile field hold a closure instead of a built instance.
 
 type changeProviderFunc func(changeprovider.Config) (changeprovider.ChangeProvider, error)
 
@@ -149,6 +169,10 @@ type storageFunc func(storage.Config) (storage.Storage, error)
 
 func (f storageFunc) For(c storage.Config) (storage.Storage, error) { return f(c) }
 
+type scorerFunc func(scorer.Config) (scorer.Scorer, error)
+
+func (f scorerFunc) For(c scorer.Config) (scorer.Scorer, error) { return f(c) }
+
 type speculatorFunc func(speculator.Config) (speculator.Speculator, error)
 
 func (f speculatorFunc) For(c speculator.Config) (speculator.Speculator, error) { return f(c) }
@@ -158,8 +182,13 @@ func (f speculatorFunc) For(c speculator.Config) (speculator.Speculator, error) 
 // baseline; each per-queue profile starts from that baseline and overrides
 // only the extensions that differ — here the conflict analyzer and the scorer.
 // Queues without an explicit profile fall back to the baseline.
+//
+// Anything expensive and queue-independent — the resolver, the metrics scope,
+// the change provider's HTTP clients — is built once, here. The closures below
+// only construct the cheap per-queue wrapper, which is the same shape
+// counterFactory.For already uses for the MySQL counter.
 func newProfiles(logger *zap.Logger, scope tally.Scope, resolver changeset.Resolver, stores storage.Factory) (Profiles, error) {
-	cp, err := newChangeProvider(logger, scope)
+	changeProviders, err := newChangeProviderFactory(logger, scope)
 	if err != nil {
 		return Profiles{}, fmt.Errorf("failed to create change provider: %w", err)
 	}
@@ -170,70 +199,84 @@ func newProfiles(logger *zap.Logger, scope tally.Scope, resolver changeset.Resol
 		return changes.TotalLinesChanged(), nil
 	}
 
+	// heuristicScorer builds a bucketed heuristic scorer, wrapped by scorerfake
+	// so a change URI carrying "sq-fake=score-error" forces a scoring error
+	// end-to-end; the wrapper is a pure passthrough otherwise.
+	heuristicScorer := func(buckets []heuristic.Bucket, scopeName string) scorer.Factory {
+		return scorerFunc(func(c scorer.Config) (scorer.Scorer, error) {
+			return scorerfake.New(c, resolver, heuristic.New(
+				c, resolver, buckets, batchLines, scope.SubScope(scopeName),
+			)), nil
+		})
+	}
+
 	// Baseline profile: shared edge integrations + a fake build runner (every
 	// build succeeds unless a head URI carries a failure marker), plus permissive
-	// defaults for scorer and conflict. The build runner instance is shared by
-	// the build and buildsignal controllers (same profile, same instance) so a
-	// build's recorded outcome survives across their separate factory lookups.
+	// defaults for scorer and conflict.
 	//
-	// The scorer is wrapped by scorerfake so a change URI carrying
-	// "sq-fake=score-error" forces a scoring error end-to-end; it is a pure
-	// passthrough otherwise. The analyzer is wrapped by conflictfake with a nil
-	// predicate (passthrough) — swap the predicate (e.g. conflictfake.FailAlways)
-	// on a queue to exercise the analyzer error path, as e2e-conflict-error-queue
-	// below does.
+	// The analyzer is wrapped by conflictfake with a nil predicate (passthrough)
+	// — swap the predicate (e.g. conflictfake.FailAlways) on a queue to exercise
+	// the analyzer error path, as e2e-conflict-error-queue below does.
 	base := Profile{
-		ChangeProvider: cp,
-		BuildRunner:    buildfake.New(buildrunner.Config{}, resolver),
+		ChangeProvider: changeProviders,
+		BuildRunner: buildRunnerFunc(func(c buildrunner.Config) (buildrunner.BuildRunner, error) {
+			return buildfake.New(c, resolver), nil
+		}),
 		// TODO: replace the delegate with a real analyzer (e.g. Tango target
 		// analysis). "all" serializes the queue conservatively.
-		Analyzer: conflictfake.New(conflict.Config{}, all.New(conflict.Config{}), nil),
-		Storage:  stores,
-
-		Scorer: scorerfake.New(scorer.Config{}, resolver, heuristic.New(
-			scorer.Config{},
-			resolver,
+		Analyzer: analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
+			return conflictfake.New(c, all.New(c), nil), nil
+		}),
+		Storage: stores,
+		Scorer: heuristicScorer(
 			[]heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: 0.5}},
-			batchLines, scope.SubScope("scorer.default"),
-		)),
+			"scorer.default",
+		),
 	}
 
 	// test-queue: bucketed heuristic scorer; conservative (serialized) conflicts
 	// inherited from the baseline.
 	testQueue := base
-	testQueue.Scorer = scorerfake.New(scorer.Config{}, resolver, heuristic.New(
-		scorer.Config{},
-		resolver,
+	testQueue.Scorer = heuristicScorer(
 		[]heuristic.Bucket{
 			{Min: 0, Max: 1, Score: 0.95},
 			{Min: 2, Max: 5, Score: 0.80},
 			{Min: 6, Max: 20, Score: 0.60},
 			{Min: 21, Max: 1<<31 - 1, Score: 0.40},
 		},
-		batchLines, scope.SubScope("scorer.test-queue"),
-	))
+		"scorer.test-queue",
+	)
 
 	// e2e-conflict-error-queue: every conflict analysis fails, exercising the
 	// analyzer error path. Scorer/edge integrations inherit the baseline.
 	conflictErrQueue := base
-	conflictErrQueue.Analyzer = conflictfake.New(conflict.Config{}, all.New(conflict.Config{}), conflictfake.FailAlways)
+	conflictErrQueue.Analyzer = analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
+		return conflictfake.New(c, all.New(c), conflictfake.FailAlways), nil
+	})
 
 	// file-overlap-queue: a real analyzer that serializes only batches sharing
 	// a changed file, resolving each batch's files itself via the resolver.
 	fileOverlapQueue := base
-	fileOverlapQueue.Analyzer = fileoverlap.New(conflict.Config{}, resolver)
+	fileOverlapQueue.Analyzer = analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
+		return fileoverlap.New(c, resolver), nil
+	})
 
 	// e2e-test-queue: composite scorer; no conflicts (maximum parallelism).
 	e2eQueue := base
-	e2eQueue.Analyzer = conflictfake.New(conflict.Config{}, none.New(conflict.Config{}), nil)
-	e2eQueue.Scorer = scorerfake.New(scorer.Config{}, resolver, composite.New(
-		scorer.Config{},
-		map[string]scorer.Scorer{
-			"size": heuristic.New(scorer.Config{}, resolver, []heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: 0.8}}, batchLines, scope),
-			"flat": heuristic.New(scorer.Config{}, resolver, []heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: 0.6}}, batchLines, scope),
-		},
-		composite.Avg, scope.SubScope("scorer.e2e-test-queue"),
-	))
+	e2eQueue.Analyzer = analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
+		return conflictfake.New(c, none.New(c), nil), nil
+	})
+	e2eQueue.Scorer = scorerFunc(func(c scorer.Config) (scorer.Scorer, error) {
+		flat := func(score float64) scorer.Scorer {
+			return heuristic.New(c, resolver,
+				[]heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: score}}, batchLines, scope)
+		}
+		return scorerfake.New(c, resolver, composite.New(
+			c,
+			map[string]scorer.Scorer{"size": flat(0.8), "flat": flat(0.6)},
+			composite.Avg, scope.SubScope("scorer.e2e-test-queue"),
+		)), nil
+	})
 
 	// The speculator is composed last, because it is built from whatever scorer
 	// the profile ended up with.
@@ -261,7 +304,17 @@ const defaultBuildBudget = 4
 // without preempting builds already running. Swapping either part changes the
 // policy without touching the speculate controller, which depends only on the
 // Speculator contract.
+//
+// The scorer is resolved at the same queue identity the speculator was asked
+// for, so a queue falling through to defaultProfile gets a speculator whose
+// underlying scorer was also built for that queue.
 func withSpeculator(p Profile) Profile {
-	p.Speculator = specstandard.New(speculator.Config{}, bestfirst.New(p.Scorer), sticky.New(defaultBuildBudget))
+	p.Speculator = speculatorFunc(func(c speculator.Config) (speculator.Speculator, error) {
+		sc, err := p.Scorer.For(scorer.Config{QueueName: c.QueueName})
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve scorer for queue %q: %w", c.QueueName, err)
+		}
+		return specstandard.New(c, bestfirst.New(sc), sticky.New(defaultBuildBudget)), nil
+	})
 	return p
 }

--- a/service/submitqueue/orchestrator/server/profiles.go
+++ b/service/submitqueue/orchestrator/server/profiles.go
@@ -184,13 +184,14 @@ func newProfiles(logger *zap.Logger, scope tally.Scope, resolver changeset.Resol
 	// below does.
 	base := Profile{
 		ChangeProvider: cp,
-		BuildRunner:    buildfake.New(resolver),
+		BuildRunner:    buildfake.New(buildrunner.Config{}, resolver),
 		// TODO: replace the delegate with a real analyzer (e.g. Tango target
 		// analysis). "all" serializes the queue conservatively.
-		Analyzer: conflictfake.New(all.New(), nil),
+		Analyzer: conflictfake.New(conflict.Config{}, all.New(conflict.Config{}), nil),
 		Storage:  stores,
 
-		Scorer: scorerfake.New(resolver, heuristic.New(
+		Scorer: scorerfake.New(scorer.Config{}, resolver, heuristic.New(
+			scorer.Config{},
 			resolver,
 			[]heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: 0.5}},
 			batchLines, scope.SubScope("scorer.default"),
@@ -200,7 +201,8 @@ func newProfiles(logger *zap.Logger, scope tally.Scope, resolver changeset.Resol
 	// test-queue: bucketed heuristic scorer; conservative (serialized) conflicts
 	// inherited from the baseline.
 	testQueue := base
-	testQueue.Scorer = scorerfake.New(resolver, heuristic.New(
+	testQueue.Scorer = scorerfake.New(scorer.Config{}, resolver, heuristic.New(
+		scorer.Config{},
 		resolver,
 		[]heuristic.Bucket{
 			{Min: 0, Max: 1, Score: 0.95},
@@ -214,20 +216,21 @@ func newProfiles(logger *zap.Logger, scope tally.Scope, resolver changeset.Resol
 	// e2e-conflict-error-queue: every conflict analysis fails, exercising the
 	// analyzer error path. Scorer/edge integrations inherit the baseline.
 	conflictErrQueue := base
-	conflictErrQueue.Analyzer = conflictfake.New(all.New(), conflictfake.FailAlways)
+	conflictErrQueue.Analyzer = conflictfake.New(conflict.Config{}, all.New(conflict.Config{}), conflictfake.FailAlways)
 
 	// file-overlap-queue: a real analyzer that serializes only batches sharing
 	// a changed file, resolving each batch's files itself via the resolver.
 	fileOverlapQueue := base
-	fileOverlapQueue.Analyzer = fileoverlap.New(resolver)
+	fileOverlapQueue.Analyzer = fileoverlap.New(conflict.Config{}, resolver)
 
 	// e2e-test-queue: composite scorer; no conflicts (maximum parallelism).
 	e2eQueue := base
-	e2eQueue.Analyzer = conflictfake.New(none.New(), nil)
-	e2eQueue.Scorer = scorerfake.New(resolver, composite.New(
+	e2eQueue.Analyzer = conflictfake.New(conflict.Config{}, none.New(conflict.Config{}), nil)
+	e2eQueue.Scorer = scorerfake.New(scorer.Config{}, resolver, composite.New(
+		scorer.Config{},
 		map[string]scorer.Scorer{
-			"size": heuristic.New(resolver, []heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: 0.8}}, batchLines, scope),
-			"flat": heuristic.New(resolver, []heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: 0.6}}, batchLines, scope),
+			"size": heuristic.New(scorer.Config{}, resolver, []heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: 0.8}}, batchLines, scope),
+			"flat": heuristic.New(scorer.Config{}, resolver, []heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: 0.6}}, batchLines, scope),
 		},
 		composite.Avg, scope.SubScope("scorer.e2e-test-queue"),
 	))
@@ -259,6 +262,6 @@ const defaultBuildBudget = 4
 // policy without touching the speculate controller, which depends only on the
 // Speculator contract.
 func withSpeculator(p Profile) Profile {
-	p.Speculator = specstandard.New(bestfirst.New(p.Scorer), sticky.New(defaultBuildBudget))
+	p.Speculator = specstandard.New(speculator.Config{}, bestfirst.New(p.Scorer), sticky.New(defaultBuildBudget))
 	return p
 }

--- a/service/submitqueue/orchestrator/server/profiles_test.go
+++ b/service/submitqueue/orchestrator/server/profiles_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/submitqueue/submitqueue/extension/buildrunner"
+	"github.com/uber/submitqueue/submitqueue/extension/changeprovider"
+	"github.com/uber/submitqueue/submitqueue/extension/conflict"
+	"github.com/uber/submitqueue/submitqueue/extension/scorer"
+	"github.com/uber/submitqueue/submitqueue/extension/speculation/speculator"
+	"github.com/uber/submitqueue/submitqueue/extension/storage"
+)
+
+// recorder captures the queue name each seam's factory was handed, so a test
+// can assert the Config survived the profile lookup instead of stopping at it.
+type recorder struct {
+	changeProvider string
+	buildRunner    string
+	analyzer       string
+	storage        string
+	scorer         string
+}
+
+// profileRecording returns a Profile whose every factory records the queue name
+// it receives into rec and returns a nil implementation. Nil is fine: these
+// tests are about what reaches the factory, not what it builds.
+func profileRecording(rec *recorder) Profile {
+	return Profile{
+		ChangeProvider: changeProviderFunc(func(c changeprovider.Config) (changeprovider.ChangeProvider, error) {
+			rec.changeProvider = c.QueueName
+			return nil, nil
+		}),
+		BuildRunner: buildRunnerFunc(func(c buildrunner.Config) (buildrunner.BuildRunner, error) {
+			rec.buildRunner = c.QueueName
+			return nil, nil
+		}),
+		Analyzer: analyzerFunc(func(c conflict.Config) (conflict.Analyzer, error) {
+			rec.analyzer = c.QueueName
+			return nil, nil
+		}),
+		Storage: storageFunc(func(c storage.Config) (storage.Storage, error) {
+			rec.storage = c.QueueName
+			return nil, nil
+		}),
+		Scorer: scorerFunc(func(c scorer.Config) (scorer.Scorer, error) {
+			rec.scorer = c.QueueName
+			return nil, nil
+		}),
+	}
+}
+
+// TestProfilesForwardQueueNameToFactories is the regression guard for the seam
+// this file exists to fix. Selecting a profile consumes the queue name, but the
+// Config must keep travelling into the profile's own factory — otherwise an
+// implementation is built without knowing which queue it serves.
+//
+// The unlisted-queue case is the one that used to be unfixable: defaultProfile
+// backs every queue with no explicit entry, so a single shared instance could
+// only ever carry one queue name (or none).
+func TestProfilesForwardQueueNameToFactories(t *testing.T) {
+	tests := []struct {
+		name  string
+		queue string
+	}{
+		{name: "queue with an explicit profile", queue: "listed-queue"},
+		{name: "queue falling through to the default profile", queue: "unlisted-queue"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rec recorder
+			profile := profileRecording(&rec)
+			profiles := Profiles{
+				defaultProfile: profile,
+				byQueue:        map[string]Profile{"listed-queue": profile},
+			}
+
+			_, err := profiles.ChangeProviderFactory().For(changeprovider.Config{QueueName: tt.queue})
+			require.NoError(t, err)
+			_, err = profiles.BuildRunnerFactory().For(buildrunner.Config{QueueName: tt.queue})
+			require.NoError(t, err)
+			_, err = profiles.AnalyzerFactory().For(conflict.Config{QueueName: tt.queue})
+			require.NoError(t, err)
+			_, err = profiles.StorageFactory().For(storage.Config{QueueName: tt.queue})
+			require.NoError(t, err)
+			_, err = profiles.ScorerFactory().For(scorer.Config{QueueName: tt.queue})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.queue, rec.changeProvider)
+			assert.Equal(t, tt.queue, rec.buildRunner)
+			assert.Equal(t, tt.queue, rec.analyzer)
+			assert.Equal(t, tt.queue, rec.storage)
+			assert.Equal(t, tt.queue, rec.scorer)
+		})
+	}
+}
+
+// TestWithSpeculatorResolvesScorerAtSameQueue covers the one seam that resolves
+// another seam: the speculator is composed from the profile's scorer, and must
+// ask for it at the queue it was itself asked for.
+func TestWithSpeculatorResolvesScorerAtSameQueue(t *testing.T) {
+	var rec recorder
+	profile := withSpeculator(profileRecording(&rec))
+	profiles := Profiles{defaultProfile: profile}
+
+	spec, err := profiles.SpeculatorFactory().For(speculator.Config{QueueName: "unlisted-queue"})
+	require.NoError(t, err)
+	assert.NotNil(t, spec)
+	assert.Equal(t, "unlisted-queue", rec.scorer)
+}
+
+// TestWithSpeculatorPropagatesScorerError covers the error path the factory
+// conversion introduced: resolving the scorer can now fail where reading a
+// struct field could not, and the failure must surface rather than yielding a
+// speculator built over a nil scorer.
+func TestWithSpeculatorPropagatesScorerError(t *testing.T) {
+	sentinel := errors.New("scorer unavailable")
+	profile := withSpeculator(Profile{
+		Scorer: scorerFunc(func(scorer.Config) (scorer.Scorer, error) { return nil, sentinel }),
+	})
+
+	spec, err := profile.Speculator.For(speculator.Config{QueueName: "any-queue"})
+	require.ErrorIs(t, err, sentinel)
+	assert.Nil(t, spec)
+}

--- a/stovepipe/extension/buildrunner/fake/fake.go
+++ b/stovepipe/extension/buildrunner/fake/fake.go
@@ -71,16 +71,19 @@ const outcomeOK = "ok"
 // Status. Uniqueness comes from a random suffix per id, so it needs no shared
 // counter and never collides across instances or processes.
 type runner struct {
+	// cfg is the per-queue identity this runner was built for.
+	cfg buildrunner.Config
 	// slowBuildDuration is how long a build-slow build reports running before
 	// it succeeds. Configuration, not per-build state: it is read at Trigger to
 	// compute the deadline baked into the id, never mutated.
 	slowBuildDuration time.Duration
 }
 
-// New returns a buildrunner.BuildRunner that defaults to succeeding and honors
-// marker tokens embedded in the triggered headURI.
-func New() buildrunner.BuildRunner {
-	return runner{slowBuildDuration: defaultSlowBuildDuration}
+// New returns a buildrunner.BuildRunner bound to the queue named in cfg that
+// defaults to succeeding and honors marker tokens embedded in the triggered
+// headURI.
+func New(cfg buildrunner.Config) buildrunner.BuildRunner {
+	return runner{cfg: cfg, slowBuildDuration: defaultSlowBuildDuration}
 }
 
 // Trigger fails when headURI carries the trigger-error marker; otherwise it

--- a/stovepipe/extension/buildrunner/fake/fake_test.go
+++ b/stovepipe/extension/buildrunner/fake/fake_test.go
@@ -26,8 +26,11 @@ import (
 	"github.com/uber/submitqueue/stovepipe/extension/buildrunner"
 )
 
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = buildrunner.Config{QueueName: "test-queue"}
+
 func TestNew_ImplementsInterface(t *testing.T) {
-	var _ buildrunner.BuildRunner = New()
+	var _ buildrunner.BuildRunner = New(testCfg)
 }
 
 func TestTrigger(t *testing.T) {
@@ -44,7 +47,7 @@ func TestTrigger(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			id, err := New().Trigger(context.Background(), "", tt.headURI, nil)
+			id, err := New(testCfg).Trigger(context.Background(), "", tt.headURI, nil)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Empty(t, id.ID)
@@ -57,9 +60,9 @@ func TestTrigger(t *testing.T) {
 }
 
 func TestTrigger_UniqueIDs(t *testing.T) {
-	a, err := New().Trigger(context.Background(), "", "git://repo/ref/deadbeef", nil)
+	a, err := New(testCfg).Trigger(context.Background(), "", "git://repo/ref/deadbeef", nil)
 	require.NoError(t, err)
-	b, err := New().Trigger(context.Background(), "", "git://repo/ref/deadbeef", nil)
+	b, err := New(testCfg).Trigger(context.Background(), "", "git://repo/ref/deadbeef", nil)
 	require.NoError(t, err)
 	assert.NotEqual(t, a.ID, b.ID)
 }
@@ -77,10 +80,10 @@ func TestStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			id, err := New().Trigger(context.Background(), "", tt.headURI, nil)
+			id, err := New(testCfg).Trigger(context.Background(), "", tt.headURI, nil)
 			require.NoError(t, err)
 
-			status, metadata, err := New().Status(context.Background(), id)
+			status, metadata, err := New(testCfg).Status(context.Background(), id)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -93,23 +96,23 @@ func TestStatus(t *testing.T) {
 }
 
 func TestStatus_UnrecognizedIDSucceeds(t *testing.T) {
-	status, metadata, err := New().Status(context.Background(), entity.BuildID{ID: "not-minted-by-this-fake"})
+	status, metadata, err := New(testCfg).Status(context.Background(), entity.BuildID{ID: "not-minted-by-this-fake"})
 	require.NoError(t, err)
 	assert.Equal(t, entity.BuildStatusSucceeded, status)
 	assert.Nil(t, metadata)
 }
 
 func TestStatus_StatelessAcrossInstances(t *testing.T) {
-	id, err := New().Trigger(context.Background(), "", "git://repo/ref/deadbeef?buildrunner-fake=build-fail", nil)
+	id, err := New(testCfg).Trigger(context.Background(), "", "git://repo/ref/deadbeef?buildrunner-fake=build-fail", nil)
 	require.NoError(t, err)
 
-	status, _, err := New().Status(context.Background(), id)
+	status, _, err := New(testCfg).Status(context.Background(), id)
 	require.NoError(t, err)
 	assert.Equal(t, entity.BuildStatusFailed, status)
 }
 
 func TestCancel_NoOp(t *testing.T) {
-	err := New().Cancel(context.Background(), entity.BuildID{ID: "anything"})
+	err := New(testCfg).Cancel(context.Background(), entity.BuildID{ID: "anything"})
 	assert.NoError(t, err)
 }
 
@@ -123,14 +126,14 @@ func TestStatus_BuildSlowReportsRunningThenSucceeds(t *testing.T) {
 	id, err := slow.Trigger(context.Background(), "", "git://repo/ref/deadbeef?buildrunner-fake=build-slow", nil)
 	require.NoError(t, err)
 
-	status, _, err := New().Status(context.Background(), id)
+	status, _, err := New(testCfg).Status(context.Background(), id)
 	require.NoError(t, err)
 	assert.Equal(t, entity.BuildStatusRunning, status)
 
 	// An id whose deadline has already passed reports the terminal outcome. Encoding
 	// the deadline in the id is what keeps Status stateless across instances.
 	elapsed := entity.BuildID{ID: fmt.Sprintf("fake-build-slow-%d-abcd1234", time.Now().UnixMilli()-1)}
-	status, _, err = New().Status(context.Background(), elapsed)
+	status, _, err = New(testCfg).Status(context.Background(), elapsed)
 	require.NoError(t, err)
 	assert.Equal(t, entity.BuildStatusSucceeded, status)
 }
@@ -139,7 +142,7 @@ func TestStatus_BuildSlowReportsRunningThenSucceeds(t *testing.T) {
 // marker but no parsable deadline is treated as already terminal rather than polling
 // forever.
 func TestStatus_BuildSlowWithoutDeadlineSucceeds(t *testing.T) {
-	status, _, err := New().Status(context.Background(), entity.BuildID{ID: "fake-build-slow-nodeadline"})
+	status, _, err := New(testCfg).Status(context.Background(), entity.BuildID{ID: "fake-build-slow-nodeadline"})
 	require.NoError(t, err)
 	assert.Equal(t, entity.BuildStatusSucceeded, status)
 }

--- a/stovepipe/extension/sourcecontrol/fake/fake.go
+++ b/stovepipe/extension/sourcecontrol/fake/fake.go
@@ -29,16 +29,19 @@ import (
 // sourceControlFake serves a single queue's linear history. history[0] is the
 // latest commit; higher indices are progressively older ancestors.
 type sourceControlFake struct {
+	// cfg is the per-queue identity this source control was built for.
+	cfg     sourcecontrol.Config
 	history []string
 }
 
-// New returns a sourcecontrol.SourceControl backed by the given ref history,
-// ordered newest-first (history[0] is the latest commit). The slice is copied so
-// later mutation by the caller does not affect the fake.
-func New(history []string) sourcecontrol.SourceControl {
+// New returns a sourcecontrol.SourceControl bound to the queue named in cfg,
+// backed by the given ref history, ordered newest-first (history[0] is the
+// latest commit). The slice is copied so later mutation by the caller does not
+// affect the fake.
+func New(cfg sourcecontrol.Config, history []string) sourcecontrol.SourceControl {
 	cp := make([]string, len(history))
 	copy(cp, history)
-	return sourceControlFake{history: cp}
+	return sourceControlFake{cfg: cfg, history: cp}
 }
 
 // Latest returns the newest commit URI, or ErrNotFound when the history is empty.

--- a/stovepipe/extension/sourcecontrol/fake/fake_test.go
+++ b/stovepipe/extension/sourcecontrol/fake/fake_test.go
@@ -23,8 +23,11 @@ import (
 	"github.com/uber/submitqueue/stovepipe/extension/sourcecontrol"
 )
 
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = sourcecontrol.Config{QueueName: "test-queue"}
+
 func TestNew_ImplementsInterface(t *testing.T) {
-	var _ sourcecontrol.SourceControl = New(nil)
+	var _ sourcecontrol.SourceControl = New(testCfg, nil)
 }
 
 // history is ordered newest-first: c is the latest, a is the oldest ancestor.
@@ -42,7 +45,7 @@ func TestLatest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.history).Latest(context.Background())
+			got, err := New(testCfg, tt.history).Latest(context.Background())
 			if tt.wantErr {
 				require.ErrorIs(t, err, sourcecontrol.ErrNotFound)
 				return
@@ -69,7 +72,7 @@ func TestIsAncestor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(history).IsAncestor(context.Background(), tt.ancestor, tt.descendant)
+			got, err := New(testCfg, history).IsAncestor(context.Background(), tt.ancestor, tt.descendant)
 			if tt.wantErr {
 				require.ErrorIs(t, err, sourcecontrol.ErrNotFound)
 				return
@@ -126,7 +129,7 @@ func TestHistory(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(history).History(context.Background(), tt.cursor, tt.limit)
+			got, err := New(testCfg, history).History(context.Background(), tt.cursor, tt.limit)
 			if tt.wantErr {
 				require.ErrorIs(t, err, sourcecontrol.ErrNotFound)
 				return

--- a/submitqueue/extension/buildrunner/fake/fake.go
+++ b/submitqueue/extension/buildrunner/fake/fake.go
@@ -59,14 +59,16 @@ const outcomeOK = "ok"
 // back out at Status. Uniqueness comes from a random suffix per ID, so it needs
 // no shared counter and never collides across instances or processes.
 type runner struct {
+	// cfg is the per-queue identity this runner was built for.
+	cfg      buildrunner.Config
 	resolver changeset.Resolver
 }
 
-// New returns a buildrunner.BuildRunner that defaults to succeeding and honors
-// marker tokens embedded in head change URIs. The resolver resolves the head
-// batch's changes so the marker can be inspected.
-func New(resolver changeset.Resolver) buildrunner.BuildRunner {
-	return &runner{resolver: resolver}
+// New returns a buildrunner.BuildRunner bound to the queue named in cfg that
+// defaults to succeeding and honors marker tokens embedded in head change URIs.
+// The resolver resolves the head batch's changes so the marker can be inspected.
+func New(cfg buildrunner.Config, resolver changeset.Resolver) buildrunner.BuildRunner {
+	return &runner{cfg: cfg, resolver: resolver}
 }
 
 // Trigger fails when a head change URI carries the trigger-error marker;

--- a/submitqueue/extension/buildrunner/fake/fake_test.go
+++ b/submitqueue/extension/buildrunner/fake/fake_test.go
@@ -26,16 +26,19 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/buildrunner"
 )
 
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = buildrunner.Config{QueueName: "test-queue"}
+
 const headBatchID = "head-batch"
 
 // newFake returns a fake runner whose head batch resolves to a single change
 // carrying the given URIs.
 func newFake(uris ...string) buildrunner.BuildRunner {
-	return New(changesetfake.New().Set(headBatchID, change.Change{URIs: uris}))
+	return New(testCfg, changesetfake.New().Set(headBatchID, change.Change{URIs: uris}))
 }
 
 func TestNew_ImplementsInterface(t *testing.T) {
-	var _ buildrunner.BuildRunner = New(changesetfake.New())
+	var _ buildrunner.BuildRunner = New(testCfg, changesetfake.New())
 }
 
 func TestRunner_Trigger_UniqueIDs(t *testing.T) {
@@ -46,7 +49,7 @@ func TestRunner_Trigger_UniqueIDs(t *testing.T) {
 	assert.NotEmpty(t, id1.ID)
 
 	// Same runner instance, different trigger (empty head — no marker).
-	r := New(changesetfake.New())
+	r := New(testCfg, changesetfake.New())
 	id2, err := r.Trigger(ctx, nil, entity.Batch{ID: "x"}, nil)
 	require.NoError(t, err)
 	id3, err := r.Trigger(ctx, nil, entity.Batch{ID: "x"}, nil)
@@ -113,7 +116,7 @@ func TestRunner_Status(t *testing.T) {
 }
 
 func TestRunner_Status_UnknownBuildSucceeds(t *testing.T) {
-	r := New(changesetfake.New())
+	r := New(testCfg, changesetfake.New())
 	status, _, err := r.Status(context.Background(), entity.BuildID{ID: "never-triggered"})
 	require.NoError(t, err)
 	assert.Equal(t, entity.BuildStatusSucceeded, status)
@@ -127,12 +130,12 @@ func TestStatus_StatelessAcrossInstances(t *testing.T) {
 	id, err := newFake("github://github.example.com/o/r/pull/1/a?sq-fake=build-fail").Trigger(ctx, nil, entity.Batch{ID: headBatchID}, nil)
 	require.NoError(t, err)
 
-	status, _, err := New(changesetfake.New()).Status(ctx, id)
+	status, _, err := New(testCfg, changesetfake.New()).Status(ctx, id)
 	require.NoError(t, err)
 	assert.Equal(t, entity.BuildStatusFailed, status)
 }
 
 func TestRunner_Cancel(t *testing.T) {
-	r := New(changesetfake.New())
+	r := New(testCfg, changesetfake.New())
 	assert.NoError(t, r.Cancel(context.Background(), entity.BuildID{ID: "any"}))
 }

--- a/submitqueue/extension/changeprovider/fake/fake.go
+++ b/submitqueue/extension/changeprovider/fake/fake.go
@@ -39,12 +39,16 @@ const tokenError = "provider-error"
 
 // provider is a changeprovider.ChangeProvider that returns empty change info
 // unless a marker token in a change URI requests a failure.
-type provider struct{}
+type provider struct {
+	// cfg is the per-queue identity this provider was built for.
+	cfg changeprovider.Config
+}
 
-// New returns a changeprovider.ChangeProvider that defaults to returning one
-// empty ChangeInfo per URI and honors marker tokens embedded in change URIs.
-func New() changeprovider.ChangeProvider {
-	return provider{}
+// New returns a changeprovider.ChangeProvider bound to the queue named in cfg
+// that defaults to returning one empty ChangeInfo per URI and honors marker
+// tokens embedded in change URIs.
+func New(cfg changeprovider.Config) changeprovider.ChangeProvider {
+	return provider{cfg: cfg}
 }
 
 // Get returns one ChangeInfo per URI in the request's change, unless a recognized

--- a/submitqueue/extension/changeprovider/fake/fake_test.go
+++ b/submitqueue/extension/changeprovider/fake/fake_test.go
@@ -25,8 +25,11 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/changeprovider"
 )
 
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = changeprovider.Config{QueueName: "test-queue"}
+
 func TestNew_ImplementsInterface(t *testing.T) {
-	var _ changeprovider.ChangeProvider = New()
+	var _ changeprovider.ChangeProvider = New(testCfg)
 }
 
 func TestProvider_Get_OnePerURI(t *testing.T) {
@@ -45,7 +48,7 @@ func TestProvider_Get_OnePerURI(t *testing.T) {
 		},
 	}
 
-	p := New()
+	p := New(testCfg)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			infos, err := p.Get(context.Background(), entity.Request{Change: change.Change{URIs: tt.uris}})
@@ -59,7 +62,7 @@ func TestProvider_Get_OnePerURI(t *testing.T) {
 }
 
 func TestProvider_Get_ErrorMarker(t *testing.T) {
-	p := New()
+	p := New(testCfg)
 	_, err := p.Get(context.Background(), entity.Request{Change: change.Change{
 		URIs: []string{"github://github.example.com/owner/repo/pull/1/abc?sq-fake=provider-error"},
 	}})

--- a/submitqueue/extension/changeprovider/github/provider.go
+++ b/submitqueue/extension/changeprovider/github/provider.go
@@ -17,6 +17,9 @@ import (
 
 // Params holds the dependencies for the GitHub ChangeProvider.
 type Params struct {
+	// Config is the per-queue identity handed to the Factory that built
+	// this provider.
+	Config changeprovider.Config
 	// HTTPClient is a pre-configured HTTP client. The caller is responsible for
 	// configuring the base URL (via BaseURLTransport) and auth (via a transport layer).
 	HTTPClient *http.Client
@@ -28,6 +31,8 @@ type Params struct {
 
 // provider implements the ChangeProvider interface for GitHub.
 type provider struct {
+	// cfg is the per-queue identity this provider was built for.
+	cfg          changeprovider.Config
 	httpClient   *http.Client
 	logger       *zap.SugaredLogger
 	metricsScope tally.Scope
@@ -36,6 +41,7 @@ type provider struct {
 // NewProvider creates a new GitHub ChangeProvider.
 func NewProvider(params Params) changeprovider.ChangeProvider {
 	return &provider{
+		cfg:          params.Config,
 		httpClient:   params.HTTPClient,
 		logger:       params.Logger.Named("github_changeprovider"),
 		metricsScope: params.MetricsScope.SubScope("github_changeprovider"),

--- a/submitqueue/extension/changeprovider/phabricator/provider.go
+++ b/submitqueue/extension/changeprovider/phabricator/provider.go
@@ -20,6 +20,9 @@ const queryDiffsBatchSize = 10
 
 // Params holds the dependencies for the Phabricator ChangeProvider.
 type Params struct {
+	// Config is the per-queue identity handed to the Factory that built
+	// this provider.
+	Config changeprovider.Config
 	// HTTPClient is a pre-configured HTTP client. The caller is responsible for
 	// configuring the base URL (e.g. via httpclient.NewClient) and authentication
 	// (e.g. via a RoundTripper that injects credentials) via transport layers.
@@ -31,6 +34,8 @@ type Params struct {
 }
 
 type provider struct {
+	// cfg is the per-queue identity this provider was built for.
+	cfg          changeprovider.Config
 	httpClient   *http.Client
 	logger       *zap.SugaredLogger
 	metricsScope tally.Scope
@@ -39,6 +44,7 @@ type provider struct {
 // NewProvider creates a new Phabricator ChangeProvider.
 func NewProvider(params Params) changeprovider.ChangeProvider {
 	return &provider{
+		cfg:          params.Config,
 		httpClient:   params.HTTPClient,
 		logger:       params.Logger.Named("phabricator_changeprovider"),
 		metricsScope: params.MetricsScope.SubScope("phabricator_changeprovider"),

--- a/submitqueue/extension/changeprovider/routing/provider.go
+++ b/submitqueue/extension/changeprovider/routing/provider.go
@@ -30,6 +30,9 @@ import (
 // Params holds the optional downstream providers, keyed by change type.
 // At least one must be non-nil.
 type Params struct {
+	// Config is the per-queue identity handed to the Factory that built
+	// this provider.
+	Config changeprovider.Config
 	// GitHub handles URIs that parse as GitHub change IDs.
 	GitHub changeprovider.ChangeProvider
 	// Phabricator handles URIs that parse as Phabricator change IDs.
@@ -47,6 +50,8 @@ type matchedURI struct {
 }
 
 type provider struct {
+	// cfg is the per-queue identity this provider was built for.
+	cfg         changeprovider.Config
 	github      changeprovider.ChangeProvider
 	phabricator changeprovider.ChangeProvider
 	git         changeprovider.ChangeProvider
@@ -60,6 +65,7 @@ func NewProvider(params Params) (changeprovider.ChangeProvider, error) {
 		return nil, fmt.Errorf("at least one change provider must be configured")
 	}
 	return &provider{
+		cfg:         params.Config,
 		github:      params.GitHub,
 		phabricator: params.Phabricator,
 		git:         params.Git,

--- a/submitqueue/extension/conflict/all/BUILD.bazel
+++ b/submitqueue/extension/conflict/all/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//submitqueue/entity:go_default_library",
+        "//submitqueue/extension/conflict:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/submitqueue/extension/conflict/all/all.go
+++ b/submitqueue/extension/conflict/all/all.go
@@ -26,12 +26,15 @@ import (
 
 // analyzer is a conflict.Analyzer that reports every in-flight batch as a
 // conflict, classified as ConflictTypeConservative.
-type analyzer struct{}
+type analyzer struct {
+	// cfg is the per-queue identity this analyzer was built for.
+	cfg conflict.Config
+}
 
 // New returns a conflict.Analyzer that reports a conflict against every
-// in-flight batch.
-func New() conflict.Analyzer {
-	return analyzer{}
+// in-flight batch, bound to the queue named in cfg.
+func New(cfg conflict.Config) conflict.Analyzer {
+	return analyzer{cfg: cfg}
 }
 
 // Analyze returns one ConflictTypeConservative Conflict per in-flight batch,

--- a/submitqueue/extension/conflict/all/all_test.go
+++ b/submitqueue/extension/conflict/all/all_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/submitqueue/submitqueue/entity"
+	"github.com/uber/submitqueue/submitqueue/extension/conflict"
 )
 
 func TestAnalyze(t *testing.T) {
@@ -56,7 +57,7 @@ func TestAnalyze(t *testing.T) {
 		},
 	}
 
-	a := New()
+	a := New(conflict.Config{QueueName: "test-queue"})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := a.Analyze(context.Background(), batch, tt.inFlight)

--- a/submitqueue/extension/conflict/fake/fake.go
+++ b/submitqueue/extension/conflict/fake/fake.go
@@ -40,16 +40,19 @@ func FailAlways(entity.Batch, []entity.Batch) bool { return true }
 // analyzerFake decorates a delegate Analyzer, injecting an error when failOn
 // reports true.
 type analyzerFake struct {
+	// cfg is the per-queue identity this analyzer was built for.
+	cfg      conflict.Config
 	delegate conflict.Analyzer
 	failOn   FailOn
 }
 
-// New returns a conflict.Analyzer that delegates to the given analyzer but
-// returns an error when failOn reports true for the call's inputs. The delegate
-// is the existing analyzer implementation to wrap (e.g. all or none). A nil
-// failOn never injects an error (pure passthrough).
-func New(delegate conflict.Analyzer, failOn FailOn) conflict.Analyzer {
-	return analyzerFake{delegate: delegate, failOn: failOn}
+// New returns a conflict.Analyzer bound to the queue named in cfg that
+// delegates to the given analyzer but returns an error when failOn reports true
+// for the call's inputs. The delegate is the existing analyzer implementation to
+// wrap (e.g. all or none). A nil failOn never injects an error (pure
+// passthrough).
+func New(cfg conflict.Config, delegate conflict.Analyzer, failOn FailOn) conflict.Analyzer {
+	return analyzerFake{cfg: cfg, delegate: delegate, failOn: failOn}
 }
 
 // Analyze returns an error when failOn reports true; otherwise it delegates to

--- a/submitqueue/extension/conflict/fake/fake_test.go
+++ b/submitqueue/extension/conflict/fake/fake_test.go
@@ -26,13 +26,16 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/conflict/none"
 )
 
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = conflict.Config{QueueName: "test-queue"}
+
 func TestNew_ImplementsInterface(t *testing.T) {
-	var _ conflict.Analyzer = New(none.New(), nil)
+	var _ conflict.Analyzer = New(testCfg, none.New(testCfg), nil)
 }
 
 func TestAnalyze_DelegatesWhenNoFailOn(t *testing.T) {
 	// Delegate to "all": one conflict per in-flight batch. nil failOn -> passthrough.
-	a := New(all.New(), nil)
+	a := New(testCfg, all.New(testCfg), nil)
 	got, err := a.Analyze(context.Background(),
 		entity.Batch{ID: "q/batch/1"},
 		[]entity.Batch{{ID: "q/batch/2"}, {ID: "q/batch/3"}})
@@ -41,21 +44,21 @@ func TestAnalyze_DelegatesWhenNoFailOn(t *testing.T) {
 }
 
 func TestAnalyze_DelegatesWhenFailOnFalse(t *testing.T) {
-	a := New(none.New(), func(entity.Batch, []entity.Batch) bool { return false })
+	a := New(testCfg, none.New(testCfg), func(entity.Batch, []entity.Batch) bool { return false })
 	got, err := a.Analyze(context.Background(), entity.Batch{ID: "q/batch/1"}, nil)
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
 
 func TestAnalyze_FailAlways(t *testing.T) {
-	a := New(none.New(), FailAlways)
+	a := New(testCfg, none.New(testCfg), FailAlways)
 	_, err := a.Analyze(context.Background(), entity.Batch{ID: "q/batch/1"}, nil)
 	require.Error(t, err)
 }
 
 func TestAnalyze_FailOnPredicate(t *testing.T) {
 	// Inject an error only for a specific batch ID.
-	a := New(none.New(), func(b entity.Batch, _ []entity.Batch) bool {
+	a := New(testCfg, none.New(testCfg), func(b entity.Batch, _ []entity.Batch) bool {
 		return b.ID == "q/batch/bad"
 	})
 

--- a/submitqueue/extension/conflict/fileoverlap/BUILD.bazel
+++ b/submitqueue/extension/conflict/fileoverlap/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     deps = [
         "//submitqueue/core/changeset/fake:go_default_library",
         "//submitqueue/entity:go_default_library",
+        "//submitqueue/extension/conflict:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/submitqueue/extension/conflict/fileoverlap/fileoverlap.go
+++ b/submitqueue/extension/conflict/fileoverlap/fileoverlap.go
@@ -33,14 +33,16 @@ import (
 // analyzer reports a conflict between batches that change a common file. The
 // files a batch changes are resolved from each batch's change details.
 type analyzer struct {
+	// cfg is the per-queue identity this analyzer was built for.
+	cfg      conflict.Config
 	resolver changeset.Resolver
 }
 
 // New returns a conflict.Analyzer that flags an in-flight batch as conflicting
-// when it changes a file the candidate batch also changes. The resolver
-// resolves each batch's changed files.
-func New(resolver changeset.Resolver) conflict.Analyzer {
-	return analyzer{resolver: resolver}
+// when it changes a file the candidate batch also changes, bound to the queue
+// named in cfg. The resolver resolves each batch's changed files.
+func New(cfg conflict.Config, resolver changeset.Resolver) conflict.Analyzer {
+	return analyzer{cfg: cfg, resolver: resolver}
 }
 
 // Analyze returns one ConflictTypeTargetOverlap Conflict per in-flight batch

--- a/submitqueue/extension/conflict/fileoverlap/fileoverlap_test.go
+++ b/submitqueue/extension/conflict/fileoverlap/fileoverlap_test.go
@@ -24,6 +24,7 @@ import (
 
 	changesetfake "github.com/uber/submitqueue/submitqueue/core/changeset/fake"
 	"github.com/uber/submitqueue/submitqueue/entity"
+	"github.com/uber/submitqueue/submitqueue/extension/conflict"
 )
 
 // detailed builds a BatchChanges whose single change touches the given files.
@@ -95,7 +96,7 @@ func TestAnalyze(t *testing.T) {
 				inFlight = append(inFlight, entity.Batch{ID: id})
 			}
 
-			got, err := New(resolver).Analyze(context.Background(), entity.Batch{ID: "cand"}, inFlight)
+			got, err := New(conflict.Config{QueueName: "test-queue"}, resolver).Analyze(context.Background(), entity.Batch{ID: "cand"}, inFlight)
 			require.NoError(t, err)
 
 			var ids []string
@@ -109,7 +110,7 @@ func TestAnalyze(t *testing.T) {
 }
 
 func TestAnalyze_EmptyInFlight(t *testing.T) {
-	got, err := New(changesetfake.New()).Analyze(context.Background(), entity.Batch{ID: "cand"}, nil)
+	got, err := New(conflict.Config{QueueName: "test-queue"}, changesetfake.New()).Analyze(context.Background(), entity.Batch{ID: "cand"}, nil)
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -118,6 +119,6 @@ func TestAnalyze_ResolverError(t *testing.T) {
 	sentinel := errors.New("resolve failed")
 	resolver := changesetfake.New().FailWith(sentinel)
 
-	_, err := New(resolver).Analyze(context.Background(), entity.Batch{ID: "cand"}, []entity.Batch{{ID: "x"}})
+	_, err := New(conflict.Config{QueueName: "test-queue"}, resolver).Analyze(context.Background(), entity.Batch{ID: "cand"}, []entity.Batch{{ID: "x"}})
 	require.ErrorIs(t, err, sentinel)
 }

--- a/submitqueue/extension/conflict/none/BUILD.bazel
+++ b/submitqueue/extension/conflict/none/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//submitqueue/entity:go_default_library",
+        "//submitqueue/extension/conflict:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/submitqueue/extension/conflict/none/none.go
+++ b/submitqueue/extension/conflict/none/none.go
@@ -25,11 +25,15 @@ import (
 )
 
 // analyzer is a conflict.Analyzer that always returns no conflicts.
-type analyzer struct{}
+type analyzer struct {
+	// cfg is the per-queue identity this analyzer was built for.
+	cfg conflict.Config
+}
 
-// New returns a conflict.Analyzer that never reports a conflict.
-func New() conflict.Analyzer {
-	return analyzer{}
+// New returns a conflict.Analyzer that never reports a conflict, bound to the
+// queue named in cfg.
+func New(cfg conflict.Config) conflict.Analyzer {
+	return analyzer{cfg: cfg}
 }
 
 // Analyze always returns a nil conflict slice, regardless of inputs.

--- a/submitqueue/extension/conflict/none/none_test.go
+++ b/submitqueue/extension/conflict/none/none_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/submitqueue/submitqueue/entity"
+	"github.com/uber/submitqueue/submitqueue/extension/conflict"
 )
 
 func TestAnalyze(t *testing.T) {
@@ -42,7 +43,7 @@ func TestAnalyze(t *testing.T) {
 		},
 	}
 
-	a := New()
+	a := New(conflict.Config{QueueName: "test-queue"})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := a.Analyze(context.Background(), batch, tt.inFlight)

--- a/submitqueue/extension/mergechecker/fake/fake.go
+++ b/submitqueue/extension/mergechecker/fake/fake.go
@@ -43,12 +43,15 @@ const (
 
 // checker is a mergechecker.MergeChecker that reports changes as mergeable
 // unless a marker token in a change URI requests otherwise.
-type checker struct{}
+type checker struct {
+	// cfg is the per-queue identity this checker was built for.
+	cfg mergechecker.Config
+}
 
-// New returns a mergechecker.MergeChecker that defaults to mergeable and honors
-// marker tokens embedded in change URIs.
-func New() mergechecker.MergeChecker {
-	return checker{}
+// New returns a mergechecker.MergeChecker bound to the queue named in cfg that
+// defaults to mergeable and honors marker tokens embedded in change URIs.
+func New(cfg mergechecker.Config) mergechecker.MergeChecker {
+	return checker{cfg: cfg}
 }
 
 // Check reports the change as mergeable unless a recognized marker token is

--- a/submitqueue/extension/mergechecker/fake/fake_test.go
+++ b/submitqueue/extension/mergechecker/fake/fake_test.go
@@ -25,8 +25,11 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/mergechecker"
 )
 
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = mergechecker.Config{QueueName: "test-queue"}
+
 func TestNew_ImplementsInterface(t *testing.T) {
-	var _ mergechecker.MergeChecker = New()
+	var _ mergechecker.MergeChecker = New(testCfg)
 }
 
 func TestChecker_Check(t *testing.T) {
@@ -64,7 +67,7 @@ func TestChecker_Check(t *testing.T) {
 		},
 	}
 
-	c := New()
+	c := New(testCfg)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := c.Check(context.Background(), entity.Request{Change: change.Change{URIs: tt.uris}})

--- a/submitqueue/extension/mergechecker/github/checker.go
+++ b/submitqueue/extension/mergechecker/github/checker.go
@@ -32,6 +32,9 @@ import (
 
 // Params holds the dependencies for the GitHub MergeChecker.
 type Params struct {
+	// Config is the per-queue identity handed to the Factory that built this
+	// merge checker.
+	Config mergechecker.Config
 	// HTTPClient is a pre-configured HTTP client. The caller is responsible for
 	// configuring the base URL (via BaseURLTransport) and auth (via a transport layer).
 	HTTPClient *http.Client
@@ -43,6 +46,8 @@ type Params struct {
 
 // mergeChecker implements the mergechecker.MergeChecker interface using the GitHub GraphQL API.
 type mergeChecker struct {
+	// cfg is the per-queue identity this checker was built for.
+	cfg          mergechecker.Config
 	httpClient   *http.Client
 	logger       *zap.SugaredLogger
 	metricsScope tally.Scope
@@ -51,9 +56,11 @@ type mergeChecker struct {
 // Verify mergeChecker implements mergechecker.MergeChecker at compile time.
 var _ mergechecker.MergeChecker = (*mergeChecker)(nil)
 
-// NewMergeChecker creates a new GitHub MergeChecker.
+// NewMergeChecker creates a new GitHub MergeChecker bound to the queue named in
+// params.Config.
 func NewMergeChecker(params Params) mergechecker.MergeChecker {
 	return &mergeChecker{
+		cfg:          params.Config,
 		httpClient:   params.HTTPClient,
 		logger:       params.Logger.Named("github_mergechecker"),
 		metricsScope: params.MetricsScope.SubScope("github_mergechecker"),

--- a/submitqueue/extension/scorer/composite/scorer.go
+++ b/submitqueue/extension/scorer/composite/scorer.go
@@ -63,6 +63,8 @@ func Avg(scores map[string]float64) float64 {
 
 // compositeScorer combines multiple named scorers into a single score using a reduce function.
 type compositeScorer struct {
+	// cfg is the per-queue identity this scorer was built for.
+	cfg scorer.Config
 	// scorers maps scorer names to their implementations.
 	scorers map[string]scorer.Scorer
 	// reduce combines named scores into a single value.
@@ -71,10 +73,11 @@ type compositeScorer struct {
 	scope tally.Scope
 }
 
-// New creates a composite Scorer that evaluates all named child scorers and combines
-// their results using the given reduce function.
+// New creates a composite Scorer bound to the queue named in cfg that evaluates
+// all named child scorers and combines their results using the given reduce
+// function.
 // Panics if scorers is empty or reduce is nil.
-func New(scorers map[string]scorer.Scorer, reduce ReduceFunc, scope tally.Scope) scorer.Scorer {
+func New(cfg scorer.Config, scorers map[string]scorer.Scorer, reduce ReduceFunc, scope tally.Scope) scorer.Scorer {
 	if len(scorers) == 0 {
 		panic("composite.New: scorers must not be empty")
 	}
@@ -82,6 +85,7 @@ func New(scorers map[string]scorer.Scorer, reduce ReduceFunc, scope tally.Scope)
 		panic("composite.New: reduce must not be nil")
 	}
 	return &compositeScorer{
+		cfg:     cfg,
 		scorers: scorers,
 		reduce:  reduce,
 		scope:   scope,

--- a/submitqueue/extension/scorer/composite/scorer_test.go
+++ b/submitqueue/extension/scorer/composite/scorer_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/scorer"
 )
 
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = scorer.Config{QueueName: "test-queue"}
+
 // fixedScorer always returns a fixed score.
 type fixedScorer struct {
 	score float64
@@ -98,7 +101,7 @@ func TestScorer_Score(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := New(tt.scorers, tt.reduce, tally.NoopScope)
+			s := New(testCfg, tt.scorers, tt.reduce, tally.NoopScope)
 			got, err := s.Score(context.Background(), entity.Batch{})
 			require.NoError(t, err)
 			assert.InDelta(t, tt.want, got, 1e-9)
@@ -107,7 +110,7 @@ func TestScorer_Score(t *testing.T) {
 }
 
 func TestScorer_Score_ChildError(t *testing.T) {
-	s := New(map[string]scorer.Scorer{
+	s := New(testCfg, map[string]scorer.Scorer{
 		"error": &errorScorer{},
 		"files": &fixedScorer{0.9},
 	}, Min, tally.NoopScope)
@@ -117,13 +120,13 @@ func TestScorer_Score_ChildError(t *testing.T) {
 
 func TestNew_EmptyScorers(t *testing.T) {
 	assert.Panics(t, func() {
-		New(map[string]scorer.Scorer{}, Min, tally.NoopScope)
+		New(testCfg, map[string]scorer.Scorer{}, Min, tally.NoopScope)
 	})
 }
 
 func TestNew_NilReduce(t *testing.T) {
 	assert.Panics(t, func() {
-		New(map[string]scorer.Scorer{"files": &fixedScorer{0.9}}, nil, tally.NoopScope)
+		New(testCfg, map[string]scorer.Scorer{"files": &fixedScorer{0.9}}, nil, tally.NoopScope)
 	})
 }
 
@@ -136,7 +139,7 @@ func TestReduceFunc_ReceivesNames(t *testing.T) {
 		return scores["files"]
 	}
 
-	s := New(map[string]scorer.Scorer{
+	s := New(testCfg, map[string]scorer.Scorer{
 		"files": &fixedScorer{0.9},
 		"deps":  &fixedScorer{0.95},
 	}, custom, tally.NoopScope)

--- a/submitqueue/extension/scorer/fake/fake.go
+++ b/submitqueue/extension/scorer/fake/fake.go
@@ -39,16 +39,19 @@ const tokenError = "score-error"
 // scorerFake decorates a delegate Scorer, injecting an error when a change URI
 // carries the failure marker. It resolves the batch itself to inspect URIs.
 type scorerFake struct {
+	// cfg is the per-queue identity this scorer was built for.
+	cfg      scorer.Config
 	resolver changeset.Resolver
 	delegate scorer.Scorer
 }
 
-// New returns a scorer.Scorer that delegates to the given scorer but returns an
-// error when a change URI carries the "sq-fake=score-error" marker. The resolver
-// resolves the batch's changes so the marker can be inspected; the delegate is the
-// existing scorer implementation to wrap (e.g. heuristic or composite).
-func New(resolver changeset.Resolver, delegate scorer.Scorer) scorer.Scorer {
-	return scorerFake{resolver: resolver, delegate: delegate}
+// New returns a scorer.Scorer bound to the queue named in cfg that delegates to
+// the given scorer but returns an error when a change URI carries the
+// "sq-fake=score-error" marker. The resolver resolves the batch's changes so the
+// marker can be inspected; the delegate is the existing scorer implementation to
+// wrap (e.g. heuristic or composite).
+func New(cfg scorer.Config, resolver changeset.Resolver, delegate scorer.Scorer) scorer.Scorer {
+	return scorerFake{cfg: cfg, resolver: resolver, delegate: delegate}
 }
 
 // Score returns an error when a change URI carries the failure marker; otherwise

--- a/submitqueue/extension/scorer/fake/fake_test.go
+++ b/submitqueue/extension/scorer/fake/fake_test.go
@@ -28,10 +28,13 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/scorer/heuristic"
 )
 
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = scorer.Config{QueueName: "test-queue"}
+
 const batchID = "q/batch/1"
 
 func TestNew_ImplementsInterface(t *testing.T) {
-	var _ scorer.Scorer = New(nil, nil)
+	var _ scorer.Scorer = New(testCfg, nil, nil)
 }
 
 // resolverFor returns a changeset resolver seeded so that batchID's detailed
@@ -47,6 +50,7 @@ func resolverFor(uris ...string) changeset.Resolver {
 // delegate returns a heuristic scorer (backed by resolver) that scores every batch at want.
 func delegate(resolver changeset.Resolver, want float64) scorer.Scorer {
 	return heuristic.New(
+		testCfg,
 		resolver,
 		[]heuristic.Bucket{{Min: 0, Max: 1<<31 - 1, Score: want}},
 		func(_ context.Context, c entity.BatchChanges) (int, error) { return len(c.Changes), nil },
@@ -56,7 +60,7 @@ func delegate(resolver changeset.Resolver, want float64) scorer.Scorer {
 
 func TestScore_DelegatesWhenUnmarked(t *testing.T) {
 	r := resolverFor("github://github.example.com/o/r/pull/1/a")
-	s := New(r, delegate(r, 0.7))
+	s := New(testCfg, r, delegate(r, 0.7))
 	got, err := s.Score(context.Background(), entity.Batch{ID: batchID})
 	require.NoError(t, err)
 	assert.Equal(t, 0.7, got)
@@ -64,7 +68,7 @@ func TestScore_DelegatesWhenUnmarked(t *testing.T) {
 
 func TestScore_ErrorMarker(t *testing.T) {
 	r := resolverFor("github://github.example.com/o/r/pull/1/a?sq-fake=score-error")
-	s := New(r, delegate(r, 0.7))
+	s := New(testCfg, r, delegate(r, 0.7))
 	_, err := s.Score(context.Background(), entity.Batch{ID: batchID})
 	require.Error(t, err)
 }

--- a/submitqueue/extension/scorer/heuristic/BUILD.bazel
+++ b/submitqueue/extension/scorer/heuristic/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     deps = [
         "//submitqueue/core/changeset/fake:go_default_library",
         "//submitqueue/entity:go_default_library",
+        "//submitqueue/extension/scorer:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@com_github_uber_go_tally//:go_default_library",

--- a/submitqueue/extension/scorer/heuristic/scorer.go
+++ b/submitqueue/extension/scorer/heuristic/scorer.go
@@ -41,6 +41,8 @@ type Bucket struct {
 // heuristicScorer computes a success probability by bucketing a metric extracted from a batch of changes.
 // It follows the Java HeuristicsBasedSuccessPredictor pattern.
 type heuristicScorer struct {
+	// cfg is the per-queue identity this scorer was built for.
+	cfg scorer.Config
 	// resolver resolves the batch identity into its detailed changes.
 	resolver changeset.Resolver
 	// buckets is the list of ranges to match against.
@@ -51,13 +53,15 @@ type heuristicScorer struct {
 	scope tally.Scope
 }
 
-// New creates a new heuristic Scorer with the given resolver, buckets and value function.
+// New creates a new heuristic Scorer bound to the queue named in cfg, with the
+// given resolver, buckets and value function.
 // Panics if valueFunc is nil.
-func New(resolver changeset.Resolver, buckets []Bucket, valueFunc ValueFunc, scope tally.Scope) scorer.Scorer {
+func New(cfg scorer.Config, resolver changeset.Resolver, buckets []Bucket, valueFunc ValueFunc, scope tally.Scope) scorer.Scorer {
 	if valueFunc == nil {
 		panic("heuristic.New: valueFunc must not be nil")
 	}
 	return &heuristicScorer{
+		cfg:       cfg,
 		resolver:  resolver,
 		buckets:   buckets,
 		valueFunc: valueFunc,

--- a/submitqueue/extension/scorer/heuristic/scorer_test.go
+++ b/submitqueue/extension/scorer/heuristic/scorer_test.go
@@ -23,7 +23,11 @@ import (
 	"github.com/uber-go/tally"
 	changesetfake "github.com/uber/submitqueue/submitqueue/core/changeset/fake"
 	"github.com/uber/submitqueue/submitqueue/entity"
+	"github.com/uber/submitqueue/submitqueue/extension/scorer"
 )
+
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = scorer.Config{QueueName: "test-queue"}
 
 // staticValue returns a ValueFunc that always returns the given value.
 func staticValue(value int) ValueFunc {
@@ -107,7 +111,7 @@ func TestScorer_Score(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := New(changesetfake.New(), tt.buckets, tt.valueFunc, tally.NoopScope)
+			s := New(testCfg, changesetfake.New(), tt.buckets, tt.valueFunc, tally.NoopScope)
 			got, err := s.Score(context.Background(), entity.Batch{})
 			if tt.wantErr {
 				require.Error(t, err)
@@ -123,13 +127,13 @@ func TestScorer_Score_ValueFuncError(t *testing.T) {
 	failing := func(_ context.Context, _ entity.BatchChanges) (int, error) {
 		return 0, assert.AnError
 	}
-	s := New(changesetfake.New(), []Bucket{{Min: 0, Max: 10, Score: 0.9}}, failing, tally.NoopScope)
+	s := New(testCfg, changesetfake.New(), []Bucket{{Min: 0, Max: 10, Score: 0.9}}, failing, tally.NoopScope)
 	_, err := s.Score(context.Background(), entity.Batch{})
 	require.Error(t, err)
 }
 
 func TestNew_NilValueFunc(t *testing.T) {
 	assert.Panics(t, func() {
-		New(changesetfake.New(), []Bucket{{Min: 0, Max: 10, Score: 0.85}}, nil, tally.NoopScope)
+		New(testCfg, changesetfake.New(), []Bucket{{Min: 0, Max: 10, Score: 0.85}}, nil, tally.NoopScope)
 	})
 }

--- a/submitqueue/extension/speculation/speculator/standard/BUILD.bazel
+++ b/submitqueue/extension/speculation/speculator/standard/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//submitqueue/extension/speculation/allocator/sticky:go_default_library",
         "//submitqueue/extension/speculation/generator/bestfirst:go_default_library",
         "//submitqueue/extension/speculation/generator/mock:go_default_library",
+        "//submitqueue/extension/speculation/speculator:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@org_uber_go_mock//gomock:go_default_library",

--- a/submitqueue/extension/speculation/speculator/standard/standard.go
+++ b/submitqueue/extension/speculation/speculator/standard/standard.go
@@ -31,14 +31,16 @@ import (
 // spec is a speculator.Speculator that opens the generator's candidate stream
 // and hands it to the allocator to spend the build budget.
 type spec struct {
+	// cfg is the per-queue identity this speculator was built for.
+	cfg   speculator.Config
 	gen   generator.Generator
 	alloc allocator.Allocator
 }
 
-// New returns the standard speculator.Speculator, composing a Generator and an
-// Allocator.
-func New(gen generator.Generator, alloc allocator.Allocator) speculator.Speculator {
-	return spec{gen: gen, alloc: alloc}
+// New returns the standard speculator.Speculator bound to the queue named in
+// cfg, composing a Generator and an Allocator.
+func New(cfg speculator.Config, gen generator.Generator, alloc allocator.Allocator) speculator.Speculator {
+	return spec{cfg: cfg, gen: gen, alloc: alloc}
 }
 
 // Speculate opens the generator over the queue's batches, then lets the

--- a/submitqueue/extension/speculation/speculator/standard/standard_test.go
+++ b/submitqueue/extension/speculation/speculator/standard/standard_test.go
@@ -28,7 +28,11 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/speculation/allocator/sticky"
 	"github.com/uber/submitqueue/submitqueue/extension/speculation/generator/bestfirst"
 	generatormock "github.com/uber/submitqueue/submitqueue/extension/speculation/generator/mock"
+	"github.com/uber/submitqueue/submitqueue/extension/speculation/speculator"
 )
+
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = speculator.Config{QueueName: "test-queue"}
 
 // assumptionFor returns what a path assumes about a given dependency batch.
 func assumptionFor(p entity.SpeculationPath, dep string) entity.DependencyAssumption {
@@ -52,7 +56,7 @@ func TestComposed_EndToEnd_NaivePair(t *testing.T) {
 	}
 
 	// bestfirst generator + sticky allocator with a 2-build budget.
-	spec := New(bestfirst.New(constScorer{0.9}), sticky.New(2))
+	spec := New(testCfg, bestfirst.New(constScorer{0.9}), sticky.New(2))
 	got, err := spec.Speculate(context.Background(), batches, nil)
 	require.NoError(t, err)
 
@@ -88,7 +92,7 @@ func TestComposed_WiresGeneratorIntoAllocator(t *testing.T) {
 	gen.EXPECT().Generate(gomock.Any(), batches).Return(iter, nil)
 	alloc.EXPECT().Allocate(gomock.Any(), pathSets, iter).Return(want, nil)
 
-	got, err := New(gen, alloc).Speculate(context.Background(), batches, pathSets)
+	got, err := New(testCfg, gen, alloc).Speculate(context.Background(), batches, pathSets)
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -103,7 +107,7 @@ func TestComposed_PropagatesGeneratorError(t *testing.T) {
 	gen.EXPECT().Generate(gomock.Any(), gomock.Any()).Return(nil, errGenerate)
 	// Allocate must not be called when Generate fails (no alloc.EXPECT()).
 
-	_, err := New(gen, alloc).Speculate(context.Background(), nil, nil)
+	_, err := New(testCfg, gen, alloc).Speculate(context.Background(), nil, nil)
 	require.ErrorIs(t, err, errGenerate)
 }
 
@@ -118,7 +122,7 @@ func TestComposed_PropagatesContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	spec := New(bestfirst.New(constScorer{0.9}), sticky.New(2))
+	spec := New(testCfg, bestfirst.New(constScorer{0.9}), sticky.New(2))
 	got, err := spec.Speculate(ctx, batches, nil)
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Nil(t, got)

--- a/submitqueue/extension/validator/composite/validator.go
+++ b/submitqueue/extension/validator/composite/validator.go
@@ -24,13 +24,16 @@ import (
 
 // compositeValidator runs all validators and joins their errors.
 type compositeValidator struct {
+	// cfg is the per-queue identity this validator was built for.
+	cfg validator.Config
 	// validators is the set of validators to run.
 	validators []validator.Validator
 }
 
-// New creates a Validator that evaluates all child validators and joins their errors.
-func New(validators []validator.Validator) validator.Validator {
-	return &compositeValidator{validators: validators}
+// New creates a Validator bound to the queue named in cfg that evaluates all
+// child validators and joins their errors.
+func New(cfg validator.Config, validators []validator.Validator) validator.Validator {
+	return &compositeValidator{cfg: cfg, validators: validators}
 }
 
 func (c *compositeValidator) Validate(ctx context.Context, request entity.Request) error {

--- a/submitqueue/extension/validator/composite/validator_test.go
+++ b/submitqueue/extension/validator/composite/validator_test.go
@@ -90,7 +90,7 @@ func TestNew(t *testing.T) {
 			v2 := validatormock.NewMockValidator(ctrl)
 			validators := tt.setup(v1, v2)
 
-			v := New(validators)
+			v := New(validator.Config{QueueName: "test-queue"}, validators)
 
 			err := v.Validate(context.Background(), entity.Request{})
 			if len(tt.wantErrs) == 0 {

--- a/submitqueue/extension/validator/fake/fake.go
+++ b/submitqueue/extension/validator/fake/fake.go
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package fake provides a validator.Validator that always passes and a
-// validator.Factory that returns it. Intended for examples, tests, and default
-// wiring when no custom validation is needed.
+// Package fake provides a validator.Validator that always passes. Intended for
+// examples, tests, and default wiring when no custom validation is needed.
 package fake
 
 import (
@@ -24,24 +23,17 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/validator"
 )
 
-type fakeValidator struct{}
+type fakeValidator struct {
+	// cfg is the per-queue identity this validator was built for.
+	cfg validator.Config
+}
 
-// New returns a validator.Validator that always passes (returns nil).
-func New() validator.Validator {
-	return fakeValidator{}
+// New returns a validator.Validator bound to the queue named in cfg that always
+// passes (returns nil).
+func New(cfg validator.Config) validator.Validator {
+	return fakeValidator{cfg: cfg}
 }
 
 func (fakeValidator) Validate(context.Context, entity.Request) error {
 	return nil
-}
-
-type fakeFactory struct{}
-
-// NewFactory returns a validator.Factory that always returns a passing validator.
-func NewFactory() validator.Factory {
-	return fakeFactory{}
-}
-
-func (fakeFactory) For(validator.Config) (validator.Validator, error) {
-	return fakeValidator{}, nil
 }

--- a/submitqueue/extension/validator/fake/fake_test.go
+++ b/submitqueue/extension/validator/fake/fake_test.go
@@ -23,22 +23,14 @@ import (
 	"github.com/uber/submitqueue/submitqueue/extension/validator"
 )
 
+// testCfg is the per-queue identity used by every case in this file.
+var testCfg = validator.Config{QueueName: "test-queue"}
+
 func TestNew_ImplementsInterface(t *testing.T) {
-	var _ validator.Validator = New()
+	var _ validator.Validator = New(testCfg)
 }
 
 func TestNew_AlwaysPasses(t *testing.T) {
-	v := New()
-	assert.NoError(t, v.Validate(context.Background(), entity.Request{}))
-}
-
-func TestNewFactory_ImplementsInterface(t *testing.T) {
-	var _ validator.Factory = NewFactory()
-}
-
-func TestNewFactory_ReturnsPassingValidator(t *testing.T) {
-	f := NewFactory()
-	v, err := f.For(validator.Config{QueueName: "test-queue"})
-	assert.NoError(t, err)
+	v := New(testCfg)
 	assert.NoError(t, v.Validate(context.Background(), entity.Request{}))
 }

--- a/submitqueue/orchestrator/controller/batch/batch_test.go
+++ b/submitqueue/orchestrator/controller/batch/batch_test.go
@@ -43,6 +43,10 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+// analyzerCfg is the per-queue identity handed to the conflict analyzer in
+// cases that do not exercise per-queue routing.
+var analyzerCfg = conflict.Config{QueueName: "test-queue"}
+
 func batchWithState(batch entity.Batch, state entity.BatchState) entity.Batch {
 	batch.State = state
 	return batch
@@ -155,7 +159,7 @@ func newTestController(t *testing.T, ctrl *gomock.Controller, cnt *countermock.M
 	}
 
 	if analyzer == nil {
-		analyzer = all.New()
+		analyzer = all.New(analyzerCfg)
 	}
 
 	mockPub := queuemock.NewMockPublisher(ctrl)
@@ -285,7 +289,7 @@ func TestController_Process_StampsQueueOnSpeculatePayload(t *testing.T) {
 	mockStorage.EXPECT().GetRequestStore().Return(mockReqStore).AnyTimes()
 
 	analyzerFactory := conflictmock.NewMockFactory(ctrl)
-	analyzerFactory.EXPECT().For(gomock.Any()).Return(all.New(), nil).AnyTimes()
+	analyzerFactory.EXPECT().For(gomock.Any()).Return(all.New(analyzerCfg), nil).AnyTimes()
 	controller := NewController(
 		zaptest.NewLogger(t).Sugar(), tally.NoopScope, registry, staticCounterFactory{counter: newSequentialCounter(ctrl)},
 		storageFactoryFor(ctrl, mockStorage), analyzerFactory, topickey.TopicKeyBatch, "orchestrator-batch",
@@ -367,7 +371,7 @@ func TestController_Process_PublishesBatchedLog(t *testing.T) {
 	require.NoError(t, err)
 
 	analyzerFactory := conflictmock.NewMockFactory(ctrl)
-	analyzerFactory.EXPECT().For(gomock.Any()).Return(all.New(), nil).AnyTimes()
+	analyzerFactory.EXPECT().For(gomock.Any()).Return(all.New(analyzerCfg), nil).AnyTimes()
 	controller := NewController(
 		zaptest.NewLogger(t).Sugar(), tally.NoopScope, registry, staticCounterFactory{counter: newSequentialCounter(ctrl)},
 		storageFactoryFor(ctrl, mockStorage), analyzerFactory, topickey.TopicKeyBatch, "orchestrator-batch",
@@ -822,7 +826,7 @@ func TestController_Process_CASLostToCancel(t *testing.T) {
 	require.NoError(t, err)
 
 	analyzerFactory := conflictmock.NewMockFactory(ctrl)
-	analyzerFactory.EXPECT().For(gomock.Any()).Return(all.New(), nil).AnyTimes()
+	analyzerFactory.EXPECT().For(gomock.Any()).Return(all.New(analyzerCfg), nil).AnyTimes()
 	controller := NewController(
 		zaptest.NewLogger(t).Sugar(), tally.NoopScope, registry, staticCounterFactory{counter: newSequentialCounter(ctrl)},
 		storageFactoryFor(ctrl, mockStorage), analyzerFactory, topickey.TopicKeyBatch, "orchestrator-batch",
@@ -992,7 +996,7 @@ func TestController_Process_ReadiesBatchBeforePublishing(t *testing.T) {
 	require.NoError(t, err)
 
 	analyzerFactory := conflictmock.NewMockFactory(ctrl)
-	analyzerFactory.EXPECT().For(conflict.Config{QueueName: request.Queue}).Return(all.New(), nil)
+	analyzerFactory.EXPECT().For(conflict.Config{QueueName: request.Queue}).Return(all.New(analyzerCfg), nil)
 	controller := NewController(
 		zaptest.NewLogger(t).Sugar(), tally.NoopScope, registry, staticCounterFactory{counter: cnt}, storageFactoryFor(ctrl, store), analyzerFactory,
 		topickey.TopicKeyBatch, "orchestrator-batch",


### PR DESCRIPTION
## Summary

### Why?

Per-queue extensions are resolved through a `Factory` contract — `For(cfg Config) (Impl, error)`, where `Config` carries the queue name. The controllers hold up their end: `build.go:233` and `buildsignal.go:183` both call `c.buildRunners.For(buildrunner.Config{QueueName: batch.Queue})`.

The wiring layer dropped it. In `service/submitqueue/orchestrator/server/profiles.go`, `Profile` held built extension **instances** for ChangeProvider, BuildRunner, Analyzer, Scorer and Speculator. Only `Storage` held a `Factory`. So the two ends of the seam looked like this:

```go
return p.For(c.QueueName).Storage.For(c)   // forwards cfg onward
return p.For(c.QueueName).BuildRunner, nil // cfg is a map key, then dropped
```

An implementation's queue name was therefore fixed at construction. For queues listed in `byQueue` you could hand-copy the name into each profile. For `defaultProfile` you could not: one instance serves every queue without an explicit entry, so it can only ever carry one queue name — or none.

The visible symptom is the Buildkite and GitHub Actions build runners, which read `cfg.QueueName` to emit `SQ_QUEUE` / `sq_queue` for the pipeline script. Both have zero non-test callers, so nothing ever exercised the path and nothing caught the gap.

### What?

**The seam.** Every `Profile` field is now a `Factory`, and each `XFactory()` resolves the profile by name and then forwards the whole `Config` into it — the same second `For(c)` that `Storage` already used. Implementations are built per resolution, which is what `counterFactory.For` already does for the MySQL counter; anything expensive and queue-independent (the resolver, the metrics scope, the change provider's HTTP clients) is still built once in `newProfiles`. `newChangeProvider` becomes `newChangeProviderFactory`, splitting HTTP client construction from the per-queue provider that wraps it.

`withSpeculator` becomes a lazy closure that resolves the profile's scorer at the queue the speculator itself was asked for, so the fix reaches one level down. That introduces a real error path where a struct field read could not fail; it is propagated rather than yielding a speculator over a nil scorer. `ScorerFactory()` is added for symmetry — the scorer was previously reachable only through `withSpeculator`.

**The implementations.** Every impl belonging to an extension that has a `Config`+`Factory` pair now receives it: the conflict analyzers, the scorers, the validators, the change providers, the merge checkers, the fake build runners, the standard speculator, Stovepipe's two fakes, and Runway's `noop` and `fake` mergers. Impls with an existing `Params` struct gain a `Config` field, matching the Buildkite precedent; the rest take `cfg` as a leading positional parameter.

Three decisions worth a reviewer's attention:

- **`bestfirst` and `sticky` are untouched.** Only `speculator` declares a `Config` and a `Factory`; `generator` and `allocator` declare neither. They are composition internals rather than per-queue seams, so giving them a `Config` would have meant inventing two types that nothing reads.
- **Runway's mergers are stateful by design.** `fakeMergerFactory` shared one instance so its `atomic.Uint64` revision-id counter stayed unique, and `gitMergerFactory` shares one checkout. Building one per queue would have broken both. The counter moves to the host factory and is injected, which keeps ids unique process-wide while letting each merger carry its own queue identity. This also fixes an existing quirk in `noopMergerFactory`, which already built a fresh merger — and therefore a fresh counter — on every resolution. `gitMergerFactory` still shares one instance and is now the only merger factory that does not forward its `Config`, with a comment recording why.
- **`validatorfake.NewFactory` moves into the wiring.** `CLAUDE.md` reserves extension packages for contracts and implementations — deciding which impl serves which queue is host policy — so it is replaced by a `validatorFactory` adapter in the orchestrator wiring.

Four implementations deliberately still take no `Config`: `submitqueue`, `stovepipe` and `platform`'s MySQL storage/counter backends already take the queue name as a plain string and the host adapters bridge to it, and `merger/git` is the shared-checkout exception above.

The change is split into five commits — four mechanical per-family ones, then the wiring rewrite that actually fixes the bug — so it can be reviewed and bisected a family at a time.

## Test Plan

✅ `make test` — 96/96, including three new cases in `profiles_test.go`
✅ `make build` — all four service binaries
✅ `bazel test //test/integration/...` — 8/8
✅ `bazel test //test/e2e/...` — 3/3
✅ `make lint`, `make check-gazelle`, `make check-tidy`, `make check-mocks` — all clean

Mutation-checked the regression guard: reverting a single `For(c)` back to `For(Config{})` fails `TestProfilesForwardQueueNameToFactories` for both the listed-queue and default-profile cases. That test is the thing that was missing — it asserts the `Config` survives the profile lookup, which is precisely what no test covered before.

The implementation half was already covered: `buildkite_test.go:109` and `githubactions_test.go:123` assert the queue name reaches the wire. Together the two halves cover the full path from controller to CI request.

Two pre-existing issues left untouched, both unrelated to this change: `go test ./runway/extension/merger/git/...` fails outside Bazel on a machine without a hermetic git toolchain (it passes under `bazel test`), and `go vet` reports `copylocks` on protobuf `MessageState` in the mergesignal tests.
