### PR TITLE
refactor(runway): compose the checkout git env from gitexec

### DIFF
--- a/service/runway/server/BUILD.bazel
+++ b/service/runway/server/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//platform/extension/consumergate/noop:go_default_library",
         "//platform/extension/messagequeue:go_default_library",
         "//platform/extension/messagequeue/mysql:go_default_library",
+        "//platform/git/exec:go_default_library",
         "//runway/controller:go_default_library",
         "//runway/controller/dlq:go_default_library",
         "//runway/controller/merge:go_default_library",

--- a/service/runway/server/checkout.go
+++ b/service/runway/server/checkout.go
@@ -26,6 +26,7 @@ import (
 
 	"go.uber.org/zap"
 
+	gitexec "github.com/uber/submitqueue/platform/git/exec"
 	gitmerger "github.com/uber/submitqueue/runway/extension/merger/git"
 )
 
@@ -190,8 +191,9 @@ func setLocalConfig(checkoutPath, key, value string) error {
 }
 
 // runGit invokes the pinned git in dir with an environment scrubbed of ambient
-// configuration but retaining what is needed to reach a remote — the same split
-// the merger draws, so provisioning and merging authenticate identically.
+// configuration but retaining what is needed to reach a remote. It composes that
+// environment through gitexec.Env, the same source the merger uses, so
+// provisioning and merging authenticate — and behave — identically.
 func runGit(ctx context.Context, runtime gitmerger.GitRuntime, dir string, args ...string) ([]byte, error) {
 	full := append([]string{
 		"--exec-path=" + runtime.ExecPath,
@@ -200,27 +202,17 @@ func runGit(ctx context.Context, runtime gitmerger.GitRuntime, dir string, args 
 
 	cmd := exec.CommandContext(ctx, runtime.Executable, full...)
 	cmd.Dir = dir
-	cmd.Env = []string{
-		"HOME=" + filepath.Join(dir, ".submitqueue-git-home"),
-		"GIT_CONFIG_NOSYSTEM=1",
-		"GIT_CONFIG_GLOBAL=" + os.DevNull,
-		"GIT_TERMINAL_PROMPT=0",
-		"GIT_EXEC_PATH=" + runtime.ExecPath,
-		"GIT_TEMPLATE_DIR=" + runtime.TemplateDir,
-		"LC_ALL=C",
-		"LANG=C",
-	}
-	for _, name := range []string{
-		"PATH", "SSH_AUTH_SOCK", "SSH_AGENT_PID",
-		"GIT_SSH", "GIT_SSH_COMMAND", "GIT_SSH_VARIANT",
-		"GIT_SSL_CAINFO", "GIT_SSL_CAPATH", "SSL_CERT_DIR", "SSL_CERT_FILE",
-		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
-		"http_proxy", "https_proxy", "no_proxy",
-	} {
-		if v, ok := os.LookupEnv(name); ok {
-			cmd.Env = append(cmd.Env, name+"="+v)
-		}
-	}
+	cmd.Env = gitexec.Env(gitexec.EnvOptions{
+		Transport:   true,
+		Passthrough: runtime.PassthroughEnv,
+		Literal: []string{
+			"HOME=" + filepath.Join(dir, ".submitqueue-git-home"),
+			"GIT_EXEC_PATH=" + runtime.ExecPath,
+			"GIT_TEMPLATE_DIR=" + runtime.TemplateDir,
+			"LC_ALL=C",
+			"LANG=C",
+		},
+	})
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout


### PR DESCRIPTION
## Summary

runGit in the Runway server's checkout provisioning kept its own copy of the scrubbed-plus-transport environment. Build it through gitexec.Env instead — the same source the merger uses — so provisioning and merging assemble an identical environment from one definition.

This also closes a gap the two hand-written copies had already opened: provisioning omitted GIT_ATTR_NOSYSTEM and the no-pager/no-editor settings the merge path sets, so a system gitattributes file could influence the initial checkout but not later merge operations. Both now run under the same scrub set.

Provisioning also passes the runtime's PassthroughEnv through gitexec, as the merger already does, so a deployment whose remote needs an extra variable reaches it during the provisioning fetch and not merges alone. The field is unset today, so this only aligns the two paths rather than changing behavior.

## Test Plan

✅ `//service/runway/server` green. Provisioning and merge paths now assemble an identical git environment from one source.

## Stack
1. #609
1. #610
1. #611
1. #612
1. @ #613


