### PR TITLE
feat(stovepipe): add request log table

### DIFF
--- a/stovepipe/extension/storage/mysql/schema/request_log.sql
+++ b/stovepipe/extension/storage/mysql/schema/request_log.sql
@@ -1,0 +1,16 @@
+-- request_log retains one append-only row per logical request occurrence. Exactly one of
+-- state and event is populated; core lifecycle fields remain columns, while occurrence-specific
+-- context and optional diagnostics share metadata.
+CREATE TABLE IF NOT EXISTS request_log (
+    queue                     VARCHAR(255) NOT NULL,
+    request_id                VARCHAR(255) NOT NULL,
+    log_id                    VARCHAR(255) NOT NULL,
+    timestamp_ms              BIGINT       NOT NULL,
+    state                     VARCHAR(64)  NOT NULL,
+    event                     VARCHAR(64)  NOT NULL,
+    request_version           INT          NOT NULL,
+    outcome_reason            VARCHAR(64)  NOT NULL,
+    metadata                  JSON         NOT NULL,
+    PRIMARY KEY (queue, request_id, log_id),
+    KEY idx_request_log_order (queue, request_id, timestamp_ms, log_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/integration/stovepipe/extension/storage/mysql/storage_test.go
+++ b/test/integration/stovepipe/extension/storage/mysql/storage_test.go
@@ -100,6 +100,7 @@ func resetStorage(t *testing.T, db *sql.DB) {
 	t.Helper()
 
 	for _, statement := range []string{
+		"TRUNCATE TABLE request_history",
 		"TRUNCATE TABLE request_uri",
 		"TRUNCATE TABLE request",
 		"TRUNCATE TABLE build",

--- a/test/integration/stovepipe/extension/storage/mysql/storage_test.go
+++ b/test/integration/stovepipe/extension/storage/mysql/storage_test.go
@@ -100,7 +100,7 @@ func resetStorage(t *testing.T, db *sql.DB) {
 	t.Helper()
 
 	for _, statement := range []string{
-		"TRUNCATE TABLE request_history",
+		"TRUNCATE TABLE request_log",
 		"TRUNCATE TABLE request_uri",
 		"TRUNCATE TABLE request",
 		"TRUNCATE TABLE build",


### PR DESCRIPTION
## Summary

Intent:
- Persist immutable request states and explanatory lifecycle occurrences in the internal Stovepipe request log.
- Keep storage terminology and metadata handling aligned with SubmitQueue while supporting the public history API from #638.

Changes:
- Add an append-only MySQL `request_log` table with stable occurrence identity.
- Keep core lifecycle values in columns and store occurrence-specific context in a non-null JSON metadata column.
- Require writers to supply every non-null column value; the table defines no value defaults.
- Remove dedicated superseding-request, build-ID, and fact-degree columns.
- Index records for bounded, complete per-request reads.
- Include request-log data in integration database cleanup.

## Test Plan

- Loaded all Stovepipe schemas into an isolated MySQL 8 database.
- Inserted representative request-log records and exercised chronological retrieval.
- `./tool/bazel test //stovepipe/extension/storage/mysql/...`
- `make lint check-tidy check-gazelle`

## Revert Plan

Revert this PR and remove the unused table before deploying code that writes request-log records.

## Jira Issues

None.