### PR TITLE
build(api): expose RPC proto sources

### DIFF
--- a/api/runway/proto/BUILD.bazel
+++ b/api/runway/proto/BUILD.bazel
@@ -1,4 +1,4 @@
 exports_files(
     ["runway.proto"],
-    visibility = ["//tool/proto:__pkg__"],
+    visibility = ["//visibility:public"],
 )

--- a/api/stovepipe/proto/BUILD.bazel
+++ b/api/stovepipe/proto/BUILD.bazel
@@ -1,4 +1,4 @@
 exports_files(
     ["stovepipe.proto"],
-    visibility = ["//tool/proto:__pkg__"],
+    visibility = ["//visibility:public"],
 )

--- a/api/submitqueue/gateway/proto/BUILD.bazel
+++ b/api/submitqueue/gateway/proto/BUILD.bazel
@@ -1,4 +1,4 @@
 exports_files(
     ["gateway.proto"],
-    visibility = ["//tool/proto:__pkg__"],
+    visibility = ["//visibility:public"],
 )

--- a/api/submitqueue/orchestrator/proto/BUILD.bazel
+++ b/api/submitqueue/orchestrator/proto/BUILD.bazel
@@ -1,4 +1,4 @@
 exports_files(
     ["orchestrator.proto"],
-    visibility = ["//tool/proto:__pkg__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Summary
Intent:
- Allow downstream Bazel repositories to vendor published RPC contracts directly.  This will let us use a rule in our internal repo to keep the vendored copies up to date on each sync.

Changes:
- Make the Runway, Stovepipe, SubmitQueue gateway, and SubmitQueue orchestrator service proto sources publicly visible.

