### PR TITLE
feat(client): a scrollable watch, and a demo with nothing to copy or repeat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,55 @@ LAND ?= true
 WATCH ?= true
 QUEUE ?= demo-queue
 STRATEGY ?= SQUASH_REBASE
-GATEWAY_ADDR ?= localhost:8081
+# Where the client looks for the gateway. Left empty, every target below finds
+# the running stack's published port for itself — Compose picks a fresh one on
+# every start, and a number copied out of a previous run's output is the most
+# common reason a demo command cannot connect. Set it to reach a gateway this
+# Makefile did not start.
+GATEWAY_ADDR ?=
+
+# Resolves $(GATEWAY_ADDR), or the local stack's port when it is unset, into
+# $$addr for the recipe that includes it. Not a $(shell ...) assignment: that
+# would run at parse time, shelling out to Docker on every `make help`.
+define resolve_gateway_addr
+	addr="$(GATEWAY_ADDR)"; \
+	port=$$(docker port $(SUBMITQUEUE_LOCAL_PROJECT)-gateway-service-1 8080 2>/dev/null | head -1 | sed 's/.*://'); \
+	if [ -z "$$addr" ]; then \
+		if [ -z "$$port" ]; then \
+			echo "No gateway found: '$(SUBMITQUEUE_LOCAL_PROJECT)' is not running." >&2; \
+			echo "Start it with 'make local-submitqueue-start', or name one with GATEWAY_ADDR=host:port." >&2; \
+			exit 2; \
+		fi; \
+		addr="localhost:$$port"; \
+	elif [ "$(origin GATEWAY_ADDR)" = "environment" ] && [ -n "$$port" ] && [ "$$addr" != "localhost:$$port" ]; then \
+		echo "Note: GATEWAY_ADDR=$$addr is exported in your shell, so that is what will be used." >&2; \
+		echo "      The stack running here is on localhost:$$port — 'unset GATEWAY_ADDR' to use it." >&2; \
+	fi
+endef
+
+# Resolves which provider to create changes for into $$provider, preferring the
+# one the running stack was started with.
+#
+# The two have to agree. A change minted for one provider is meaningless to a
+# stack wired to another: fake changes point at no repository, so a stack
+# running the git merger rejects every one of them as a commit it cannot find,
+# and fifty requests fail identically for a reason that is nowhere in the error.
+# The stack knows which provider it has — it is mounted at /etc/submitqueue —
+# so a run that was not told otherwise asks it rather than guessing.
+define resolve_provider
+	provider="$(PROVIDER)"; \
+	mounted=$$(docker inspect $(SUBMITQUEUE_LOCAL_PROJECT)-orchestrator-service-1 \
+		--format '{{range .Mounts}}{{if eq .Destination "/etc/submitqueue"}}{{.Source}}{{end}}{{end}}' 2>/dev/null); \
+	if [ -n "$$mounted" ]; then \
+		running=$$(basename "$$mounted"); \
+		if [ "$(origin PROVIDER)" = "file" ]; then \
+			provider="$$running"; \
+		elif [ "$$provider" != "$$running" ]; then \
+			echo "Note: creating $$provider changes, but the running stack is '$$running'." >&2; \
+			echo "      They have to match — a $$provider change is not something a '$$running' stack can land." >&2; \
+		fi; \
+	fi
+endef
 
 # Fails if git working tree is dirty. Usage: $(call assert_clean,fix command)
 define assert_clean
@@ -197,8 +245,9 @@ clean-proto: ## Clean generated proto files
 	@echo "Proto clean complete!"
 
 demo-requests: ## Create N changes, enqueue each as it is created, and watch (PROVIDER=fake|git|github COUNT=3 FOLDERS=0 FILES=3 CONCURRENCY=5)
-	@$(BAZEL) run //service/submitqueue/demo/requests -- \
-		-provider $(PROVIDER) \
+	@set -e; $(resolve_gateway_addr); $(resolve_provider); \
+	$(BAZEL) run //service/submitqueue/demo/requests -- \
+		-provider $$provider \
 		-repo $(DEMO_REPO) \
 		-sandbox-dir $(SQ_GIT_SANDBOX_DIR) \
 		-count $(COUNT) \
@@ -206,7 +255,7 @@ demo-requests: ## Create N changes, enqueue each as it is created, and watch (PR
 		-files $(FILES) \
 		-concurrency $(CONCURRENCY) \
 		-stacked=$(STACKED) \
-		-addr $(GATEWAY_ADDR) \
+		-addr $$addr \
 		-queue $(QUEUE) \
 		-strategy $(STRATEGY) \
 		-land=$(LAND) -watch=$(WATCH)
@@ -262,8 +311,9 @@ land: ## Land a change or a stack (PR=<url>, PRS="<url> <url>", or URI=<change-u
 		echo "   opts: QUEUE=$(QUEUE) STRATEGY=$(STRATEGY) GATEWAY_ADDR=$(GATEWAY_ADDR)"; \
 		exit 2; \
 	fi
-	@$(BAZEL) run //service/submitqueue/gateway/client:gateway -- \
-		-addr $(GATEWAY_ADDR) land \
+	@set -e; $(resolve_gateway_addr); \
+	$(BAZEL) run //service/submitqueue/gateway/client:gateway -- \
+		-addr $$addr land \
 		-queue $(QUEUE) \
 		-strategy $(STRATEGY) \
 		$(if $(PR),-pr $(PR)) $(foreach p,$(PRS),-pr $(p)) \
@@ -271,16 +321,19 @@ land: ## Land a change or a stack (PR=<url>, PRS="<url> <url>", or URI=<change-u
 
 land-status: ## Read a landed request's status (SQID=... [QUEUE=demo-queue])
 	@if [ -z "$(SQID)" ]; then echo "Usage: make land-status SQID=demo-queue/1 [QUEUE=demo-queue]"; exit 2; fi
-	@$(BAZEL) run //service/submitqueue/gateway/client:gateway -- \
-		-addr $(GATEWAY_ADDR) status -queue $(QUEUE) -sqid $(SQID)
+	@set -e; $(resolve_gateway_addr); \
+	$(BAZEL) run //service/submitqueue/gateway/client:gateway -- \
+		-addr $$addr status -queue $(QUEUE) -sqid $(SQID)
 
 land-list: ## Show a queue's recent requests as a table (QUEUE=demo-queue SINCE=1h LIMIT=50)
-	@$(BAZEL) run //service/submitqueue/gateway/client:gateway -- \
-		-addr $(GATEWAY_ADDR) list -queue $(QUEUE) -since $(SINCE) -limit $(LIMIT)
+	@set -e; $(resolve_gateway_addr); \
+	$(BAZEL) run //service/submitqueue/gateway/client:gateway -- \
+		-addr $$addr list -queue $(QUEUE) -since $(SINCE) -limit $(LIMIT)
 
 land-watch: ## Follow a queue's requests until they settle (QUEUE=demo-queue SINCE=15m LIMIT=50)
-	@$(BAZEL) run //service/submitqueue/gateway/client:gateway -- \
-		-addr $(GATEWAY_ADDR) watch -queue $(QUEUE) -since $(SINCE) -limit $(LIMIT)
+	@set -e; $(resolve_gateway_addr); \
+	$(BAZEL) run //service/submitqueue/gateway/client:gateway -- \
+		-addr $$addr watch -queue $(QUEUE) -since $(SINCE) -limit $(LIMIT)
 
 license-fix: ## Add missing license headers to source files
 	@$(BAZEL) run //tool/linter/licenseheader -- --fix
@@ -470,7 +523,7 @@ local-submitqueue-start: build-all-linux ## Start full stack (PROVIDER=fake|git|
 	fi
 	@echo ""
 	@echo "Generate traffic with:"
-	@echo "  make demo-requests GATEWAY_ADDR=localhost:<gateway port>"
+	@echo "  make demo-requests"
 
 local-submitqueue-stop: ## Stop the SubmitQueue stack (keeps data and PROVIDER=git's sandbox)
 	@echo "Stopping SubmitQueue services..."

--- a/README.md
+++ b/README.md
@@ -15,17 +15,14 @@ Cross-domain Go code (errors, metrics, consumer framework, HTTP helpers, shared 
 
 ## Quick Start
 
-Put traffic through the queue and watch it land. Requires Docker and Docker Compose, and nothing else — no repository, no account, no token. See [Development Setup](doc/howto/DEVELOPMENT.md) for full prerequisites.
+Put traffic through the queue and watch it land. Requires Docker and Docker Compose, and nothing else — no repository, no account, no token.
 
 ```bash
 # Start the full stack (Gateway + Orchestrator + Runway + MySQL)
 make local-submitqueue-start
 
-# Compose publishes a random host port; the line above prints it, as does this
-make local-submitqueue-ps
-export GATEWAY_ADDR=localhost:<gateway port>
-
-# Create changes, enqueue each as it is created, and watch them settle
+# Create changes, enqueue each as it is created, and watch them settle.
+# It finds the running stack's port and provider itself — nothing to copy.
 make demo-requests
 
 # Stop services

--- a/doc/howto/DEVELOPMENT.md
+++ b/doc/howto/DEVELOPMENT.md
@@ -60,15 +60,11 @@ docker ps
 # 2. Start the full stack
 make local-submitqueue-start
 
-# 3. Read the gateway's port (Compose publishes a random one)
-make local-submitqueue-ps
-export GATEWAY_ADDR=localhost:<gateway port>
-
-# 4. Create changes, enqueue them, and watch them land
+# 3. Create changes, enqueue them, and watch them land
 make demo-requests
 
-# 5. Stop services
-make local-stop
+# 4. Stop services
+make local-submitqueue-stop
 ```
 
 [QUICKSTART.md](QUICKSTART.md) walks through the same run in detail, and on to `PROVIDER=git`, which lands real commits into a repository on disk — still with no credential.

--- a/doc/howto/QUICKSTART.md
+++ b/doc/howto/QUICKSTART.md
@@ -28,13 +28,7 @@ Compose publishes each service on a **random** host port so several stacks can r
 Gateway gRPC port: 58537
 ```
 
-Export it, because every command below needs it:
-
-```bash
-export GATEWAY_ADDR=localhost:58537
-```
-
-Leaving it unset does not fall back to anything useful — the client's default is `localhost:8081`, the `go run` port rather than the compose one.
+You do not have to note it down. Every command below finds the running stack's port for itself, which matters because Compose picks a fresh one on every start — a number copied from an earlier run is the most common reason a demo command cannot connect. Set `GATEWAY_ADDR=host:port` only to reach a gateway this Makefile did not start.
 
 ## Put traffic through it
 
@@ -118,6 +112,17 @@ Eight builds means the batch was speculating down eight paths at once, and `wait
 
 `land-watch` fixes its set when it starts and exits non-zero if any request in that set finishes anywhere other than `landed`, which makes it usable from a script. A request accepted after the watch begins is not picked up: a watch that grew as the queue did would never finish.
 
+Watching more requests than the window holds takes over the screen while it runs, the way `top` does, so the table can be scrolled rather than trimmed:
+
+| Key | |
+|---|---|
+| `↑` `↓` or `k` `j` | one row |
+| `PgUp` `PgDn` or `Space` | one screen |
+| `g` `G` | first row, last row |
+| `q` | stop watching |
+
+The view follows the end of the table by default, so new rows and new stages appear without touching it. Scrolling up holds your place; scrolling back to the bottom starts following again. The screen you had is restored on exit and the finished table is printed into it whole, so nothing is lost with the view — and when output is redirected, none of this happens at all and the run stays a plain log.
+
 A listing of a busy queue is mostly `speculating` rows, since that is where a request spends most of its active life — waiting on the build its batch was admitted for.
 
 Under the hood these are `client list` and `client watch`, which take a queue and reach any gateway:
@@ -178,12 +183,13 @@ Gateway gRPC port: 55295
 Merge target:      /tmp/sq-sandbox/sandbox.git
 ```
 
-Then the same command as before, with the same `PROVIDER`:
+Then the same command as before, unchanged:
 
 ```bash
-export GATEWAY_ADDR=localhost:55295
-PROVIDER=git make demo-requests
+make demo-requests
 ```
+
+`demo-requests` creates changes for whichever provider the running stack was started with, so there is nothing to repeat and nothing to keep in sync. The two must agree — a fake change points at no repository, so a stack running the git merger rejects every one of them as a commit it cannot find — and rather than leaving that to memory, a run with no `PROVIDER` of its own asks the stack which one it has. Passing one that disagrees still works, and says so before it starts.
 
 Now `demo-requests` pushes real branches with real commits, and landing them is a real cherry-pick and push. Look at the repository itself:
 
@@ -200,13 +206,11 @@ b5d86d6 seed the sandbox
 
 The commits are there, and they are not the ones that were pushed: `SQUASH_REBASE` replays each change onto the target rather than merging it, which is why the queue can keep the trunk linear.
 
-**`PROVIDER` has to match on both commands.** It selects what the stack merges with *and* what `demo-requests` creates; pointing fake changes at a stack wired to git means asking the merger to fetch a ref that was never pushed.
-
 One property worth seeing, because it is the thing a submit queue exists for. A stack lands as a single push, so no reader ever observes it half-applied:
 
 ```bash
 git -C /tmp/sq-sandbox/sandbox.git reflog show refs/heads/main | wc -l
-PROVIDER=git make demo-requests COUNT=3 STACKED=true
+make demo-requests COUNT=3 STACKED=true
 git -C /tmp/sq-sandbox/sandbox.git reflog show refs/heads/main | wc -l
 ```
 
@@ -257,7 +261,7 @@ PROVIDER=github make local-submitqueue-start
 
 The token is required rather than defaulted: a stack that silently falls back to the fake integrations reports changes as landed without having gone near the provider, which is a much worse way to find out.
 
-From here everything is as before — `PROVIDER=github make demo-requests` opens real pull requests, enqueues them and watches them land.
+From here everything is as before — `make demo-requests` opens real pull requests, enqueues them and watches them land, having picked up from the running stack that this one is GitHub.
 
 ### Land a pull request
 

--- a/service/submitqueue/demo/requests/main.go
+++ b/service/submitqueue/demo/requests/main.go
@@ -211,11 +211,21 @@ func run(ctx context.Context, cfg config) error {
 		return nil
 	}
 
+	// A large run has more changes than a window has lines, so the wait happens
+	// in a full-screen view the reader can scroll. Restored before Conclude, so
+	// the final table lands in the scrollback and not on a screen that is about
+	// to be handed back.
+	stop, quit := t.Interact(ctx)
+	defer stop()
+
 	select {
 	case <-ctx.Done():
+		stop()
 		return ctx.Err()
+	case <-quit:
 	case <-t.Settled():
 	}
+	stop()
 	return t.Conclude()
 }
 

--- a/service/submitqueue/gateway/client/main.go
+++ b/service/submitqueue/gateway/client/main.go
@@ -282,13 +282,23 @@ func runWatch(ctx context.Context, sq *client.Client, args []string) error {
 	t.Seal()
 	t.Note("watching %d request(s) in %s", len(rows), *queue)
 
+	// A watch of a busy queue holds more requests than a window does, so it runs
+	// as a full-screen view the reader can scroll. Restored before Conclude, so
+	// the final table lands in the scrollback rather than disappearing with the
+	// screen it was drawn on.
+	stop, quit := t.Interact(ctx)
+	defer stop()
+
 	go t.Poll(ctx, sq.Gateway(), *queue)
 
 	select {
 	case <-ctx.Done():
+		stop()
 		return ctx.Err()
+	case <-quit:
 	case <-t.Settled():
 	}
+	stop()
 	return t.Conclude()
 }
 

--- a/submitqueue/client/BUILD.bazel
+++ b/submitqueue/client/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "conn.go",
         "land.go",
         "query.go",
+        "tui.go",
         "view.go",
         "watch.go",
     ],
@@ -28,6 +29,7 @@ go_test(
     srcs = [
         "conn_test.go",
         "query_test.go",
+        "tui_test.go",
         "view_test.go",
     ],
     embed = [":go_default_library"],

--- a/submitqueue/client/tui.go
+++ b/submitqueue/client/tui.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// action is what a keypress asks the view to do.
+type action int
+
+const (
+	actionNone action = iota
+	actionUp
+	actionDown
+	actionPageUp
+	actionPageDown
+	actionTop
+	actionBottom
+	actionQuit
+)
+
+// keyReader turns a byte stream into actions.
+//
+// Terminals send arrows and page keys as escape sequences rather than
+// characters, and a sequence arrives one byte at a time, so this reads from a
+// buffered stream rather than from fixed-size chunks: a three-byte arrow split
+// across two reads is normal, not an error.
+type keyReader struct {
+	in *bufio.Reader
+}
+
+func newKeyReader(r io.Reader) *keyReader {
+	return &keyReader{in: bufio.NewReader(r)}
+}
+
+// next blocks until it can report one action. An unrecognized key is
+// actionNone, which the caller ignores — an unknown key should do nothing
+// rather than close the view.
+func (k *keyReader) next() (action, error) {
+	b, err := k.in.ReadByte()
+	if err != nil {
+		return actionNone, err
+	}
+
+	switch b {
+	case 'q', 'Q', 0x03: // 0x03 is Ctrl-C, which raw mode delivers as a byte.
+		return actionQuit, nil
+	case 'j':
+		return actionDown, nil
+	case 'k':
+		return actionUp, nil
+	case 'g':
+		return actionTop, nil
+	case 'G':
+		return actionBottom, nil
+	case ' ':
+		return actionPageDown, nil
+	case 0x1b: // ESC: the start of an arrow or page key, or a bare Escape.
+		return k.escape()
+	}
+	return actionNone, nil
+}
+
+// escape reads the remainder of a CSI sequence.
+//
+// It waits for the next byte rather than checking whether one has already
+// arrived. A terminal may deliver an arrow's three bytes across separate reads,
+// and treating "nothing buffered yet" as "this was a bare Escape" would turn
+// the arrow into a keypress that does nothing — intermittently, under load,
+// which is the worst way for it to be wrong.
+//
+// The cost is that a bare Escape is not seen until another key follows it, and
+// swallows that key. Nothing here binds Escape, so the exchange is a good one.
+func (k *keyReader) escape() (action, error) {
+	b, err := k.in.ReadByte()
+	if err != nil || b != '[' {
+		return actionNone, err
+	}
+
+	b, err = k.in.ReadByte()
+	if err != nil {
+		return actionNone, err
+	}
+	switch b {
+	case 'A':
+		return actionUp, nil
+	case 'B':
+		return actionDown, nil
+	case 'H':
+		return actionTop, nil
+	case 'F':
+		return actionBottom, nil
+	case '5', '6': // Page Up and Page Down arrive as "5~" and "6~".
+		if tilde, err := k.in.ReadByte(); err != nil || tilde != '~' {
+			return actionNone, err
+		}
+		if b == '5' {
+			return actionPageUp, nil
+		}
+		return actionPageDown, nil
+	}
+	return actionNone, nil
+}
+
+// scroll is which slice of the rows the view is showing.
+//
+// follow is what makes a watch usable without touching it: while it holds, the
+// view stays pinned to the end as rows are added, the way a log tail does.
+// Scrolling up drops it, so the reader keeps the place they chose; scrolling
+// back to the end restores it, so they can hand control back without a
+// dedicated key.
+type scroll struct {
+	offset int
+	follow bool
+}
+
+// apply moves the view, given how many rows there are and how many fit.
+func (s *scroll) apply(a action, total, capacity int) {
+	page := capacity - 1
+	if page < 1 {
+		page = 1
+	}
+
+	switch a {
+	case actionUp:
+		s.offset--
+	case actionDown:
+		s.offset++
+	case actionPageUp:
+		s.offset -= page
+	case actionPageDown:
+		s.offset += page
+	case actionTop:
+		s.offset = 0
+	case actionBottom:
+		s.offset = total
+	default:
+		return
+	}
+	// A move is the reader's, so it decides where the view sits — including
+	// whether it is still following. Snapping to the end here instead would
+	// make scrolling up impossible from a following view.
+	s.bound(total, capacity)
+}
+
+// bound keeps the window inside the rows and derives whether the view is
+// following from where it ended up: being at the end is what following is,
+// however the view got there.
+func (s *scroll) bound(total, capacity int) {
+	max := maxOffset(total, capacity)
+	if s.offset > max {
+		s.offset = max
+	}
+	if s.offset < 0 {
+		s.offset = 0
+	}
+	s.follow = s.offset == max
+}
+
+// clamp prepares the window for a draw: a following view is carried to the new
+// end, so rows arriving do not push it out from under a reader who is watching
+// the newest ones, while a reader who scrolled away keeps their place.
+func (s *scroll) clamp(total, capacity int) {
+	if s.follow {
+		s.offset = maxOffset(total, capacity)
+	}
+	s.bound(total, capacity)
+}
+
+// maxOffset is the furthest the window can start and still be full.
+func maxOffset(total, capacity int) int {
+	if max := total - capacity; max > 0 {
+		return max
+	}
+	return 0
+}
+
+// window is the slice of rows the view shows.
+func (s *scroll) window(rows []*Row, capacity int) []*Row {
+	if capacity >= len(rows) {
+		return rows
+	}
+	end := s.offset + capacity
+	if end > len(rows) {
+		end = len(rows)
+	}
+	return rows[s.offset:end]
+}
+
+// terminal owns the screen while a watch is running: the alternate buffer it
+// draws into, and the raw mode that delivers keystrokes as they are typed
+// rather than a line at a time.
+//
+// Both are global state on the user's terminal, so restore must run on every
+// path out — a normal finish, a signal, or a panic. Leaving a terminal in raw
+// mode without an echo is the kind of breakage that outlives the process.
+type terminal struct {
+	fd    int
+	state *term.State
+	out   io.Writer
+}
+
+// enterTerminal takes over the screen, reporting whether it could.
+//
+// It needs both halves: a screen to draw on and a keyboard to read. A run whose
+// input is redirected keeps the plain redraw, because a full-screen view nobody
+// can scroll is worse than a table that scrolls with the terminal.
+func enterTerminal(out io.Writer) (*terminal, bool) {
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return nil, false
+	}
+	state, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, false
+	}
+
+	t := &terminal{fd: fd, state: state, out: out}
+	// Alternate buffer, cursor hidden: the scrollback the reader had before this
+	// started is theirs and comes back untouched on exit.
+	fmt.Fprint(out, "\033[?1049h\033[?25l")
+	return t, true
+}
+
+// restore gives the terminal back. It is safe to call more than once, because
+// the paths that have to call it — deferred cleanup and a signal handler — can
+// both run.
+func (t *terminal) restore() {
+	if t == nil || t.state == nil {
+		return
+	}
+	fmt.Fprint(t.out, "\033[?25h\033[?1049l")
+	_ = term.Restore(t.fd, t.state)
+	t.state = nil
+}
+
+// readKeys reports keystrokes until the context ends or the stream does.
+//
+// The read itself cannot be cancelled — a blocking read on a terminal stays
+// blocked until a key arrives — so this outlives a cancelled context by at most
+// one keypress and drops what it reads after. That is why it sends on a
+// buffered channel and never blocks on the send: the receiver may already be
+// gone.
+func readKeys(ctx context.Context, r io.Reader, actions chan<- action) {
+	keys := newKeyReader(r)
+	for {
+		a, err := keys.next()
+		if err != nil {
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if a == actionNone {
+			continue
+		}
+		select {
+		case actions <- a:
+		default:
+		}
+	}
+}

--- a/submitqueue/client/tui_test.go
+++ b/submitqueue/client/tui_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyReader(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []action
+	}{
+		{name: "letters", input: "jkgGq", want: []action{
+			actionDown, actionUp, actionTop, actionBottom, actionQuit,
+		}},
+		{name: "space pages down", input: " ", want: []action{actionPageDown}},
+		{name: "ctrl-c quits, since raw mode delivers it as a byte", input: "\x03", want: []action{actionQuit}},
+		{name: "arrows", input: "\x1b[A\x1b[B", want: []action{actionUp, actionDown}},
+		{name: "page keys", input: "\x1b[5~\x1b[6~", want: []action{actionPageUp, actionPageDown}},
+		{name: "home and end", input: "\x1b[H\x1b[F", want: []action{actionTop, actionBottom}},
+		{
+			// An unknown key must do nothing rather than close the view.
+			name:  "unknown keys are ignored",
+			input: "xyz\x1b[Zj",
+			want:  []action{actionDown},
+		},
+		{
+			// Escape is bound to nothing, so it and whatever it is mistaken for
+			// the start of are both ignored.
+			name:  "an escape that begins no sequence is ignored",
+			input: "\x1bxj",
+			want:  []action{actionDown},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys := newKeyReader(strings.NewReader(tt.input))
+
+			var got []action
+			for {
+				a, err := keys.next()
+				if err != nil {
+					break
+				}
+				if a != actionNone {
+					got = append(got, a)
+				}
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// An arrow is three bytes and a terminal may deliver them across separate
+// reads, which is normal rather than an error.
+func TestKeyReaderHandlesASplitSequence(t *testing.T) {
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+	keys := newKeyReader(pr)
+
+	done := make(chan action, 1)
+	go func() {
+		a, err := keys.next()
+		require.NoError(t, err)
+		done <- a
+	}()
+
+	_, _ = pw.Write([]byte{0x1b})
+	_, _ = pw.Write([]byte{'['})
+	_, _ = pw.Write([]byte{'A'})
+
+	assert.Equal(t, actionUp, <-done)
+}
+
+func TestScrollApply(t *testing.T) {
+	const (
+		total    = 40
+		capacity = 10
+	)
+
+	tests := []struct {
+		name       string
+		start      scroll
+		action     action
+		wantOffset int
+		wantFollow bool
+	}{
+		{name: "down one", start: scroll{offset: 0}, action: actionDown, wantOffset: 1},
+		{name: "up one", start: scroll{offset: 5}, action: actionUp, wantOffset: 4},
+		{name: "page down", start: scroll{offset: 0}, action: actionPageDown, wantOffset: 9},
+		{name: "page up", start: scroll{offset: 20}, action: actionPageUp, wantOffset: 11},
+		{name: "top", start: scroll{offset: 20}, action: actionTop, wantOffset: 0},
+		{
+			name: "bottom follows from then on", start: scroll{offset: 0}, action: actionBottom,
+			wantOffset: total - capacity, wantFollow: true,
+		},
+		{
+			name: "cannot scroll above the first row", start: scroll{offset: 0}, action: actionPageUp,
+			wantOffset: 0,
+		},
+		{
+			// Scrolling past the end lands on it, and being on the end is what
+			// following means — however the view got there.
+			name: "cannot scroll past the last row", start: scroll{offset: 38}, action: actionPageDown,
+			wantOffset: total - capacity, wantFollow: true,
+		},
+		{
+			name: "scrolling up releases follow", start: scroll{offset: total - capacity, follow: true}, action: actionUp,
+			wantOffset: total - capacity - 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.start
+			s.apply(tt.action, total, capacity)
+			assert.Equal(t, tt.wantOffset, s.offset)
+			assert.Equal(t, tt.wantFollow, s.follow)
+		})
+	}
+}
+
+// Following is what makes a watch usable without touching it: rows arriving
+// must not push the end out from under a reader who is already at it.
+func TestScrollFollowsRowsAsTheyArrive(t *testing.T) {
+	s := scroll{}
+	s.apply(actionBottom, 10, 5)
+	require.True(t, s.follow)
+	require.Equal(t, 5, s.offset)
+
+	s.clamp(30, 5)
+	assert.Equal(t, 25, s.offset, "a following view stays at the end as the table grows")
+
+	s.apply(actionUp, 30, 5)
+	assert.False(t, s.follow, "scrolling away holds the reader's place")
+	s.clamp(60, 5)
+	assert.Equal(t, 24, s.offset, "and rows arriving no longer move it")
+}
+
+func TestScrollWindow(t *testing.T) {
+	rows := make([]*Row, 10)
+	for i := range rows {
+		rows[i] = &Row{SQID: string(rune('a' + i))}
+	}
+
+	t.Run("everything fits", func(t *testing.T) {
+		s := scroll{}
+		assert.Len(t, s.window(rows, 20), 10)
+	})
+
+	t.Run("a window in the middle", func(t *testing.T) {
+		s := scroll{offset: 3}
+		window := s.window(rows, 4)
+		require.Len(t, window, 4)
+		assert.Equal(t, "d", window[0].SQID)
+		assert.Equal(t, "g", window[3].SQID)
+	})
+
+	t.Run("a window at the end is not short", func(t *testing.T) {
+		s := scroll{offset: 6}
+		assert.Len(t, s.window(rows, 4), 4)
+	})
+}

--- a/submitqueue/client/view.go
+++ b/submitqueue/client/view.go
@@ -179,7 +179,16 @@ func digest(events []*pb.HistoryEvent) (trail []string, status, note string) {
 			pending, counts = nil, make(map[string]int)
 			return
 		}
-		trail[len(trail)-1] += " [" + strings.Join(annotate(pending, counts), ", ") + "]"
+		events := strings.Join(annotate(pending, counts), ", ")
+		// A request that has settled cannot be doing anything, so an event
+		// recorded against a terminal status is work that outlived it: a build
+		// for a speculation path nobody needed any more, which reported before
+		// the runner could be told to stop. Saying when it happened keeps the
+		// trail from reading as though a landed change built itself afterwards.
+		if terminalStatuses[last] {
+			events = "after: " + events
+		}
+		trail[len(trail)-1] += " [" + events + "]"
 		pending, counts = nil, make(map[string]int)
 	}
 
@@ -299,6 +308,16 @@ type renderer struct {
 	// free to be taller than the window: no later frame has to line up with it.
 	oneShot bool
 
+	// scrollable marks the full-screen view, where the reader can move a window
+	// over the rows instead of the renderer choosing which ones to drop.
+	scrollable bool
+	scroll     scroll
+
+	// lastCapacity is how many rows the last frame had room for. A keypress has
+	// to move the window by a page without knowing the rows or their heights,
+	// and the last frame is the best evidence of what a page is.
+	lastCapacity int
+
 	// width and height are the terminal's, re-read before every draw. A watch
 	// runs for minutes and a window can be resized inside them, so neither is a
 	// property the process can sample once — see resize.
@@ -395,6 +414,11 @@ func (r *renderer) draw(rows []*Row, status string) {
 	// resize as rows come and go from view.
 	r.fit(rows)
 
+	if r.scrollable {
+		r.drawScrollable(rows, status)
+		return
+	}
+
 	visible, hidden := r.visibleRows(rows)
 	body := r.body(visible)
 	if hidden > 0 {
@@ -432,6 +456,97 @@ func (r *renderer) draw(rows []*Row, status string) {
 // line and the status line below it, plus the row the cursor rests on, which
 // has to stay inside the window or the next redraw starts a line too low.
 const frameOverhead = 3
+
+// drawScrollable paints the full-screen view: a window over the rows that the
+// reader moves, and a footer saying where in the table it sits.
+//
+// It repaints from the top of the screen rather than counting lines backwards.
+// The alternate buffer never scrolls — the frame is built to fit — so there is
+// no previous frame to find, and the whole class of drift the in-place redraw
+// has to guard against does not arise.
+func (r *renderer) drawScrollable(rows []*Row, status string) {
+	capacity := r.rowCapacity(rows)
+	r.lastCapacity = capacity
+	r.scroll.clamp(len(rows), capacity)
+	window := r.scroll.window(rows, capacity)
+
+	var out strings.Builder
+	out.WriteString("\033[H")
+	for _, line := range r.body(window) {
+		out.WriteString("\033[K")
+		out.WriteString(line)
+		out.WriteString("\r\n")
+	}
+	out.WriteString("\033[K\r\n")
+	out.WriteString("\033[K  ▸ ")
+	out.WriteString(truncate(status, r.lineWidth()-4))
+	out.WriteString("\r\n")
+	out.WriteString("\033[K  ")
+	out.WriteString(truncate(r.scrollFooter(len(rows), len(window)), r.lineWidth()-2))
+	// Erase whatever the previous frame left below this one, which is how a
+	// table that shrinks does not leave its own tail on screen.
+	out.WriteString("\033[J")
+	fmt.Print(out.String())
+}
+
+// scrollFooter says which rows are on screen and how to move them.
+func (r *renderer) scrollFooter(total, shown int) string {
+	keys := "↑↓ PgUp/PgDn  g/G top/bottom  q quit"
+	if shown >= total {
+		return fmt.Sprintf("%d request(s)   %s", total, keys)
+	}
+	following := ""
+	if r.scroll.follow {
+		following = "  following"
+	}
+	return fmt.Sprintf("%d-%d of %d%s   %s",
+		r.scroll.offset+1, r.scroll.offset+shown, total, following, keys)
+}
+
+// rowCapacity is how many rows the window has room for, given that rows are not
+// all one line tall — a wrapped stage or an error note makes one taller.
+//
+// Measured from the rows actually at the top of the view, so a window of tall
+// rows holds fewer of them rather than overflowing. The floor of one keeps a
+// very short terminal drawing something rather than nothing.
+func (r *renderer) rowCapacity(rows []*Row) int {
+	// The header, its rule, a blank line, the status line, the footer, and the
+	// row the cursor rests on.
+	const chrome = 6
+
+	budget := r.height - chrome
+	if r.height <= 0 {
+		budget = len(rows)
+	}
+	if budget < 1 {
+		return 1
+	}
+
+	used, count := 0, 0
+	for _, rw := range rows[min(r.scroll.offset, len(rows)):] {
+		height := len(r.rowLines(rw)) + len(r.noteLines(rw))
+		if used+height > budget && count > 0 {
+			break
+		}
+		used += height
+		count++
+	}
+	if count < 1 {
+		return 1
+	}
+	return count
+}
+
+// scrollBy moves the view by one action, over a table of the given size.
+func (r *renderer) scrollBy(a action, total int) {
+	r.resize()
+	capacity := r.lastCapacity
+	if capacity < 1 {
+		// Nothing drawn yet, so no measured page. One row still moves.
+		capacity = 1
+	}
+	r.scroll.apply(a, total, capacity)
+}
 
 // visibleRows is the rows that fit in the window, and how many were left out.
 //

--- a/submitqueue/client/view_test.go
+++ b/submitqueue/client/view_test.go
@@ -147,6 +147,20 @@ func TestDigest(t *testing.T) {
 			wantStatus: "accepted",
 		},
 		{
+			// Seen in a real run: a build for a speculation path nobody needed
+			// any more finished after the batch had landed, and was recorded
+			// against every request in it. Attaching it like any other event
+			// would read as a landed change building itself afterwards.
+			name: "work recorded after the request settled says so",
+			events: []*pb.HistoryEvent{
+				{Status: "landing"},
+				{Status: "landed"},
+				{Event: "building"}, {Event: "built"},
+			},
+			wantTrail:  []string{"landing", "landed [after: building, built]"},
+			wantStatus: "landed",
+		},
+		{
 			name: "an error carried by an event is still reported",
 			events: []*pb.HistoryEvent{
 				{Status: "speculating"}, {Event: "building", LastError: "runner unreachable"},

--- a/submitqueue/client/watch.go
+++ b/submitqueue/client/watch.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -96,8 +97,102 @@ func (t *Tracker) Conclude() error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.status = outcome(t.rows)
+	// The interactive view is gone by now, taking the alternate screen with it,
+	// so the last table is drawn into the scrollback the reader keeps. A run
+	// whose result vanished with the window it was drawn in would be a strange
+	// thing to hand someone.
+	//
+	// It is drawn whole, however tall that is. Nothing will be drawn over it,
+	// so a table longer than the window scrolls — which is what a reader of a
+	// finished run wants, and the reason the height limit a live view lives
+	// under does not apply to the last one.
+	t.r.scrollable = false
+	t.r.oneShot = true
 	t.r.draw(t.rows, t.status)
 	return summarize(t.rows)
+}
+
+// Interact puts the terminal into a scrollable full-screen view for as long as
+// the watch runs, and reports when the reader asks to leave.
+//
+// It is optional and degrades rather than fails: without a terminal on both
+// ends there is nothing to take over and nobody to read a key, so the caller
+// gets a no-op stop and a channel that never fires, and the plain redraw is
+// used exactly as before.
+func (t *Tracker) Interact(ctx context.Context) (stop func(), quit <-chan struct{}) {
+	quitCh := make(chan struct{})
+
+	t.mu.Lock()
+	inPlace := t.r.inPlace
+	t.mu.Unlock()
+	if !inPlace {
+		return func() {}, quitCh
+	}
+
+	screen, ok := enterTerminal(os.Stdout)
+	if !ok {
+		return func() {}, quitCh
+	}
+
+	t.mu.Lock()
+	t.r.scrollable = true
+	t.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(ctx)
+	actions := make(chan action, 8)
+	go readKeys(ctx, os.Stdin, actions)
+
+	var once sync.Once
+	restore := func() {
+		once.Do(func() {
+			cancel()
+			screen.restore()
+			t.mu.Lock()
+			t.r.scrollable = false
+			t.mu.Unlock()
+		})
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case a := <-actions:
+				if a == actionQuit {
+					restore()
+					close(quitCh)
+					return
+				}
+				t.scrollBy(a)
+			}
+		}
+	}()
+
+	// A redraw on a timer as well as on a keypress, so the elapsed column keeps
+	// moving in a view the reader is not touching.
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				t.Update(func() {})
+			}
+		}
+	}()
+
+	return restore, quitCh
+}
+
+// scrollBy moves the view and redraws it.
+func (t *Tracker) scrollBy(a action) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.r.scrollBy(a, len(t.rows))
+	t.r.draw(t.rows, t.status)
 }
 
 // Seal declares that nothing further will be watched, which is what lets an

--- a/tool/gitsandbox/main.go
+++ b/tool/gitsandbox/main.go
@@ -97,7 +97,9 @@ func provision(ctx context.Context, git, bare, branch string) (bool, error) {
 	// HEAD is written by `git init` before anything else, so its presence marks
 	// a repository that has at least been initialized.
 	if _, err := os.Stat(filepath.Join(bare, "HEAD")); err == nil {
-		return false, nil
+		// Settings are re-applied rather than assumed, so a sandbox created by
+		// an older version gains them without having to be thrown away.
+		return false, configure(ctx, git, bare)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(bare), 0o755); err != nil {
@@ -123,12 +125,43 @@ func create(ctx context.Context, git, bare, branch string) error {
 	if err := gitexec.Run(ctx, git, "", "init", "--bare", "-b", branch, bare); err != nil {
 		return err
 	}
-	// Bare repositories do not log ref updates by default, and the reflog is
-	// how a reader confirms a whole stack landed in a single push.
-	if err := gitexec.Run(ctx, git, bare, "config", "core.logAllRefUpdates", "true"); err != nil {
+	if err := configure(ctx, git, bare); err != nil {
 		return err
 	}
 	return seed(ctx, git, bare, branch)
+}
+
+// configure applies the settings the sandbox needs to be both readable and
+// safe to share between the host and the containers.
+func configure(ctx context.Context, git, bare string) error {
+	settings := [][2]string{
+		// Bare repositories do not log ref updates by default, and the reflog
+		// is how a reader confirms a whole stack landed in a single push.
+		{"core.logAllRefUpdates", "true"},
+
+		// No automatic housekeeping, which here is a correctness setting rather
+		// than a tuning one.
+		//
+		// Git runs `gc --auto` after every push by default, and packing refs
+		// rewrites packed-refs wholesale. That is safe on one filesystem, where
+		// the replacement is a rename nobody can observe halfway — but this
+		// repository is written from the host and read from inside a container
+		// through a bind mount, and that boundary does not preserve the
+		// guarantee. A run pushing fifty branches gives fifty chances for the
+		// merger to read a packed-refs truncated mid-name and fail a land that
+		// had nothing wrong with it. Left unpacked, there is nothing to rewrite;
+		// loose refs cost a sandbox that gets deleted nothing.
+		{"gc.auto", "0"},
+		{"receive.autogc", "false"},
+		{"maintenance.auto", "false"},
+	}
+
+	for _, s := range settings {
+		if err := gitexec.Run(ctx, git, bare, "config", s[0], s[1]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // seed commits an initial file on the target branch, through a throwaway clone

--- a/tool/gitsandbox/main_test.go
+++ b/tool/gitsandbox/main_test.go
@@ -150,6 +150,51 @@ func TestProvision_EnablesTheReflog(t *testing.T) {
 	assert.Equal(t, "true", value)
 }
 
+// Git packs refs after a push by default, rewriting packed-refs wholesale. The
+// host writes this repository and a container reads it through a bind mount,
+// which does not preserve the atomicity that makes the rewrite safe — a reader
+// can catch the file mid-name and fail a land for no reason. Nothing to repack,
+// nothing to catch.
+func TestProvision_DisablesAutomaticHousekeeping(t *testing.T) {
+	git := testGit(t)
+	ctx := context.Background()
+	bare := filepath.Join(t.TempDir(), "sandbox.git")
+
+	_, err := provision(ctx, git, bare, "main")
+	require.NoError(t, err)
+
+	for setting, want := range map[string]string{
+		"gc.auto":          "0",
+		"receive.autogc":   "false",
+		"maintenance.auto": "false",
+	} {
+		got, err := gitexec.Output(ctx, git, bare, "config", "--get", setting)
+		require.NoError(t, err, "%s must be set", setting)
+		assert.Equal(t, want, got, setting)
+	}
+}
+
+// A sandbox made before these settings existed is reused rather than recreated,
+// so it has to gain them on the next start instead of staying broken until
+// someone deletes it.
+func TestProvision_AppliesSettingsToAnExistingSandbox(t *testing.T) {
+	git := testGit(t)
+	ctx := context.Background()
+	bare := filepath.Join(t.TempDir(), "sandbox.git")
+
+	_, err := provision(ctx, git, bare, "main")
+	require.NoError(t, err)
+	require.NoError(t, gitexec.Run(ctx, git, bare, "config", "receive.autogc", "true"))
+
+	created, err := provision(ctx, git, bare, "main")
+	require.NoError(t, err)
+	require.False(t, created, "an existing sandbox is reused, not recreated")
+
+	got, err := gitexec.Output(ctx, git, bare, "config", "--get", "receive.autogc")
+	require.NoError(t, err)
+	assert.Equal(t, "false", got)
+}
+
 func TestRun_RequiresASandboxDirectory(t *testing.T) {
 	err := run(context.Background(), testGit(t), "", "", "sandbox", "main")
 	require.Error(t, err)


### PR DESCRIPTION
## Summary
### Why?

Two things made a watch awkward to actually use.

**A big table could only be trimmed.** The previous change stopped a frame taller than the window from repainting the screen, by dropping settled rows and saying how many it had dropped. That keeps the redraw honest but it is still a table you cannot read: the rows are there, and the only reason they are not on screen is that the renderer had to choose. What a reader wants is what `top` gives them — the whole table, and a way to move through it.

**The gateway address had to be copied by hand, and went stale.** Compose publishes a fresh random port on every start, so a `GATEWAY_ADDR` noted from an earlier run points at a port that no longer exists, and every demo command fails with a connection refused that says nothing about why. That is not a hypothetical: it is the most common way these commands fail.

### What?

**A watch of a queue is now a scrollable full-screen view.** It takes the alternate buffer while it runs, reads keys in raw mode, and gives the screen back untouched afterwards:

| Key | |
|---|---|
| `↑` `↓` / `k` `j` | one row |
| `PgUp` `PgDn` / `Space` | one screen |
| `g` `G` | first row, last row |
| `q` | stop watching |

It follows the end of the table by default, so rows and stages appear without anyone touching it; scrolling up holds the reader's place, and scrolling back to the bottom resumes following. There is no dedicated key for that, because being at the end is what following is.

The full-screen view also removes the class of bug the trimming worked around, rather than managing it: the alternate buffer never scrolls, so each frame is painted from the top and there is no previous frame to find. The trimming path remains for the case where it is still needed — a terminal on stdout but not on stdin, where there is a screen to draw on but nobody to press a key.

The finished table is printed into the restored screen whole, however tall it is. Nothing is drawn over it, so a long one scrolls, which is what a reader of a completed run wants.

No new dependency: `golang.org/x/term` was already in use for the window size and provides raw mode too.

**Work recorded after a request settles says so.** A build for a speculation path nobody needed any more can finish after its batch has landed and be recorded against every request in it — seen in a fifty-request run, where two rows carried a `building`/`built` pair timestamped 350ms after `landed`. Rendering those like any other event read as a landed change building itself afterwards, so a terminal status marks them `[after: …]`. The orchestrator does cancel unwanted builds, but only ones still running when it next polls, and the fake runner finishes instantly — so this is mostly a demo artifact that a real runner would usually cancel instead.

**`make land`, `land-status`, `land-list`, `land-watch` and `demo-requests` find the gateway themselves**, by asking Docker for the running stack's published port. `GATEWAY_ADDR` is now an override for reaching a gateway the Makefile did not start, and a stack that is not running produces a sentence saying so rather than a refused connection. The resolution is done inside each recipe rather than as a `$(shell ...)` assignment, which would shell out to Docker on every `make help`.

**`demo-requests` also takes the provider from the running stack.** The two have to agree, and nothing enforced it: a stack started with `PROVIDER=git` and a `make demo-requests` that was not told so mints fake changes pointing at no repository, which the git merger rejects as commits it cannot find. Observed as fifty consecutive failures reading `not available from remote origin`, with nothing in the error to say the provider was the problem. The stack knows which one it has — it is mounted at `/etc/submitqueue` — so a run given no provider of its own asks it, and one given a provider that disagrees says so before it starts rather than after fifty rejections.

Finding the port is not enough on its own, because `?=` treats a variable exported in the shell as already set — so anyone who ran the `export GATEWAY_ADDR=…` the quickstart used to recommend keeps a dead port forever and never reaches the discovery at all. That is the failure this was meant to remove, so when the address came from the environment and a local stack is running somewhere else, both are named and `unset GATEWAY_ADDR` is suggested. An address given on the command line is deliberate and passes without comment.

**The quick start is three commands.** Two of its five were reading a port and exporting it, which is exactly the copying this removes — so the README and `DEVELOPMENT.md` are now start the stack, put traffic through it, stop it, and nothing in between. The README no longer sends the reader to the development setup for "full prerequisites" either, having just told them Docker is all they need.

**The git sandbox no longer repacks its refs.** A fifty-request run failed one land with `git ls-remote … fatal: unterminated line in ./packed-refs`, reading a ref name cut in half. Git runs `gc --auto` after every push by default, and packing refs rewrites `packed-refs` wholesale — safe on one filesystem, where the replacement is a rename nobody can observe halfway, but this repository is written from the host and read from inside a container through a bind mount, and that boundary does not preserve the guarantee. Fifty pushes are fifty chances to fail a land that had nothing wrong with it. `gc.auto`, `receive.autogc` and `maintenance.auto` are now off on the sandbox, so there is nothing to rewrite; loose refs cost a directory that gets deleted nothing. The settings are re-applied on every start, so a sandbox made before this gains them instead of staying broken.

It is the same hazard as the `loose object … is corrupt` failure fixed earlier by moving Runway's checkout to a named volume. The bare repository cannot follow it there — being readable from the host with `git log` is the point of it — so the fix is to stop the rewriting instead.

## Test Plan
- ✅ drove the view through a pty with real keystrokes — `G`, two up-arrows, `PgUp`, `q` — and read the positions back out of the footer: `40-40 → 39-40 → 38-40 → 36-40 of 40`, then a clean exit
- ✅ the alternate screen is entered once and left once in every run captured, so the terminal is never left on it
- ✅ after `q`, all 40 rows are printed into the restored screen; after a settled 25-request run, all 25 are, with nothing hidden
- ✅ `make demo-requests` and `make land-list` with no `GATEWAY_ADDR` set at all; with it set explicitly; and with no stack running, which now says `No gateway found: 'submitqueue' is not running`
- ✅ reproduced the provider mismatch that prompted the detection — a `PROVIDER=git` stack with a plain `make demo-requests` — and confirmed it now creates git changes and lands them, while an explicit `PROVIDER=fake` against that stack warns before starting
- ✅ reproduced the stale-export case that prompted the guard — an exported address pointing at a port from an earlier stack, with a live stack elsewhere — and confirmed it names both and suggests unsetting, while the same address given on the command line stays silent
- ✅ redirected output still produces a plain log: `make demo-requests LAND=false` and piped runs take neither the screen nor the keyboard
- ✅ new tests for the parts that are not a terminal: every key and escape sequence including one split across reads, and the scroll arithmetic — bounds, paging, and that scrolling up releases follow while rows arriving do not move a view that has scrolled away
- ✅ the sandbox settings are applied at creation, and applied again to a sandbox that already exists — the upgrade path, since an existing one is reused rather than recreated
- ✅ `make test` (105 targets), `make lint`, `make gazelle`

Not verified at scale: the packed-refs failure was one land in fifty and depends on when git decides to pack against when the merger reads, so a single clean run would not prove much. What is verified is that nothing repacks any more, which is the condition that made it possible.

Two behaviours worth knowing. A bare `Escape` is not acted on until another key follows, and swallows it — the alternative is misreading an arrow whose bytes arrive in separate reads, which is worse and intermittent. And with tall wrapped rows in a short window, moving up one row can land back at the bottom, because the number of rows that fit changes with their height.

## Issues

