### PR TITLE
build(go): upgrade toolchain to Go 1.25.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,7 +28,7 @@ use_repo(protoc, "toolchains_protoc_hub")
 
 register_toolchains("@toolchains_protoc_hub//:all")
 
-GO_VERSION = "1.24.5"
+GO_VERSION = "1.25.0"
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 

--- a/doc/howto/DEVELOPMENT.md
+++ b/doc/howto/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Go 1.24+** — needed for `gopls`, `go mod`, and installing protoc plugins. Download from [go.dev/dl](https://go.dev/dl/). Note: Bazel manages its own Go toolchain for builds, but a local Go installation is required for editor tooling and dependency management.
+- **Go 1.25+** — needed for `gopls`, `go mod`, and installing protoc plugins. Download from [go.dev/dl](https://go.dev/dl/). Note: Bazel manages its own Go toolchain for builds, but a local Go installation is required for editor tooling and dependency management.
 - **Docker** and **Docker Compose** — for integration and e2e tests, and for running services locally.
 - **direnv** (recommended) — automatically loads `.envrc` so you can use `bazel` directly instead of `./tool/bazel`.
 
@@ -149,7 +149,7 @@ See [TESTING.md](TESTING.md) for the full testing guide, including integration a
 
 **`gopls` or `go mod tidy` errors:**
 - Run `go mod download` to fetch all dependencies
-- Check that your Go version matches what's in `go.mod` (currently Go 1.24)
+- Check that your Go version matches what's in `go.mod` (currently Go 1.25)
 - If using VS Code, restart the Go language server: `Ctrl+Shift+P` > "Go: Restart Language Server"
 
 ## Shell Auto-Completion

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uber/submitqueue
 
-go 1.24.5
+go 1.25.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/service/stovepipe/server/Dockerfile.debug
+++ b/service/stovepipe/server/Dockerfile.debug
@@ -1,5 +1,5 @@
 # Debug image: delve wraps a -compilation_mode=dbg binary (make build-stovepipe-linux-debug).
-FROM golang:1.24-bookworm AS dlv
+FROM golang:1.25-bookworm AS dlv
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.24.2
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary

### Why?

The toolchain was pinned at Go 1.25.0's predecessor, 1.24.5. Nothing in the tree required the bump — this is routine currency, done as its own change so that a later functional PR is not the one that first exercises a new compiler.

The pin is duplicated, and the copies are load-bearing in different places. `go.mod` feeds `go_sdk.from_file`, which resolves the hermetic SDK used for host builds and tests. `GO_VERSION` in `MODULE.bazel` is separate and drives the extra linux/amd64 SDK that the `build-*-linux` targets cross-compile the Docker images with. Bumping one and not the other is silent: the host suite stays green while the containers ship a binary built by a different compiler. They move together here.

### What?

Four pins, all mechanical:

- `go.mod` — the module's Go directive, and by extension the host SDK.
- `MODULE.bazel` — `GO_VERSION`, the linux/amd64 cross-compile SDK.
- `service/stovepipe/server/Dockerfile.debug` — the `golang:1.24-bookworm` builder stage that supplies delve becomes `golang:1.25-bookworm`, so the debug image's dlv is built by the same major version as the binary it wraps.
- `doc/howto/DEVELOPMENT.md` — the stated prerequisite and the troubleshooting note that tells you to match your local Go to `go.mod`.

Two things deliberately left alone. The `dlv@v1.24.2` on the line below the Dockerfile bump is a delve release that happens to share the number — unrelated to the Go version. And CI carries no Go pin of its own: the workflows build through Bazel and pick the toolchain up from the two pins above, so there is nothing to change under `.github/`.

No source changes. `make tidy`, `make gazelle`, and `make fmt` all produce zero drift on top of these four edits — no `go.sum`, lockfile, or `BUILD.bazel` churn.

## Test Plan

✅ `bazel run @rules_go//go -- version` — reports `go1.25.0 darwin/arm64`, confirming the hermetic SDK actually moved rather than the pin merely being edited.
✅ `make build` — 309 targets.
✅ `make test` — 98/98 pass.
✅ `make tidy` / `make gazelle` / `make fmt` — clean, no generated-file drift.

Not run locally: the Docker-based integration and e2e suites, which is where the cross-compiled linux SDK and the rebuilt debug image are first exercised end to end. Those run in CI — worth watching them here specifically rather than treating this as a no-op diff.


